### PR TITLE
Reset PPL if RTK Float Lock is detected

### DIFF
--- a/Firmware/RTK_Everywhere/MQTT_Client.ino
+++ b/Firmware/RTK_Everywhere/MQTT_Client.ino
@@ -315,7 +315,8 @@ void mqttClientReceiveMessage(int messageSize)
                     updateCorrectionsLastSeen(CORR_IP);
                     if (isHighestRegisteredCorrectionsSource(CORR_IP))
                     {
-                        if (((settings.debugMqttClientData == true) || (settings.debugCorrections == true)) && !inMainMenu)
+                        if (((settings.debugMqttClientData == true) || (settings.debugCorrections == true)) &&
+                            !inMainMenu)
                             systemPrintf("Pushing %d bytes from %s topic to GNSS\r\n", mqttCount, topic);
 
                         updateZEDCorrectionsSource(0); // Set SOURCE to 0 (IP) if needed
@@ -325,8 +326,10 @@ void mqttClientReceiveMessage(int messageSize)
                     }
                     else
                     {
-                        if (((settings.debugMqttClientData == true) || (settings.debugCorrections == true)) && !inMainMenu)
-                            systemPrintf("NOT pushing %d bytes from %s topic to GNSS due to priority\r\n", mqttCount, topic);
+                        if (((settings.debugMqttClientData == true) || (settings.debugCorrections == true)) &&
+                            !inMainMenu)
+                            systemPrintf("NOT pushing %d bytes from %s topic to GNSS due to priority\r\n", mqttCount,
+                                         topic);
                     }
                 }
                 // Always push KEYS and MGA to the ZED
@@ -423,6 +426,10 @@ void mqttClientStop(bool shutdown)
     // Free the mqttClient resources
     if (mqttClient)
     {
+        // Disconnect from broker
+        if (mqttClient->connected() == true)
+            mqttClient->stop(); // Disconnects and stops client
+
         if (settings.debugMqttClientState)
             systemPrintln("Freeing mqttClient");
 

--- a/Firmware/RTK_Everywhere/PointPerfectLibrary.ino
+++ b/Firmware/RTK_Everywhere/PointPerfectLibrary.ino
@@ -4,12 +4,13 @@
 void updatePplTask(void *e)
 {
     // Start notification
-    online.updatePplTaskRunning = true;
+    task.updatePplTaskRunning = true;
     if (settings.printTaskStartStop)
         systemPrintln("updatePplTask started");
 
-    // Verify that the task is still running
-    while (online.updatePplTaskRunning)
+    // Run task until a request is raised
+    task.updatePplTaskStopRequest = false;
+    while (task.updatePplTaskStopRequest == false)
     {
         // Display an alive message
         if (PERIODIC_DISPLAY(PD_TASK_UPDATE_PPL))
@@ -93,7 +94,7 @@ void updatePplTask(void *e)
                 }
             }
 
-            online.updatePplTaskRunning = false; // Stop task either because new key failed or we need to apply new key
+            break; // Stop task either because new key failed or we need to apply new key
         }
 
         feedWdt();
@@ -103,7 +104,7 @@ void updatePplTask(void *e)
     // Stop notification
     if (settings.printTaskStartStop)
         systemPrintln("Task updatePplTask stopped");
-    online.updatePplTaskRunning = false;
+    task.updatePplTaskRunning = false;
     vTaskDelete(NULL);
 }
 
@@ -174,7 +175,7 @@ void beginPPL()
         TaskHandle_t taskHandle;
 
         // Starts task for feeding NMEA+RTCM to PPL
