### PR TITLE
WebServer: Fix example, add PSRAM

### DIFF
--- a/Firmware/Test Sketches/WebServer/Begin.ino
+++ b/Firmware/Test Sketches/WebServer/Begin.ino
@@ -1,5 +1,3 @@
-const int pin_microSD_CS = 25;
-
 typedef struct struct_settings {
   bool enableSD = true;
   uint16_t spiFrequency = 16; //By default, use 16MHz SPI


### PR DESCRIPTION
Bug Fixes:
* Set proper pin for the microSD card chip select
* Turn on the peripheral power to power microSD card
* Add redirect flag to sdCardWebSite call

Add PSRAM and reportHeapNow support to display PSRAM during the SD card use.