### PR TITLE
Allow entry into browser config if WiFi is on

### DIFF
--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -152,6 +152,7 @@ bool wifiConnect(unsigned long timeout) {return false;}
 IPAddress wifiGetGatewayIpAddress() {return IPAddress((uint32_t)0);}
 IPAddress wifiGetIpAddress() {return IPAddress((uint32_t)0);}
 int wifiGetRssi() {return -999;}
+String wifiGetSsid() {return "**WiFi Not compiled**";}
 bool wifiIsConnected() {return false;}
 bool wifiIsNeeded() {return false;}
 int wifiNetworkCount() {return 0;}

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1037,6 +1037,9 @@ const char * networkTypeToString(uint8_t type)
 //----------------------------------------
 void networkTypeUpdate(uint8_t networkType)
 {
+    if(inWiFiConfigMode())
+        return; //Avoid network layer while in Browser Config Mode
+
     char errorMsg[64];
     NETWORK_DATA *network;
 

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1038,7 +1038,11 @@ const char * networkTypeToString(uint8_t type)
 void networkTypeUpdate(uint8_t networkType)
 {
     if(inWiFiConfigMode())
-        return; //Avoid network layer while in Browser Config Mode
+    {
+        //Avoid the full network layer while in Browser Config Mode
+        wifiUpdate();
+        return; 
+    }
 
     char errorMsg[64];
     NETWORK_DATA *network;

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -389,7 +389,7 @@ void networkDisplayIpAddress(uint8_t networkType)
         {
             strcpy(ipAddress, networkGetIpAddress(networkType).toString().c_str());
             if (network->type == NETWORK_TYPE_WIFI)
-                systemPrintf("%s IP address: %s, RSSI: %d\r\n", networkName[network->type], ipAddress, wifiGetRssi());
+                systemPrintf("%s '%s' IP address: %s, RSSI: %d\r\n", networkName[network->type], ipAddress, wifiGetSsid(), wifiGetRssi());
             else
                 systemPrintf("%s IP address: %s\r\n", networkName[network->type], ipAddress);
 

--- a/Firmware/RTK_Everywhere/States.ino
+++ b/Firmware/RTK_Everywhere/States.ino
@@ -421,6 +421,7 @@ void stateUpdate()
 
             displayWiFiConfigNotStarted(); // Display immediately during SD cluster pause
 
+            WIFI_STOP(); //Notify the network layer that it should stop so we can take over control of WiFi
             bluetoothStop();
             espnowStop();
 

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -530,38 +530,17 @@ bool wifiConnect(unsigned long timeout)
 
     int wifiResponse = WL_DISCONNECTED;
 
-    // WiFi.begin() is much faster than wifiMulti (requires scan time)
-    // Use wifiMulti only if multiple credentials exist
-    if (wifiNetworkCount() == 1)
+    systemPrint("Connecting WiFi... ");
+    WiFiMulti wifiMulti;
+
+    // Load SSIDs
+    for (int x = 0; x < MAX_WIFI_NETWORKS; x++)
     {
-        systemPrint("Connecting WiFi");
-
-        // Load SSID - may not be in spot 0
-        for (int x = 0; x < MAX_WIFI_NETWORKS; x++)
-        {
-            if (strlen(settings.wifiNetworks[x].ssid) > 0)
-            {
-                WiFi.begin(settings.wifiNetworks[x].ssid, settings.wifiNetworks[x].password);
-                break;
-            }
-        }
-
-        wifiResponse = WiFi.waitForConnectResult();
+        if (strlen(settings.wifiNetworks[x].ssid) > 0)
+            wifiMulti.addAP(settings.wifiNetworks[x].ssid, settings.wifiNetworks[x].password);
     }
-    else
-    {
-        systemPrint("Connecting WiFi... ");
-        WiFiMulti wifiMulti;
 
-        // Load SSIDs
-        for (int x = 0; x < MAX_WIFI_NETWORKS; x++)
-        {
-            if (strlen(settings.wifiNetworks[x].ssid) > 0)
-                wifiMulti.addAP(settings.wifiNetworks[x].ssid, settings.wifiNetworks[x].password);
-        }
-
-        wifiResponse = wifiMulti.run(timeout);
-    }
+    wifiResponse = wifiMulti.run(timeout);
 
     if (wifiResponse == WL_CONNECTED)
     {

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -171,7 +171,7 @@ void menuWiFi()
 // Display the WiFi IP address
 void wifiDisplayIpAddress()
 {
-    systemPrintf("WiFi %s IP address: ", WiFi.SSID());
+    systemPrintf("WiFi '%s' IP address: ", WiFi.SSID());
     systemPrint(WiFi.localIP());
     systemPrintf(" RSSI: %d\r\n", WiFi.RSSI());
 
@@ -253,12 +253,15 @@ bool wifiStartAP(bool forceAP)
         IPAddress subnet(255, 255, 255, 0);
 
         WiFi.softAPConfig(local_IP, gateway, subnet);
-        if (WiFi.softAP("RTK Config") == false) // Must be short enough to fit OLED Width
+
+        const char *softApSsid = "RTK Config";
+
+        if (WiFi.softAP(softApSsid) == false) // Must be short enough to fit OLED Width
         {
             systemPrintln("WiFi AP failed to start");
             return (false);
         }
-        systemPrint("WiFi AP Started with IP: ");
+        systemPrintf("WiFi AP '%s' started with IP: ", softApSsid);
         systemPrintln(WiFi.softAPIP());
 
         // Start DNS Server
@@ -706,6 +709,11 @@ IPAddress wifiGetIpAddress()
 int wifiGetRssi()
 {
     return WiFi.RSSI();
+}
+
+String wifiGetSsid()
+{
+    return WiFi.SSID();
 }
 
 #endif // COMPILE_WIFI

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -34,7 +34,6 @@
 //----------------------------------------
 
 int wifiConnectionAttempts; // Count the number of connection attempts between restarts
-bool mdnsIsRunning = false; // Ending mdns when it was not yet started causes it to fail to start
 
 #ifdef COMPILE_WIFI
 
@@ -432,11 +431,8 @@ void wifiStop()
     stopWebServer();
 
     // Stop the multicast domain name server
-    if (mdnsIsRunning == true && settings.mdnsEnable == true)
-    {
+    if (settings.mdnsEnable == true)
         MDNS.end();
-        mdnsIsRunning = false;
-    }
 
     // Stop the DNS server if we were using the captive portal
     if (WiFi.getMode() == WIFI_AP && settings.enableCaptivePortal)
@@ -554,10 +550,7 @@ bool wifiConnect(unsigned long timeout)
                 if (MDNS.begin("rtk") == false) // This should make the device findable from 'rtk.local' in a browser
                     systemPrintln("Error setting up MDNS responder!");
                 else
-                {
                     MDNS.addService("http", "tcp", settings.httpPort); // Add service to MDNS
-                    mdnsIsRunning = true;
-                }
             }
         }
 


### PR DESCRIPTION
If WiFi is active, then WiFi Config is started, the network layer will shut down the AP, and start WiFi again. This PR prevents the network layer from running while in WiFi config mode.