### PR TITLE
Only exit wifiConnect early when connected && AP_STA mode is not needed

### DIFF
--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -498,8 +498,11 @@ bool wifiConnect(unsigned long timeout)
 
 bool wifiConnect(unsigned long timeout, bool useAPSTAMode, bool *wasInAPmode)
 {
-    if (wifiIsConnected())
+    // If WiFi is already connected and AP_STA mode is not needed, then return true now
+    if (wifiIsConnected() && !useAPSTAMode)
+    {
         return (true); // Nothing to do
+    }
 
     displayWiFiConnect();
 


### PR DESCRIPTION
If AP_STA mode is needed, we need to continue even if wifiIsConnected...

A nasty flaw... It's been there for quite a while... Embarrassing really.