### PR TITLE
Fix network failover detection

### DIFF
--- a/Firmware/RTK_Everywhere/MQTT_Client.ino
+++ b/Firmware/RTK_Everywhere/MQTT_Client.ino
@@ -138,6 +138,7 @@ static uint32_t mqttClientConnectionAttemptTimeout;
 static int mqttClientConnectionAttemptsTotal; // Count the number of connection attempts absolutely
 
 static volatile uint32_t mqttClientLastDataReceived; // Last time data was received via MQTT
+static NetPriority_t mqttClientPriority = NETWORK_OFFLINE;
 
 static NetworkClientSecure *mqttSecureClient;
 
@@ -722,6 +723,7 @@ void mqttClientUpdate()
     case MQTT_CLIENT_ON: {
         if ((millis() - mqttClientTimer) > mqttClientConnectionAttemptTimeout)
         {
+            mqttClientPriority = NETWORK_OFFLINE;
             mqttClientSetState(MQTT_CLIENT_WAIT_FOR_NETWORK);
         }
         break;
@@ -734,7 +736,7 @@ void mqttClientUpdate()
             mqttClientStop(true);
 
         // Wait until the network is connected to the media
-        else if (networkHasInternet())
+        else if (networkIsConnected(&mqttClientPriority))
             mqttClientSetState(MQTT_CLIENT_CONNECTING_2_SERVER);
         break;
     }
