### PR TITLE
SD_FileListing: Fix example, add PSRAM

### DIFF
--- a/Firmware/Test Sketches/SD_FileListing/SD_FileListing.ino
+++ b/Firmware/Test Sketches/SD_FileListing/SD_FileListing.ino
@@ -9,7 +9,12 @@
 #define ASCII_LF      0x0a
 #define ASCII_CR      0x0d
 
-int pin_microSD_CS = 25;
+const int pin_microSD_CS = 4;
+const int pin_SCK = 18;
+const int pin_MISO = 19;
+const int pin_MOSI = 23;
+const int pin_peripheralPowerControl = 32;
+const int pin_microSD_CardDetect = 36;
 
 //microSD Interface
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -46,7 +51,33 @@ uint8_t buffer[5701];
 void setup()
 {
   Serial.begin(115200);
-  delay(500);
+
+  Serial.println();
+  Serial.println();
+
+  reportHeapNow();
+  if (psramInit())
+  {
+    Serial.printf("%d MB of PSRAM detected\r\n", (ESP.getFreePsram() + (512 * 1024)) / (1024 * 1024));
+    online.psram = true;
+    reportHeapNow();
+  }
+  else
+    Serial.println("PSRAM is not available!");
+
+  Serial.printf("pin_peripheralPowerControl: %d\r\n", pin_peripheralPowerControl);
+  pinMode(pin_peripheralPowerControl, OUTPUT);
+  digitalWrite(pin_peripheralPowerControl, HIGH);
+
+  // Disable the microSD card
+  Serial.printf("pin_microSD_CardDetect: %d\r\n", pin_microSD_CardDetect);
+  pinMode(pin_microSD_CardDetect, INPUT); // Internal pullups not supported on input only pins
+
+  Serial.printf("pin_microSD_CS: %d\r\n", pin_microSD_CS);
+  pinMode(pin_microSD_CS, OUTPUT);
+  digitalWrite(pin_microSD_CS, HIGH);
+
+  delay(1000);
   Serial.println("SD File Listing");
 
   beginSD();
@@ -55,6 +86,8 @@ void setup()
     Serial.println("SD not detected. Please check card. Is it formatted?");
   else
     sd.ls(LS_R | LS_DATE | LS_SIZE); //Print files on card
+  if (online.psram)
+    reportHeapNow();
 }
 
 void loop()
@@ -100,10 +133,14 @@ void loop()
         break;
       }
       Serial.printf("File %s opened successfully!\n", filename);
+      if (online.psram)
+        reportHeapNow();
 
       // Close the root directory
       Serial.println("Closing the root directory");
       sdRootDir.close();
+      if (online.psram)
+        reportHeapNow();
 
       // Read the file
       do {
@@ -113,11 +150,15 @@ void loop()
         Serial.printf("Attempting to read %d bytes from %s\n", bytesToRead, filename);
         bytesRead = sdFile.read(buffer, bytesToRead);
         Serial.printf("bytesRead: %d\n", bytesRead);
+        if (online.psram)
+          reportHeapNow();
       } while (bytesRead > 0);
 
       // Close the file
       Serial.printf("Closing %s\n", filename);
       sdFile.close();
+      if (online.psram)
+        reportHeapNow();
       Serial.println();
     } while (0);
   }
@@ -127,4 +168,12 @@ void loop()
 
   while (!Serial.available());
   ESP.restart();
+}
+
+void reportHeapNow()
+{
+    Serial.printf("FreeHeap: %d / HeapLowestPoint: %d / LargestBlock: %d\r\n", ESP.getFreeHeap(),
+                 xPortGetMinimumEverFreeHeapSize(), heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+    if (online.psram)
+        Serial.printf("Free PSRAM: %d\r\n", ESP.getFreePsram());
 }

--- a/Firmware/Test Sketches/SD_FileListing/settings.h
+++ b/Firmware/Test Sketches/SD_FileListing/settings.h
@@ -31,7 +31,7 @@ typedef enum
   STATE_PROFILE_2,
   STATE_PROFILE_3,
   STATE_PROFILE_4,
-  STATE_SHUTDOWN, 
+  STATE_SHUTDOWN,
 } SystemState;
 volatile SystemState systemState = STATE_ROVER_NOT_STARTED;
 SystemState lastSystemState = STATE_ROVER_NOT_STARTED;
@@ -313,7 +313,7 @@ typedef struct struct_settings {
   };
 
   //Constellations monitored/used for fix
-  ubxConstellation ubxConstellations[MAX_CONSTELLATIONS] = 
+  ubxConstellation ubxConstellations[MAX_CONSTELLATIONS] =
   {
     {UBLOX_CFG_SIGNAL_GPS_ENA, SFE_UBLOX_GNSS_ID_GPS, true, "GPS"},
     {UBLOX_CFG_SIGNAL_SBAS_ENA, SFE_UBLOX_GNSS_ID_SBAS, true, "SBAS"},
@@ -341,4 +341,5 @@ struct struct_online {
   bool rtc = false;
   bool battery = false;
   bool accelerometer = false;
+  bool psram = false;
 } online;


### PR DESCRIPTION
Bug Fixes:
* Set proper pin for the microSD card chip select
* Turn on the peripheral power to power microSD card

Add PSRAM and reportHeapNow support to display PSRAM during the SD card use.