### PR TITLE
HAS_GNSS_TP_INT: Verify that pin_GNSS_TimePulse is set

### DIFF
--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -201,7 +201,7 @@ const int platformGnssTableEntries = sizeof (platformGnssTable) / sizeof(platfor
 // Macro to show if the the RTK variant has a GNSS TP interrupt - for accurate clock setting
 // The GNSS UBX PVT message is sent ahead of the top-of-second
 // The rising edge of the TP signal indicates the true top-of-second
-#define HAS_GNSS_TP_INT ((productVariant == REFERENCE_STATION) || (productVariant == RTK_EVERYWHERE))
+#define HAS_GNSS_TP_INT (((productVariant == REFERENCE_STATION) || (productVariant == RTK_EVERYWHERE)) && (pin_GNSS_TimePulse != -1))
 
 // Macro to show if the the RTK variant has no battery
 #define HAS_NO_BATTERY ((productVariant == REFERENCE_STATION) || (productVariant == RTK_EVERYWHERE))


### PR DESCRIPTION
Fix pinMode crash when pin_GNSS_TimePulse is not initialized