### PR TITLE
Update libraries: GNSS -> 3.1.4, OLED -> 1.0.13

### DIFF
--- a/.github/workflows/compile-rtk-everywhere.yml
+++ b/.github/workflows/compile-rtk-everywhere.yml
@@ -80,9 +80,9 @@ jobs:
           "SdFat"@2.1.1
           "SparkFun LIS2DH12 Arduino Library"@1.0.3
           "SparkFun MAX1704x Fuel Gauge Arduino Library"@1.0.4
-          "SparkFun u-blox GNSS v3"@3.0.14
+          "SparkFun u-blox GNSS v3"@3.1.4
           SparkFun_WebServer_ESP32_W5500@1.5.5
-          "SparkFun Qwiic OLED Arduino Library"@1.0.10
+          "SparkFun Qwiic OLED Arduino Library"@1.0.13
           SSLClientESP32@2.0.0
           SSLClientESP32@2.0.0
           "SparkFun Extensible Message Parser"@1.0.0

--- a/.github/workflows/non-release-build.yml
+++ b/.github/workflows/non-release-build.yml
@@ -80,9 +80,9 @@ jobs:
           "SdFat"@2.1.1
           "SparkFun LIS2DH12 Arduino Library"@1.0.3
           "SparkFun MAX1704x Fuel Gauge Arduino Library"@1.0.4
-          "SparkFun u-blox GNSS v3"@3.0.14
+          "SparkFun u-blox GNSS v3"@3.1.4
           SparkFun_WebServer_ESP32_W5500@1.5.5
-          "SparkFun Qwiic OLED Arduino Library"@1.0.10
+          "SparkFun Qwiic OLED Arduino Library"@1.0.13
           SSLClientESP32@2.0.0
           SSLClientESP32@2.0.0
           "SparkFun Extensible Message Parser"@1.0.0


### PR DESCRIPTION
OLED 1.0.13 fixes a nasty crash when using a pointer to access the display.
GNSS >= v3.1.0 is useful for SFRBX storage for the PointPerfect Library. Useful, but probably not essential here, if we are parsing messages within the firmware?