@@ -742,7 +744,7 @@ void mqttClientUpdate()
     // Connect to the MQTT server
     case MQTT_CLIENT_CONNECTING_2_SERVER: {
         // Determine if the network has failed
-        if (networkHasInternet() == false)
+        if (!networkIsConnected(&mqttClientPriority))
         {
             // Failed to connect to the network, attempt to restart the network
             mqttClientStop(true); // Was mqttClientRestart(); - #StopVsRestart
@@ -888,7 +890,7 @@ void mqttClientUpdate()
 
     case MQTT_CLIENT_SERVICES_CONNECTED: {
         // Determine if the network has failed
-        if (networkHasInternet() == false)
+        if (!networkIsConnected(&mqttClientPriority))
         {
             // Failed to connect to the network, attempt to restart the network
             mqttClientStop(true); // Was mqttClientRestart(); - #StopVsRestart

--- a/Firmware/RTK_Everywhere/NTP.ino
+++ b/Firmware/RTK_Everywhere/NTP.ino
@@ -75,6 +75,7 @@ const RtkMode_t ntpServerMode = RTK_MODE_NTP;
 // Locals
 //----------------------------------------
 
+static NetPriority_t ntpServerPriority = NETWORK_OFFLINE;
 static NetworkUDP *ntpServer; // This will be instantiated when we know the NTP port
 static uint8_t ntpServerState;
 static uint32_t lastLoggedNTPRequest;
@@ -792,6 +793,7 @@ void ntpServerUpdate()
             // The NTP server only works over Ethernet
             if (networkInterfaceHasInternet(NETWORK_ETHERNET))
             {
+                ntpServerPriority = NETWORK_OFFLINE;
                 ntpServerSetState(NTP_STATE_NETWORK_CONNECTED);
             }
         }

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -584,6 +584,22 @@ const char *networkGetNameByPriority(NetPriority_t priority)
 }
 
 //----------------------------------------
+// Determine if the network is available
+//----------------------------------------
+bool networkIsConnected(NetPriority_t *clientPriority)
+{
+    // If the client is using the highest priority network and that
+    // network is still available then continue as normal
+    if (networkHasInternet_bm && (*clientPriority == networkPriority))
+        return (networkHasInternet_bm & (1 << networkIndexTable[networkPriority]))
+            ? true : false;
+
+    // The network has changed, notify the client of the change
+    *clientPriority = networkPriority;
+    return false;
+}
+
+//----------------------------------------
 // Determine if the network interface is online
 //----------------------------------------
 bool networkInterfaceHasInternet(NetIndex_t index)

--- a/Firmware/RTK_Everywhere/NtripServer.ino
+++ b/Firmware/RTK_Everywhere/NtripServer.ino
@@ -175,6 +175,7 @@ const RtkMode_t ntripServerMode = RTK_MODE_BASE_FIXED;
 
 // NTRIP Servers
 static NTRIP_SERVER_DATA ntripServerArray[NTRIP_SERVER_MAX];
+static NetPriority_t ntripServerPriority = NETWORK_OFFLINE;
 
 //----------------------------------------
 // NTRIP Server Routines
@@ -607,6 +608,7 @@ void ntripServerUpdate(int serverIndex)
 
     // Start the network
     case NTRIP_SERVER_ON:
+        ntripServerPriority = NETWORK_OFFLINE;
         ntripServerSetState(ntripServer, NTRIP_SERVER_WAIT_FOR_NETWORK);
         break;
 
@@ -622,7 +624,7 @@ void ntripServerUpdate(int serverIndex)
         }
 
         // Wait until the network is connected
-        else if (networkHasInternet())
+        else if (networkIsConnected(&ntripServerPriority))
         {
             // Allocate the networkClient structure
             ntripServer->networkClient = new NetworkClient();
@@ -645,7 +647,7 @@ void ntripServerUpdate(int serverIndex)
     // Network available
     case NTRIP_SERVER_NETWORK_CONNECTED:
         // Determine if the network has failed
-        if (networkHasInternet() == false)
+        if (!networkIsConnected(&ntripServerPriority))
             // Failed to connect to to the network, attempt to restart the network
             ntripServerStop(serverIndex, true); // Was ntripServerRestart(serverIndex); - #StopVsRestart
 
@@ -663,7 +665,7 @@ void ntripServerUpdate(int serverIndex)
     // Wait for GNSS correction data
     case NTRIP_SERVER_WAIT_GNSS_DATA:
         // Determine if the network has failed
-        if (networkHasInternet() == false)
+        if (!networkIsConnected(&ntripServerPriority))
             // Failed to connect to to the network, attempt to restart the network
             ntripServerStop(serverIndex, true); // Was ntripServerRestart(serverIndex); - #StopVsRestart
 
@@ -673,7 +675,7 @@ void ntripServerUpdate(int serverIndex)
     // Initiate the connection to the NTRIP caster
     case NTRIP_SERVER_CONNECTING:
         // Determine if the network has failed
-        if (networkHasInternet() == false)
+        if (!networkIsConnected(&ntripServerPriority))
             // Failed to connect to to the network, attempt to restart the network
             ntripServerStop(serverIndex, true); // Was ntripServerRestart(serverIndex); - #StopVsRestart
 
@@ -701,7 +703,7 @@ void ntripServerUpdate(int serverIndex)
     // Wait for authorization response
     case NTRIP_SERVER_AUTHORIZATION:
         // Determine if the network has failed
-        if (networkHasInternet() == false)
+        if (!networkIsConnected(&ntripServerPriority))
             // Failed to connect to to the network, attempt to restart the network
             ntripServerStop(serverIndex, true); // Was ntripServerRestart(serverIndex); - #StopVsRestart
 
@@ -795,7 +797,7 @@ void ntripServerUpdate(int serverIndex)
     // NTRIP server authorized to send RTCM correction data to NTRIP caster
     case NTRIP_SERVER_CASTING:
         // Determine if the network has failed
-        if (networkHasInternet() == false)
+        if (!networkIsConnected(&ntripServerPriority))
             // Failed to connect to the network, attempt to restart the network
             ntripServerStop(serverIndex, true); // Was ntripServerRestart(serverIndex); - #StopVsRestart
 

--- a/Firmware/RTK_Everywhere/UdpServer.ino
+++ b/Firmware/RTK_Everywhere/UdpServer.ino
@@ -94,6 +94,7 @@ static NetworkUDP *udpServer = nullptr;
 static uint8_t udpServerState;
 static uint32_t udpServerTimer;
 static volatile RING_BUFFER_OFFSET udpServerTail;
+static NetPriority_t udpServerPriority;
 
 //----------------------------------------
 // UDP Server handleGnssDataTask Support Routines
@@ -106,7 +107,7 @@ int32_t udpServerSendDataBroadcast(uint8_t *data, uint16_t length)
         return 0;
 
     // Send the data as broadcast
-    if (settings.enableUdpServer && online.udpServer && networkHasInternet())
+    if (settings.enableUdpServer && online.udpServer && networkIsConnected(&udpServerPriority))
     {
         IPAddress broadcastAddress = networkGetBroadcastIpAddress();
         udpServer->beginPacket(broadcastAddress, settings.udpServerPort);
@@ -324,6 +325,7 @@ void udpServerUpdate()
         {
             if (settings.debugUdpServer && (!inMainMenu))
                 systemPrintln("UDP server starting the network");
+            udpServerPriority = NETWORK_OFFLINE;
             udpServerSetState(UDP_SERVER_STATE_WAIT_FOR_NETWORK);
         }
         break;
@@ -335,7 +337,7 @@ void udpServerUpdate()
             udpServerStop();
 
         // Wait until the network is connected
-        else if (networkHasInternet() || WIFI_SOFT_AP_RUNNING())
+        else if (networkIsConnected(&udpServerPriority) || WIFI_SOFT_AP_RUNNING())
         {
             // Delay before starting the UDP server
             if ((millis() - udpServerTimer) >= (1 * 1000))
@@ -353,7 +355,7 @@ void udpServerUpdate()
     // Handle client connections and link failures
     case UDP_SERVER_STATE_RUNNING:
         // Determine if the network has failed
-        if ((networkHasInternet() == false && WIFI_SOFT_AP_RUNNING() == false) || (!settings.enableUdpServer && !settings.baseCasterOverride))
+        if ((networkIsConnected(&udpServerPriority) == false && WIFI_SOFT_AP_RUNNING() == false) || (!settings.enableUdpServer && !settings.baseCasterOverride))
         {
             if ((settings.debugUdpServer || PERIODIC_DISPLAY(PD_UDP_SERVER_DATA)) && (!inMainMenu))
             {

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -27,6 +27,8 @@ static const char *const webServerStateNames[] = {
 
 static const int webServerStateEntries = sizeof(webServerStateNames) / sizeof(webServerStateNames[0]);
 
+static NetPriority_t webServerPriority = NETWORK_OFFLINE;
+
 static uint8_t webServerState;
 
 // Once connected to the access point for WiFi Config, the ESP32 sends current setting values in one long string to
@@ -779,7 +781,7 @@ void webServerUpdate()
     // Wait for connection to the network
     case WEBSERVER_STATE_WAIT_FOR_NETWORK:
         // Wait until the network is connected to the internet or has WiFi AP
-        if (networkHasInternet() || WIFI_SOFT_AP_RUNNING())
+        if (networkIsConnected(&webServerPriority) || WIFI_SOFT_AP_RUNNING())
         {
             if (settings.debugWebServer)
                 systemPrintln("Web Server connected to network");
@@ -791,7 +793,7 @@ void webServerUpdate()
     // Start the web server
     case WEBSERVER_STATE_NETWORK_CONNECTED: {
         // Determine if the network has failed
-        if (networkHasInternet() == false && WIFI_SOFT_AP_RUNNING() == false)
+        if (networkIsConnected(&webServerPriority) == false && WIFI_SOFT_AP_RUNNING() == false)
             webServerStop();
         if (settings.debugWebServer)
             systemPrintln("Assigning web server resources");
@@ -807,7 +809,7 @@ void webServerUpdate()
     // Allow web services
     case WEBSERVER_STATE_RUNNING:
         // Determine if the network has failed
-        if (networkHasInternet() == false && WIFI_SOFT_AP_RUNNING() == false)
+        if (networkIsConnected(&webServerPriority) == false && WIFI_SOFT_AP_RUNNING() == false)
             webServerStop();
 
         // This state is exited when webServerStop() is called

--- a/Firmware/RTK_Everywhere/menuFirmware.ino
+++ b/Firmware/RTK_Everywhere/menuFirmware.ino
@@ -33,6 +33,7 @@ static const int otaStateEntries = sizeof(otaStateNames) / sizeof(otaStateNames[
 //----------------------------------------
 
 static uint32_t otaLastUpdateCheck;
+static NetPriority_t otaPriority = NETWORK_OFFLINE;
 static uint8_t otaState;
 
 #endif // COMPILE_OTA_AUTO
@@ -840,9 +841,7 @@ void otaUpdate()
                 otaUpdateStop();
 
             // Wait until the network is connected to the media
-            // else if (networkHasInternet())
-            else if (networkInterfaceHasInternet(
-                         NETWORK_WIFI)) // TODO Remove once OTA works over other network interfaces
+            else if (networkIsConnected(&otaPriority))
             {
                 if (settings.debugFirmwareUpdate)
                     systemPrintln("Firmware update connected to network");
@@ -855,9 +854,7 @@ void otaUpdate()
         // Get firmware version from server
         case OTA_STATE_GET_FIRMWARE_VERSION:
             // Determine if the network has failed
-            // if (networkHasInternet() == false)
-            if (networkInterfaceHasInternet(NETWORK_WIFI) ==
-                false) // TODO Remove once OTA works over other network interfaces
+            if (!networkIsConnected(&otaPriority))
                 otaUpdateStop();
             if (settings.debugFirmwareUpdate)
                 systemPrintln("Checking for latest firmware version");
@@ -913,7 +910,7 @@ void otaUpdate()
         // Update the firmware
         case OTA_STATE_UPDATE_FIRMWARE:
             // Determine if the network has failed
-            if (networkHasInternet() == false)
+            if (!networkIsConnected(&otaPriority))
                 otaUpdateStop();
             else
             {

--- a/Firmware/RTK_Everywhere/menuPP.ino
+++ b/Firmware/RTK_Everywhere/menuPP.ino
@@ -21,6 +21,7 @@ static const uint8_t ppIpToken[16] = {POINTPERFECT_IP_TOKEN};            // Toke
 static const uint8_t ppLbandIpToken[16] = {POINTPERFECT_LBAND_IP_TOKEN}; // Token in HEX form
 
 #ifdef COMPILE_NETWORK
+static NetPriority_t pointperfectPriority = NETWORK_OFFLINE;
 MqttClient *menuppMqttClient;
 #endif // COMPILE_NETWORK
 
@@ -1308,7 +1309,7 @@ void provisioningUpdate()
         }
         // Wait until the network is available
 #ifdef COMPILE_NETWORK
-        else if (networkHasInternet())
+        else if (networkIsConnected(&pointperfectPriority))
         {
             if (settings.debugPpCertificate)
                 systemPrintln("PointPerfect key update connected to network");


### PR DESCRIPTION
Ensure that each client and server gets notified of the network failover
in a timely manor.  Using networkHasInternet may either not change or
only a subset of clients and servers may get notified.  Using
networkIsConnected ensures that the client gets rapid notification of
the failover.
