### PR TITLE
Add WiFi restart support

### DIFF
--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -211,6 +211,7 @@ void wifiResetThrottleTimeout()                 {}
 void wifiResetTimeout()                         {}
 #define WIFI_SOFT_AP_RUNNING()                  false
 bool wifiStart()                                {return false;}
+void wifiStationReconnectionRequest()           {}
 #define WIFI_STATION_RUNNING()                  false
 #define WIFI_STOP()                             {}
 bool wifiUnavailable()                          {return true;}

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1390,6 +1390,10 @@ void networkUpdate()
             networkStop(index, settings.debugNetworkLayer);
         }
 
+        // Check for the WiFi station reconnection
+        if ((index == NETWORK_WIFI) && wifiReconnectionTimer)
+            wifiStationReconnectionRequest();
+
         // Handle the network has internet event
         if (networkEventInternetAvailable[index])
         {

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -603,6 +603,9 @@ void networkInterfaceEventInternetAvailable(NetIndex_t index)
     // Validate the index
     networkValidateIndex(index);
 
+    // Notify networkUpdate of the change in state
+    if (settings.debugNetworkLayer)
+        systemPrintf("%s internet available event\r\n", networkInterfaceTable[index].name);
     networkEventInternetAvailable[index] = true;
 }
 
@@ -615,6 +618,8 @@ void networkInterfaceEventInternetLost(NetIndex_t index)
     networkValidateIndex(index);
 
     // Notify networkUpdate of the change in state
+    if (settings.debugNetworkLayer)
+        systemPrintf("%s lost internet access event\r\n", networkInterfaceTable[index].name);
     networkEventInternetLost[index] = true;
 }
 
@@ -626,6 +631,9 @@ void networkInterfaceEventStop(NetIndex_t index)
     // Validate the index
     networkValidateIndex(index);
 
+    // Notify networkUpdate of the change in state
+    if (settings.debugNetworkLayer)
+        systemPrintf("%s stop event\r\n", networkInterfaceTable[index].name);
     networkEventStop[index] = true;
 }
 
@@ -658,12 +666,18 @@ void networkInterfaceInternetConnectionLost(NetIndex_t index)
 
     // Check for network offline
     if (networkInterfaceHasInternet(index) == false)
+    {
+        if (settings.debugNetworkLayer)
+            systemPrintf("%s previously lost internet access\r\n", networkInterfaceTable[index].name);
         // Already offline, nothing to do
         return;
+    }
 
     // Mark this network as offline
     bitMask = 1 << index;
     networkHasInternet_bm &= ~bitMask;
+    if (settings.debugNetworkLayer)
+        systemPrintf("%s does NOT have internet access\r\n", networkInterfaceTable[index].name);
 
     // Disable mDNS if necessary
     networkMulticastDNSStop(index);
@@ -731,12 +745,18 @@ void networkInterfaceInternetConnectionAvailable(NetIndex_t index)
     // Check for network online
     previousIndex = index;
     if (networkInterfaceHasInternet(index))
+    {
         // Already online, nothing to do
+        if (settings.debugNetworkLayer)
+            systemPrintf("%s already has internet access\r\n", networkInterfaceTable[index].name);
         return;
+    }
 
     // Mark this network as online
     bitMask = 1 << index;
     networkHasInternet_bm |= bitMask;
+    if (settings.debugNetworkLayer)
+        systemPrintf("%s has internet access\r\n", networkInterfaceTable[index].name);
 
     // Raise the network priority if necessary
     previousPriority = networkPriority;

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -600,6 +600,9 @@ bool networkHasInternet()
 //----------------------------------------
 void networkInterfaceEventInternetAvailable(NetIndex_t index)
 {
+    // Validate the index
+    networkValidateIndex(index);
+
     networkEventInternetAvailable[index] = true;
 }
 
@@ -608,6 +611,9 @@ void networkInterfaceEventInternetAvailable(NetIndex_t index)
 //----------------------------------------
 void networkInterfaceEventInternetLost(NetIndex_t index)
 {
+    // Validate the index
+    networkValidateIndex(index);
+
     // Notify networkUpdate of the change in state
     networkEventInternetLost[index] = true;
 }
@@ -617,6 +623,9 @@ void networkInterfaceEventInternetLost(NetIndex_t index)
 //----------------------------------------
 void networkInterfaceEventStop(NetIndex_t index)
 {
+    // Validate the index
+    networkValidateIndex(index);
+
     networkEventStop[index] = true;
 }
 

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1447,7 +1447,6 @@ void networkUpdate()
                 systemPrintln("WiFi settings changed, restarting WiFi");
 
             wifiResetThrottleTimeout();
-            WIFI_STOP();
             networkStop(NETWORK_WIFI, settings.debugNetworkLayer);
         }
     }

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -653,6 +653,9 @@ void networkInterfaceInternetConnectionLost(NetIndex_t index)
     // Validate the index
     networkValidateIndex(index);
 