-        if (online.updatePplTaskRunning == false)
+        if (task.updatePplTaskRunning == false)
             xTaskCreate(updatePplTask,
                         "UpdatePpl",            // Just for humans
                         updatePplTaskStackSize, // Stack Size

--- a/Firmware/RTK_Everywhere/PointPerfectLibrary.ino
+++ b/Firmware/RTK_Everywhere/PointPerfectLibrary.ino
@@ -196,8 +196,8 @@ void beginPPL()
 void stopPPL()
 {
     // Stop task if running
-    if (task.gnssReadTaskRunning)
-        task.gnssReadTaskStopRequest = true;
+    if (task.updatePplTaskRunning)
+        task.updatePplTaskStopRequest = true;
 
     if (pplRtcmBuffer != nullptr)
     {
@@ -208,7 +208,7 @@ void stopPPL()
     // Wait for task to stop running
     do
         delay(10);
-    while (task.gnssReadTaskRunning);
+    while (task.updatePplTaskRunning);
 
     online.ppl = false;
 }

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -760,7 +760,6 @@ bool configureViaEthernet;
 unsigned long lbandTimeFloatStarted; // Monitors the ZED during L-Band reception if a fix takes too long
 int floatLockRestarts;
 unsigned long rtkTimeToFixMs;
-unsigned long lbandLastReport;
 
 volatile PeriodicDisplay_t periodicDisplay;
 

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -758,7 +758,7 @@ correctionsSource pplCorrectionsSource = CORR_NUM; // Record which source is fee
 bool configureViaEthernet;
 
 unsigned long lbandTimeFloatStarted; // Monitors the ZED during L-Band reception if a fix takes too long
-int lbandRestarts;
+int floatLockRestarts;
 unsigned long rtkTimeToFixMs;
 unsigned long lbandLastReport;
 

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -757,7 +757,6 @@ correctionsSource pplCorrectionsSource = CORR_NUM; // Record which source is fee
 //  This is to allow SparkFun_WebServer_ESP32_W5500 to have _exclusive_ access to WiFi, SPI and Interrupts.
 bool configureViaEthernet;
 
-unsigned long lbandTimeFloatStarted; // Monitors the ZED during L-Band reception if a fix takes too long
 int floatLockRestarts;
 unsigned long rtkTimeToFixMs;
 

--- a/Firmware/RTK_Everywhere/States.ino
+++ b/Firmware/RTK_Everywhere/States.ino
@@ -626,14 +626,15 @@ void stateUpdate()
         break;
 
         case (STATE_KEYS_WIFI_STARTED): {
+                wifiMaxConnectionAttempts =
+                    wifiOriginalMaxConnectionAttempts; // Revert setting
+
             if (wifiIsConnected())
                 changeState(STATE_KEYS_WIFI_CONNECTED);
             else
             {
                 wifiShutdown(); // Turn off WiFi
 
-                wifiMaxConnectionAttempts =
-                    wifiOriginalMaxConnectionAttempts; // Override setting to 2 attemps during keys
                 changeState(STATE_KEYS_WIFI_TIMEOUT);
             }
         }

--- a/Firmware/RTK_Everywhere/States.ino
+++ b/Firmware/RTK_Everywhere/States.ino
@@ -138,11 +138,7 @@ void stateUpdate()
 
         case (STATE_ROVER_FIX): {
             if (gnssIsRTKFloat())
-            {
-                // Restart timer for L-Band. Don't immediately reset ZED to achieve fix.
-                lbandTimeFloatStarted = millis();
                 changeState(STATE_ROVER_RTK_FLOAT);
-            }
             else if (gnssIsRTKFix())
                 changeState(STATE_ROVER_RTK_FIX);
         }
@@ -160,11 +156,7 @@ void stateUpdate()
             if (gnssIsRTKFix() == false && gnssIsRTKFloat() == false) // No RTK
                 changeState(STATE_ROVER_FIX);
             if (gnssIsRTKFloat())
-            {
-                // Restart timer for L-Band. Don't immediately reset ZED to achieve fix.
-                lbandTimeFloatStarted = millis();
                 changeState(STATE_ROVER_RTK_FLOAT);
-            }
         }
         break;
 

--- a/Firmware/RTK_Everywhere/menuPP.ino
+++ b/Firmware/RTK_Everywhere/menuPP.ino
@@ -1396,7 +1396,7 @@ void menuPointPerfect()
         systemPrintln("Menu: PointPerfect Corrections");
 
         if (settings.debugCorrections == true)
-            systemPrintf("Time to first RTK Fix: %ds Restarts: %d\r\n", rtkTimeToFixMs / 1000, lbandRestarts);
+            systemPrintf("Time to first RTK Fix: %ds Restarts: %d\r\n", rtkTimeToFixMs / 1000, floatLockRestarts);
 
         if (settings.debugCorrections == true)
             systemPrintf("settings.pointPerfectKeyDistributionTopic: %s\r\n",
@@ -1617,7 +1617,7 @@ void updateLBand()
                 lbandLastReport = millis();
 
                 if (settings.debugCorrections == true)
-                    systemPrintf("ZED restarts: %d Time remaining before L-Band forced restart: %ds\r\n", lbandRestarts,
+                    systemPrintf("ZED restarts: %d Time remaining before L-Band forced restart: %ds\r\n", floatLockRestarts,
                                  settings.lbandFixTimeout_seconds - ((millis() - lbandTimeFloatStarted) / 1000));
             }
 
@@ -1625,7 +1625,7 @@ void updateLBand()
             {
                 if ((millis() - lbandTimeFloatStarted) > (settings.lbandFixTimeout_seconds * 1000L))
                 {
-                    lbandRestarts++;
+                    floatLockRestarts++;
 
                     lbandTimeFloatStarted =
                         millis(); // Restart timer for L-Band. Don't immediately reset ZED to achieve fix.
@@ -1634,7 +1634,7 @@ void updateLBand()
                     theGNSS->softwareResetGNSSOnly();
 
                     if (settings.debugCorrections == true)
-                        systemPrintf("Restarting ZED. Number of L-Band restarts: %d\r\n", lbandRestarts);
+                        systemPrintf("Restarting ZED. Number of L-Band restarts: %d\r\n", floatLockRestarts);
                 }
             }
         }

--- a/Firmware/RTK_Everywhere/menuPP.ino
+++ b/Firmware/RTK_Everywhere/menuPP.ino
@@ -1592,6 +1592,7 @@ bool pointPerfectIsEnabled()
 void updateLBand()
 {
     static unsigned long lbandLastReport;
+    static unsigned long lbandTimeFloatStarted; // Monitors the ZED during L-Band reception if a fix takes too long
 
     // Skip if in configure-via-ethernet mode
     if (configureViaEthernet)

--- a/Firmware/RTK_Everywhere/menuPP.ino
+++ b/Firmware/RTK_Everywhere/menuPP.ino
@@ -1617,7 +1617,7 @@ void updateLBand()
                 lbandLastReport = millis();
 
                 if (settings.debugCorrections == true)
-                    systemPrintf("ZED restarts: %d Time remaining before L-Band forced restart: %ds\r\n", floatLockRestarts,
+                    systemPrintf("ZED restarts: %d Time remaining before Float lock forced restart: %ds\r\n", floatLockRestarts,
                                  settings.lbandFixTimeout_seconds - ((millis() - lbandTimeFloatStarted) / 1000));
             }
 
@@ -1634,7 +1634,7 @@ void updateLBand()
                     theGNSS->softwareResetGNSSOnly();
 
                     if (settings.debugCorrections == true)
-                        systemPrintf("Restarting ZED. Number of L-Band restarts: %d\r\n", floatLockRestarts);
+                        systemPrintf("Restarting ZED. Number of Float lock restarts: %d\r\n", floatLockRestarts);
                 }
             }
         }

