### PR TITLE
Prevent crash calling uninitialized NTRIP Server networkClient

### DIFF
--- a/Firmware/RTK_Everywhere/NtripServer.ino
+++ b/Firmware/RTK_Everywhere/NtripServer.ino
@@ -397,7 +397,7 @@ void ntripServerProcessRTCM(int serverIndex, uint8_t incoming)
             ntripServer->bytesSent = 0;
         }
 
-        if (ntripServer->networkClient->connected())
+        if (ntripServer->networkClient && ntripServer->networkClient->connected())
         {
             ntripServer->networkClient->write(incoming); // Send this byte to socket
             ntripServer->bytesSent++;


### PR DESCRIPTION
I'm seeing the code crash at line 400 when I add a second NTRIP Server (when the first is already running).
I think we're calling connected when the networkClient hasn't yet been initialized?