### PR TITLE
Fix #419

### DIFF
--- a/Firmware/RTK_Everywhere/MQTT_Client.ino
+++ b/Firmware/RTK_Everywhere/MQTT_Client.ino
@@ -457,8 +457,9 @@ void mqttClientReceiveMessage(int messageSize)
 
                 settings.pointPerfectNextKeyDuration = (1000LL * 60 * 60 * 24 * 28) - 1; // Assume next key duration is 28 days
 
-                settings.lastKeyAttempt = rtc.getEpoch(); // Mark it
-                
+                if (online.rtc)
+                    settings.lastKeyAttempt = rtc.getEpoch(); // Mark it - but only if RTC is online
+
                 recordSystemSettings();                   // Record these settings to unit
 
                 if (settings.debugCorrections == true)

--- a/Firmware/RTK_Everywhere/menuPP.ino
+++ b/Firmware/RTK_Everywhere/menuPP.ino
@@ -1445,7 +1445,7 @@ void updateProvisioning()
             provisioningSetState(PROVISIONING_WAIT_ATTEMPT);
         }
         break;
-        case PROVISIONING_WAIT_ATTEMPT:
+        case PROVISIONING_WAIT_ATTEMPT: // We may still not have RTC... Or RTC may come online _during_ this state.
         {
             if (settings.requestKeyUpdate)
                 provisioningSetState(PROVISIONING_CHECK_REMAINING);

--- a/Firmware/RTK_Everywhere/menuPP.ino
+++ b/Firmware/RTK_Everywhere/menuPP.ino
@@ -1209,8 +1209,8 @@ void provisioningSetState(uint8_t newState)
     }
 }
 
-unsigned long provisioningStartTime;
-const unsigned long provisioningTimeout = 120000;
+unsigned long provisioningStartTime_millis;
+const unsigned long provisioningTimeout_ms = 120000;
 
 void updateProvisioning()
 {
@@ -1229,14 +1229,15 @@ void updateProvisioning()
         default:
         case PROVISIONING_OFF:
         {
-            provisioningStartTime = millis(); // Record the start time so we can timeout
+            provisioningStartTime_millis = millis(); // Record the start time so we can timeout
             provisioningSetState(PROVISIONING_WAIT_RTC);
         }
         break;
         case PROVISIONING_WAIT_RTC:
         {
             if  ((online.rtc)
-                || (millis() > (provisioningStartTime + provisioningTimeout))
+                // If RTC is not online after provisioningTimeout_ms, try to provision anyway
+                || (millis() > (provisioningStartTime_millis + provisioningTimeout_ms))
                 || (settings.requestKeyUpdate))
                 provisioningSetState(PROVISIONING_NOT_STARTED);
         }
@@ -1258,6 +1259,7 @@ void updateProvisioning()
                     systemPrintln("Invalid certificates or keys. Starting provisioning");
                 provisioningSetState(PROVISIONING_CHECK_NETWORK);
             }
+            // If RTC is not online, we have to skip PROVISIONING_CHECK_ATTEMPT
             else if (!online.rtc)
             {
                 if (settings.debugPpCertificate)
@@ -1266,7 +1268,7 @@ void updateProvisioning()
             }
             else
             {
-                // Determine days until next key expires
+                // RTC is online. Determine days until next key expires
                 int daysRemaining =
                     daysFromEpoch(settings.pointPerfectNextKeyStart + settings.pointPerfectNextKeyDuration + 1);
 
@@ -1274,13 +1276,13 @@ void updateProvisioning()
                     systemPrintf("Days until keys expire: %d\r\n", daysRemaining);
 
                 if (daysRemaining > 28)
-                    provisioningSetState(PROVISIONING_KEYS_REMAINING);
+                    provisioningSetState(PROVISIONING_KEYS_REMAINING); // Don't need new keys
                 else
-                    provisioningSetState(PROVISIONING_CHECK_ATTEMPT);
+                    provisioningSetState(PROVISIONING_CHECK_ATTEMPT); // Do need new keys
             }
         }
         break;
