### PR TITLE
Change to station before setting WiFi protocols.

### DIFF
--- a/Firmware/RTK_Everywhere/ESPNOW.ino
+++ b/Firmware/RTK_Everywhere/ESPNOW.ino
@@ -101,7 +101,7 @@ void espnowStart()
 
     if (wifiState == WIFI_OFF && espnowState == ESPNOW_OFF)
     {
-        if (WiFi.getMode() == WIFI_OFF)
+        if (WiFi.getMode() != WIFI_STA)
             WiFi.mode(WIFI_STA);
 
         // Radio is off, turn it on
@@ -115,6 +115,9 @@ void espnowStart()
     // If WiFi is on but ESP NOW is off, then enable LR protocol
     else if (wifiState > WIFI_OFF && espnowState == ESPNOW_OFF)
     {
+        if (WiFi.getMode() != WIFI_STA)
+            WiFi.mode(WIFI_STA);
+
         // Enable WiFi + ESP-Now
         // Enable long range, PHY rate of ESP32 will be 512Kbps or 256Kbps
         // esp_wifi_set_protocol requires WiFi to be started
@@ -216,6 +219,9 @@ void espnowStop()
     // Forget all ESP-Now Peers
     for (int x = 0; x < settings.espnowPeerCount; x++)
         espnowRemovePeer(settings.espnowPeers[x]);
+
+    if (WiFi.getMode() != WIFI_STA)
+        WiFi.mode(WIFI_STA);
 
     // Leave WiFi with default settings (no WIFI_PROTOCOL_LR for ESP NOW)
     // esp_wifi_set_protocol requires WiFi to be started

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -440,7 +440,7 @@ void wifiShutdown()
     // If ESP-Now is active, change protocol to only Long Range and re-start WiFi
     if (espnowState > ESPNOW_OFF)
     {
-        if (WiFi.getMode() == WIFI_OFF)
+        if (WiFi.getMode() != WIFI_STA)
             WiFi.mode(WIFI_STA);
 
         // Enable long range, PHY rate of ESP32 will be 512Kbps or 256Kbps
@@ -477,7 +477,7 @@ bool wifiConnect(unsigned long timeout)
     displayWiFiConnect();
 
     // Before we can issue esp_wifi_() commands WiFi must be started
-    if (WiFi.getMode() == WIFI_OFF)
+    if (WiFi.getMode() != WIFI_STA)
         WiFi.mode(WIFI_STA);
 
     // Verify that the necessary protocols are set


### PR DESCRIPTION
Prior to this, the WiFi radio could be on, but be in AP mode. If the old code ran, the protocols would not get set correctly because of mode was not correctly set to station (getMode != WIFI_OFF).