+    // Clear the event flag
+    networkEventInternetLost[index] = false;
+
     // Check for network offline
     if (networkInterfaceHasInternet(index) == false)
         // Already offline, nothing to do
@@ -721,6 +724,9 @@ void networkInterfaceInternetConnectionAvailable(NetIndex_t index)
 
     // Validate the index
     networkValidateIndex(index);
+
+    // Clear the event flag
+    networkEventInternetAvailable[index] = false;
 
     // Check for network online
     previousIndex = index;
@@ -1281,6 +1287,9 @@ void networkStop(NetIndex_t index, bool debug)
     // Validate the index
     networkValidateIndex(index);
 
+    // Clear the event flag
+    networkEventStop[index] = false;
+
     // Only stop networks that exist on the platform
     if (networkIsPresent(index))
     {
@@ -1385,17 +1394,11 @@ void networkUpdate()
 
         // Handle the network lost internet event
         if (networkEventInternetLost[index])
-        {
-            networkEventInternetLost[index] = false;
             networkInterfaceInternetConnectionLost(index);
-        }
 
         // Handle the network stop event
         if (networkEventStop[index])
-        {
-            networkEventStop[index] = false;
             networkStop(index, settings.debugNetworkLayer);
-        }
 
         // Check for the WiFi station reconnection
         if ((index == NETWORK_WIFI) && wifiReconnectionTimer)
@@ -1403,10 +1406,7 @@ void networkUpdate()
 
         // Handle the network has internet event
         if (networkEventInternetAvailable[index])
-        {
-            networkEventInternetAvailable[index] = false;
             networkInterfaceInternetConnectionAvailable(index);
-        }
 
         // Execute any active polling routine
         sequence = networkSequence[index];

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -382,6 +382,7 @@ RTK_WIFI wifi(false);
 #endif // COMPILE_WIFI
 
 // WiFi Globals - For other module direct access
+uint32_t wifiReconnectionTimer; // Delay before reconnection, timer running when non-zero
 bool wifiRestartRequested;      // Restart WiFi if user changes anything
 
 #define MQTT_CLIENT_STOP(shutdown)                                                                                     \

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -381,7 +381,8 @@ RTK_WIFI wifi(false);
     }
 #endif // COMPILE_WIFI
 
-bool wifiRestartRequested = false; // Restart WiFi if user changes anything
+// WiFi Globals - For other module direct access
+bool wifiRestartRequested;      // Restart WiFi if user changes anything
 
 #define MQTT_CLIENT_STOP(shutdown)                                                                                     \
     {                                                                                                                  \

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -678,6 +678,30 @@ void wifiStartThrottled(NetIndex_t index, uintptr_t parameter, bool debug)
 }
 
 //*********************************************************************