-        case PROVISIONING_CHECK_ATTEMPT:
+        case PROVISIONING_CHECK_ATTEMPT: // Requires RTC to be online
         {
             // When did we last try to get keys? Attempt every 24 hours - or always for DEVELOPER
             //if (rtc.getEpoch() - settings.lastKeyAttempt > ( ENABLE_DEVELOPER ? 0 : (60 * 60 * 24)))
@@ -1317,13 +1319,13 @@ void updateProvisioning()
             recordSystemSettings(); // Record these settings to unit
             ztpResponse = ZTP_NOT_STARTED; // HTTP_Client will update this
             httpClientModeNeeded = true; // This will start the HTTP_Client
-            provisioningStartTime = millis(); // Record the start time so we can timeout
+            provisioningStartTime_millis = millis(); // Record the start time so we can timeout
             paintGettingKeys();
             provisioningSetState(PROVISIONING_STARTED);
         }
         case PROVISIONING_STARTED:
         {
-            if (millis() > (provisioningStartTime + provisioningTimeout))
+            if (millis() > (provisioningStartTime_millis + provisioningTimeout_ms))
             {
                 httpClientModeNeeded = false; // Tell HTTP_Client to give up. (But it probably already has...)
                 paintKeyUpdateFail(5000);
@@ -1331,8 +1333,8 @@ void updateProvisioning()
             }
             else if (ztpResponse == ZTP_SUCCESS)
             {
-                httpClientModeNeeded = false; // Tell HTTP_Client to give up. (But it probably already has...)
-                recordSystemSettings();
+                httpClientModeNeeded = false; // Tell HTTP_Client to give up
+                recordSystemSettings(); // Make sure the new cert and keys are recorded
                 provisioningSetState(PROVISIONING_KEYS_REMAINING);
             }
             else if (ztpResponse == ZTP_DEACTIVATED)
@@ -1356,7 +1358,7 @@ void updateProvisioning()
                                 "subscription. Please reference device ID: %s\r\n",
                                 landingPageUrl, hardwareID);
 
-                httpClientModeNeeded = false; // Tell HTTP_Client to give up. (But it probably already has...)
+                httpClientModeNeeded = false; // Tell HTTP_Client to give up
                 displayAccountExpired(5000);
 
                 provisioningSetState(PROVISIONING_KEYS_REMAINING);
@@ -1382,7 +1384,7 @@ void updateProvisioning()
                                 "activated. Please reference device ID: %s\r\n",
                                 landingPageUrl, hardwareID);
 
-                httpClientModeNeeded = false; // Tell HTTP_Client to give up. (But it probably already has...)
+                httpClientModeNeeded = false; // Tell HTTP_Client to give up
                 displayNotListed(5000);
 
                 provisioningSetState(PROVISIONING_KEYS_REMAINING);
@@ -1398,7 +1400,7 @@ void updateProvisioning()
                                 "support@sparkfun.com for more assistance. Please reference device ID: %s\r\n",
                                 hardwareID);
                 
-                httpClientModeNeeded = false; // Tell HTTP_Client to give up. (But it probably already has...)
+                httpClientModeNeeded = false; // Tell HTTP_Client to give up
                 displayAlreadyRegistered(5000);
 
                 provisioningSetState(PROVISIONING_KEYS_REMAINING);
@@ -1407,7 +1409,7 @@ void updateProvisioning()
             {
                 systemPrintln("updateProvisioning: ZTP_UNKNOWN_ERROR");
 
-                httpClientModeNeeded = false; // Tell HTTP_Client to give up. (But it probably already has...)
+                httpClientModeNeeded = false; // Tell HTTP_Client to give up
                 
                 provisioningSetState(PROVISIONING_KEYS_REMAINING);
             }
@@ -1439,24 +1441,21 @@ void updateProvisioning()
 
             gnssApplyPointPerfectKeys(); // Send current keys, if available, to GNSS
 
+            provisioningStartTime_millis = millis(); // Record the time so we can restart after 24 hours
             provisioningSetState(PROVISIONING_WAIT_ATTEMPT);
         }
         break;
         case PROVISIONING_WAIT_ATTEMPT:
         {
             if (settings.requestKeyUpdate)
-                provisioningSetState(PROVISIONING_STARTING);
+                provisioningSetState(PROVISIONING_CHECK_REMAINING);
             else if (!settings.enablePointPerfectCorrections || !settings.autoKeyRenewal)
                 provisioningSetState(PROVISIONING_OFF);
             // When did we last try to get keys? Attempt every 24 hours - or every 15 mins for DEVELOPER
-            //else if (online.rtc && (rtc.getEpoch() - settings.lastKeyAttempt > ( ENABLE_DEVELOPER ? (15 * 60) : (60 * 60 * 24))))
+            //else if (millis() > (provisioningStartTime_millis + ( ENABLE_DEVELOPER ? (1000 * 60 * 15) : (1000 * 60 * 60 * 24))))
             // When did we last try to get keys? Attempt every 24 hours
-            else if (online.rtc && (rtc.getEpoch() - settings.lastKeyAttempt > (60 * 60 * 24)))
-            {
-                settings.lastKeyAttempt = rtc.getEpoch(); // Mark it
-                recordSystemSettings();                   // Record these settings to unit
-                provisioningSetState(PROVISIONING_STARTING);
-            }
+            else if (millis() > (provisioningStartTime_millis + (1000 * 60 * 60 * 24))) // Don't use settings.lastKeyAttempt (#419)
+                provisioningSetState(PROVISIONING_CHECK_REMAINING);
         }
         break;
     }


### PR DESCRIPTION
This PR resolves #419 by improving ```updateProvisioning```:
* Restart from PROVISIONING_CHECK_REMAINING, not PROVISIONING_STARTING
* Avoid using ```lastKeyAttempt``` in PROVISIONING_WAIT_ATTEMPT as the RTC may come online _during_ this state
* Only update and save ```lastKeyAttempt``` when the RTC is online
* Add _ms and _millis units clarifiers