--- a/Firmware/RTK_Everywhere/menuPP.ino
+++ b/Firmware/RTK_Everywhere/menuPP.ino
@@ -1613,8 +1613,11 @@ void updateLBand()
             lbandCorrectionsReceived = false;
 
         // If we don't get an L-Band fix within Timeout, hot-start ZED-F9x
-        if (systemState == STATE_ROVER_RTK_FLOAT)
+        if (gnssIsRTKFloat())
         {
+            if (lbandTimeFloatStarted == 0)
+                lbandTimeFloatStarted = millis();
+
             if (millis() - lbandLastReport > 1000)
             {
                 lbandLastReport = millis();
@@ -1644,9 +1647,16 @@ void updateLBand()
         }
         else if (gnssIsRTKFix() && rtkTimeToFixMs == 0)
         {
+            lbandTimeFloatStarted = 0; //Restart timer in case we drop from RTK Fix
+
             rtkTimeToFixMs = millis();
             if (settings.debugCorrections == true)
                 systemPrintf("Time to first RTK Fix: %ds\r\n", rtkTimeToFixMs / 1000);
+        }
+        else
+        {
+            // We are not in float or fix, so restart timer
+            lbandTimeFloatStarted = 0;
         }
     }
 

--- a/Firmware/RTK_Everywhere/menuPP.ino
+++ b/Firmware/RTK_Everywhere/menuPP.ino
@@ -1591,11 +1591,13 @@ bool pointPerfectIsEnabled()
 // Process any new L-Band from I2C
 void updateLBand()
 {
+    static unsigned long lbandLastReport;
+
     // Skip if in configure-via-ethernet mode
     if (configureViaEthernet)
     {
-        //if (settings.debugCorrections == true)
-        //    systemPrintln("configureViaEthernet: skipping updateLBand");
+        // if (settings.debugCorrections == true)
+        //     systemPrintln("configureViaEthernet: skipping updateLBand");
         return;
     }
 
@@ -1617,7 +1619,8 @@ void updateLBand()
                 lbandLastReport = millis();
 
                 if (settings.debugCorrections == true)
-                    systemPrintf("ZED restarts: %d Time remaining before Float lock forced restart: %ds\r\n", floatLockRestarts,
+                    systemPrintf("ZED restarts: %d Time remaining before Float lock forced restart: %ds\r\n",
+                                 floatLockRestarts,
                                  settings.lbandFixTimeout_seconds - ((millis() - lbandTimeFloatStarted) / 1000));
             }
 

--- a/Firmware/RTK_Everywhere/menuSystem.ino
+++ b/Firmware/RTK_Everywhere/menuSystem.ino
@@ -946,6 +946,13 @@ void menuOperation()
         if(present.gnss_zedf9p)
             systemPrintln("10) Mirror ZED-F9x's UART1 settings to USB");
 
+        // PPL Float Lock timeout
+        systemPrint("11) Set PPL RTK Fix Timeout (seconds): ");
+        if (settings.pplFixTimeoutS > 0)
+            systemPrintln(settings.pplFixTimeoutS);
+        else
+            systemPrintln("Disabled - no resets");
+
         systemPrintln("----  Interrupts  ----");
         systemPrint("30) Bluetooth Interrupts Core: ");
         systemPrintln(settings.bluetoothInterruptsCore);
@@ -1045,6 +1052,11 @@ void menuOperation()
                 systemPrintln(F("Failed to enable USB messages"));
             else
                 systemPrintln(F("USB messages successfully enabled"));
+        }
+        else if (incoming == 11)
+        {
+            getNewSetting("Enter number of seconds in RTK float using PPL, before reset", 0, 3600,
+                          &settings.pplFixTimeoutS); // Arbitrary 60 minute limit
         }
 
         else if (incoming == 30)

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1731,7 +1731,6 @@ struct struct_tasks
     volatile bool sdSizeCheckTaskRunning = false;
     volatile bool updatePplTaskRunning = false;
 