+// Handle WiFi station reconnection requests
+void wifiStationReconnectionRequest()
+{
+    uint32_t currentMsec;
+
+    // Has the reconnection delay expired
+    currentMsec = millis();
+    if ((currentMsec - wifiReconnectionTimer) >= WIFI_RECONNECTION_DELAY)
+    {
+        // Stop the reconnection timer
+        wifiReconnectionTimer = 0;
+        if (settings.debugWifiState)
+            systemPrintf("Reconnection timer fired!\r\n");
+
+        // Start the WiFi scan
+        if (wifi.stationRunning())
+        {
+            wifi.clearStarted(WIFI_STA_RECONNECT);
+            wifi.stopStart(WIFI_AP_START_MDNS, WIFI_STA_RECONNECT);
+        }
+    }
+}
+
+//*********************************************************************
 // Stop WiFi, used by wifiStopSequence
 void wifiStop(NetIndex_t index, uintptr_t parameter, bool debug)
 {
@@ -1692,32 +1716,6 @@ bool RTK_WIFI::stationHostName(const char * hostName)
 bool RTK_WIFI::stationOnline()
 {
     return (_started & WIFI_STA_ONLINE) ? true : false;
-}
-
-//*********************************************************************
-// Handle WiFi station reconnection requests
-void RTK_WIFI::stationReconnectionRequest()
-{
-    uint32_t currentMsec;
-
-    // Check for reconnection request
-    currentMsec = millis();
-    if (wifiReconnectionTimer)
-    {
-        if ((currentMsec - wifiReconnectionTimer) >= WIFI_RECONNECTION_DELAY)
-        {
-            wifiReconnectionTimer = 0;
-            if (settings.debugWifiState)
-                systemPrintf("Reconnection timer fired!\r\n");
-
-            // Start the WiFi scan
-            if (stationRunning())
-            {
-                _started = _started & ~WIFI_STA_RECONNECT;
-                stopStart(WIFI_AP_START_MDNS, WIFI_STA_RECONNECT);
-            }
-        }
-    }
 }
 
 //*********************************************************************

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -2309,6 +2309,8 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         // Start the radio operations
         //****************************************
 
+        enabled = false;
+
         // Start the soft AP mode
         if (starting & WIFI_AP_SET_MODE)
         {

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -744,6 +744,18 @@ RTK_WIFI::RTK_WIFI(bool verbose)
 }
 
 //*********************************************************************
+// Clear some of the started components
+// Inputs:
+//   components: Bitmask of components to clear
+// Outputs:
+//   Returns the bitmask of started components
+WIFI_ACTION_t RTK_WIFI::clearStarted(WIFI_ACTION_t components)
+{
+    _started = _started & ~components;
+    return _started;
+}
+
+//*********************************************************************
 // Attempts a connection to all provided SSIDs
 bool RTK_WIFI::connect(unsigned long timeout,
                        bool startAP)

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -1502,14 +1502,6 @@ void RTK_WIFI::stationEventHandler(arduino_event_id_t event, arduino_event_info_
     bool success;
     int type;
 
-    // Take the network offline if necessary
-    if (networkInterfaceHasInternet(NETWORK_WIFI) && (event != ARDUINO_EVENT_WIFI_STA_GOT_IP) &&
-        (event != ARDUINO_EVENT_WIFI_STA_GOT_IP6))
-    {
-        // Stop WiFi to allow it to restart
-        networkInterfaceEventStop(NETWORK_WIFI);
-    }
-
     //------------------------------
     // WiFi Status Values:
     //     WL_CONNECTED: assigned when connected to a WiFi network

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -739,6 +739,7 @@ RTK_WIFI::RTK_WIFI(bool verbose)
       _started{false}, _stationChannel{0},
       _timer{0}, _usingDefaultChannel{true}, _verbose{verbose}
 {
+    wifiRestartRequested = false;
 }
 
 //*********************************************************************

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -681,7 +681,11 @@ void wifiStartThrottled(NetIndex_t index, uintptr_t parameter, bool debug)
 // Stop WiFi, used by wifiStopSequence
 void wifiStop(NetIndex_t index, uintptr_t parameter, bool debug)
 {
-    WIFI_STOP();
+    networkInterfaceInternetConnectionLost(NETWORK_WIFI);
+
+    // Stop WiFi stataion
+    wifi.enable(wifi.espNowRunning(), wifi.softApRunning(), false);
+
     networkSequenceNextEntry(NETWORK_WIFI, settings.debugNetworkLayer);
 }
 

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2086,14 +2086,6 @@ class RTK_WIFI
     //   Returns the channel number of the AP
     WIFI_CHANNEL_t stationSelectAP(uint8_t apCount, bool list);
 
-    // Stop and start WiFi components
-    // Inputs:
-    //   stopping: WiFi components that need to be stopped
-    //   starting: WiFi components that neet to be started
-    // Outputs:
-    //   Returns true if the modes were successfully configured
-    bool stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting);
-
     // Handle the WiFi event
     // Inputs:
     //   event: Arduino ESP32 event number found on
@@ -2229,6 +2221,14 @@ class RTK_WIFI
     // Outputs:
     //  Returns true if the WiFi station is being started or is online
     bool stationRunning();
+
+    // Stop and start WiFi components
+    // Inputs:
+    //   stopping: WiFi components that need to be stopped
+    //   starting: WiFi components that neet to be started
+    // Outputs:
+    //   Returns true if the modes were successfully configured
+    bool stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting);
 
     // Test the WiFi modes
     // Inputs:

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2214,9 +2214,6 @@ class RTK_WIFI
     //   Returns true when the WiFi station is online and ready for use
     bool stationOnline();
 
-    // Handle WiFi station reconnection requests
-    void stationReconnectionRequest();
-
     // Get the station status
     // Outputs:
     //  Returns true if the WiFi station is being started or is online

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2109,6 +2109,13 @@ class RTK_WIFI
     //   verbose: Set to true to display additional WiFi debug data
     RTK_WIFI(bool verbose = false);
 
+    // Clear some of the started components
+    // Inputs:
+    //   components: Bitmask of components to clear
+    // Outputs:
+    //   Returns the bitmask of started components
+    WIFI_ACTION_t clearStarted(WIFI_ACTION_t components);
+
     // Attempts a connection to all provided SSIDs
     // Inputs:
     //    timeout: Number of milliseconds to wait for the connection


### PR DESCRIPTION
WiFi: Initialize wifiRestartRequested in RTK_WIFI constructor
WiFi: Make RTK_WIFI::_timer a global: wifiReconnectionTimer
WiFi: Add clearStarted routine
WiFi: Make stopStart public
WiFi: Initiate the WiFi reconnection
* Move RTK_WIFI::stationReconnection to wifiStationReconnectionRequest
* Call wifiStationReconnectionRequest when the reconnection timer is
   running (non-zero)
WiFi: Stop connection timer when WiFi stops or connection successful
Network: Validate the index
Network: Use networkInterfaceHasInternet where possible
Network: Let networkInterfaceInternet* and networkStop clear flags
Network: Add more debug output
Network: Move routines *ConnectionLost & *ConnectionAvailable