### PR TITLE
Everywhere: Always initialize the Ethernet controller

### DIFF
--- a/Firmware/RTK_Everywhere/Ethernet.ino
+++ b/Firmware/RTK_Everywhere/Ethernet.ino
@@ -131,7 +131,7 @@ void ethernetBegin()
         return;
     }
 
-    if (!ethernetIsNeeded())
+    if ((productVariant != RTK_EVERYWHERE) && (!ethernetIsNeeded()))
         return;
 
     if (PERIODIC_DISPLAY(PD_ETHERNET_STATE))


### PR DESCRIPTION
Prevents crash when menuSystem attempts to display the link status