-    bool i2cPinnedTaskStopRequest = false;
     bool btReadTaskStopRequest = false;
     bool buttonCheckTaskStopRequest = false;
     bool gnssReadTaskStopRequest = false;

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1713,8 +1713,15 @@ struct struct_online
     bool bluetooth = false;
     bool mqttClient = false;
     bool psram = false;
-    volatile bool gnssUartPinned = false;
-    volatile bool i2cPinned = false;
+    bool ppl = false;
+    bool batteryCharger = false;
+} online;
+
+// Monitor which tasks are running.
+struct struct_tasks
+{
+    volatile bool gnssUartPinnedTaskRunning = false;
+    volatile bool i2cPinnedTaskRunning = false;
     volatile bool btReadTaskRunning = false;
     volatile bool buttonCheckTaskRunning = false;
     volatile bool gnssReadTaskRunning = false;
@@ -1723,9 +1730,15 @@ struct struct_online
     volatile bool idleTask1Running = false;
     volatile bool sdSizeCheckTaskRunning = false;
     volatile bool updatePplTaskRunning = false;
-    bool ppl = false;
-    bool batteryCharger = false;
-} online;
+
+    bool i2cPinnedTaskStopRequest = false;
+    bool btReadTaskStopRequest = false;
+    bool buttonCheckTaskStopRequest = false;
+    bool gnssReadTaskStopRequest = false;
+    bool handleGnssDataTaskStopRequest = false;
+    bool sdSizeCheckTaskStopRequest = false;
+    bool updatePplTaskStopRequest = false;
+} task;
 
 #ifdef COMPILE_WIFI
 // AWS certificate for PointPerfect API

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1318,6 +1318,7 @@ struct Settings
     bool enableGalileoHas = true; // Allow E6 corrections if possible
 
     bool enableGnssToUsbSerial = false;
+    uint16_t pplFixTimeoutS = 180; // Number of seconds of no RTK fix when using PPL before resetting GNSS
 
     // Add new settings above <------------------------------------------------------------>
     // Then also add to rtkSettingsEntries below
@@ -1620,6 +1621,7 @@ const RTK_Settings_Entry rtkSettingsEntries[] = {
     { & settings.enableGalileoHas, "enableGalileoHas", _bool, 0, false, true, true },
 
     { & settings.enableGnssToUsbSerial, "enableGnssToUsbSerial", _bool, 0, false, true, true },
+    { & settings.pplFixTimeoutS, "pplFixTimeoutS", _uint16_t, 0, false, true, true },
 
     // Add new settings above <------------------------------------------------------------>
     /*


### PR DESCRIPTION
If we stay in RTK Float (or 3D fix) for more than 180 seconds, re-initialize the PPL.