### PR TITLE
Reduce the use of macros, use global variables or call routines directly

### DIFF
--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -211,6 +211,7 @@ void wifiResetThrottleTimeout()                 {}
 void wifiResetTimeout()                         {}
 #define WIFI_SOFT_AP_RUNNING()                  false
 bool wifiStart()                                {return false;}
+void wifiStationReconnectionRequest()           {}
 #define WIFI_STATION_RUNNING()                  false
 #define WIFI_STOP()                             {}
 bool wifiUnavailable()                          {return true;}

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -212,7 +212,6 @@ void wifiResetTimeout()                         {}
 #define WIFI_SOFT_AP_RUNNING()                  false
 bool wifiStart()                                {return false;}
 void wifiStationReconnectionRequest()           {}
-#define WIFI_STATION_RUNNING()                  false
 #define WIFI_STOP()                             {}
 bool wifiUnavailable()                          {return true;}
 

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -179,7 +179,7 @@ void webServerVerifyTables() {}
 #ifndef COMPILE_ESPNOW
 
 bool espnowGetState()                   {return ESPNOW_OFF;}
-#define ESPNOW_IS_PAIRED()              false
+bool espNowIsPaired()                   {return false;}
 void espNowProcessRTCM(byte incoming)   {}
 bool espNowProcessRxPairedMessage()     {return true;}
 esp_err_t espNowRemovePeer(uint8_t *peerMac)        {return ESP_OK;}

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -209,7 +209,6 @@ uint32_t wifiGetStartTimeout()                  {return 0;}
 int wifiNetworkCount()                          {return 0;}
 void wifiResetThrottleTimeout()                 {}
 void wifiResetTimeout()                         {}
-#define WIFI_SOFT_AP_RUNNING()                  false
 bool wifiStart()                                {return false;}
 void wifiStationReconnectionRequest()           {}
 #define WIFI_STOP()                             {}

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -204,7 +204,6 @@ void menuWiFi()                 {systemPrintln("**WiFi not compiled**");}
 #define WIFI_ESPNOW_SET_CHANNEL(chan)
 #define WIFI_GET_CHANNEL()                      0
 uint32_t wifiGetStartTimeout()                  {return 0;}
-#define WIFI_IS_RUNNING()                       false
 int wifiNetworkCount()                          {return 0;}
 void wifiResetThrottleTimeout()                 {}
 void wifiResetTimeout()                         {}

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -201,7 +201,6 @@ void espNowUpdate()                     {}
 #ifndef COMPILE_WIFI
 
 void menuWiFi()                 {systemPrintln("**WiFi not compiled**");}
-#define WIFI_ESPNOW_RUNNING()                   false
 #define WIFI_ESPNOW_SET_CHANNEL(chan)
 #define WIFI_GET_CHANNEL()                      0
 uint32_t wifiGetStartTimeout()                  {return 0;}

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -202,7 +202,6 @@ void espNowUpdate()                     {}
 
 void menuWiFi()                 {systemPrintln("**WiFi not compiled**");}
 #define WIFI_ESPNOW_SET_CHANNEL(chan)
-#define WIFI_GET_CHANNEL()                      0
 uint32_t wifiGetStartTimeout()                  {return 0;}
 int wifiNetworkCount()                          {return 0;}
 void wifiResetThrottleTimeout()                 {}

--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -656,7 +656,7 @@ void setRadioIcons(std::vector<iconPropertyBlinking> *iconList)
             uint8_t numberOfRadios = 1; // Bluetooth always indicated. TODO don't count if BT radio type is OFF.
             if (wifiStationRunning || wifiSoftApRunning)
                 numberOfRadios++;
-            if (WIFI_ESPNOW_RUNNING())
+            if (wifiEspNowRunning)
                 numberOfRadios++;
 
             // Bluetooth only
@@ -673,7 +673,7 @@ void setRadioIcons(std::vector<iconPropertyBlinking> *iconList)
                 // Do we have WiFi or ESP
                 if (wifiStationRunning || wifiSoftApRunning)
                     setWiFiIcon_TwoRadios(iconList);
-                else if (WIFI_ESPNOW_RUNNING())
+                else if (wifiEspNowRunning)
                     setESPNowIcon_TwoRadios(iconList);
 
                 setModeIcon(iconList); // Turn on Rover/Base type icons

--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -753,7 +753,7 @@ void setRadioIcons(std::vector<iconPropertyBlinking> *iconList)
             }
 #endif // /COMPILE_CELLULAR
 
-            if (ESPNOW_IS_PAIRED()) // ESPNOW : Columns 64 - 71
+            if (espNowIsPaired()) // ESPNOW : Columns 64 - 71
             {
                 iconPropertyBlinking prop;
                 prop.duty = 0b11111111;
@@ -792,7 +792,7 @@ void setRadioIcons(std::vector<iconPropertyBlinking> *iconList)
                 }
             }
 
-            if (ESPNOW_IS_PAIRED())
+            if (espNowIsPaired())
             {
                 if (espNowIncomingRTCM == true) // Download : Columns 74 - 81
                 {
@@ -1023,7 +1023,7 @@ void setBluetoothIcon_TwoRadios(std::vector<iconPropertyBlinking> *iconList)
 // This is 64x48-specific
 void setESPNowIcon_TwoRadios(std::vector<iconPropertyBlinking> *iconList)
 {
-    if (ESPNOW_IS_PAIRED())
+    if (espNowIsPaired())
     {
         if (espNowIncomingRTCM == true || espNowOutgoingRTCM == true)
         {

--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -654,7 +654,7 @@ void setRadioIcons(std::vector<iconPropertyBlinking> *iconList)
 
             // Count the number of radios in use
             uint8_t numberOfRadios = 1; // Bluetooth always indicated. TODO don't count if BT radio type is OFF.
-            if (WIFI_STATION_RUNNING() || WIFI_SOFT_AP_RUNNING())
+            if (wifiStationRunning || WIFI_SOFT_AP_RUNNING())
                 numberOfRadios++;
             if (WIFI_ESPNOW_RUNNING())
                 numberOfRadios++;
@@ -671,7 +671,7 @@ void setRadioIcons(std::vector<iconPropertyBlinking> *iconList)
                 setBluetoothIcon_TwoRadios(iconList);
 
                 // Do we have WiFi or ESP
-                if (WIFI_STATION_RUNNING() || WIFI_SOFT_AP_RUNNING())
+                if (wifiStationRunning || WIFI_SOFT_AP_RUNNING())
                     setWiFiIcon_TwoRadios(iconList);
                 else if (WIFI_ESPNOW_RUNNING())
                     setESPNowIcon_TwoRadios(iconList);
@@ -706,7 +706,7 @@ void setRadioIcons(std::vector<iconPropertyBlinking> *iconList)
                 iconList->push_back(prop);
             }
 
-            if (WIFI_STATION_RUNNING() || WIFI_SOFT_AP_RUNNING()) // WiFi : Columns 34 - 46
+            if (wifiStationRunning || WIFI_SOFT_AP_RUNNING()) // WiFi : Columns 34 - 46
             {
 #ifdef COMPILE_WIFI
                 int wifiRSSI = WiFi.RSSI();

--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -654,7 +654,7 @@ void setRadioIcons(std::vector<iconPropertyBlinking> *iconList)
 
             // Count the number of radios in use
             uint8_t numberOfRadios = 1; // Bluetooth always indicated. TODO don't count if BT radio type is OFF.
-            if (wifiStationRunning || WIFI_SOFT_AP_RUNNING())
+            if (wifiStationRunning || wifiSoftApRunning)
                 numberOfRadios++;
             if (WIFI_ESPNOW_RUNNING())
                 numberOfRadios++;
@@ -671,7 +671,7 @@ void setRadioIcons(std::vector<iconPropertyBlinking> *iconList)
                 setBluetoothIcon_TwoRadios(iconList);
 
                 // Do we have WiFi or ESP
-                if (wifiStationRunning || WIFI_SOFT_AP_RUNNING())
+                if (wifiStationRunning || wifiSoftApRunning)
                     setWiFiIcon_TwoRadios(iconList);
                 else if (WIFI_ESPNOW_RUNNING())
                     setESPNowIcon_TwoRadios(iconList);
@@ -706,7 +706,7 @@ void setRadioIcons(std::vector<iconPropertyBlinking> *iconList)
                 iconList->push_back(prop);
             }
 
-            if (wifiStationRunning || WIFI_SOFT_AP_RUNNING()) // WiFi : Columns 34 - 46
+            if (wifiStationRunning || wifiSoftApRunning) // WiFi : Columns 34 - 46
             {
 #ifdef COMPILE_WIFI
                 int wifiRSSI = WiFi.RSSI();

--- a/Firmware/RTK_Everywhere/ESPNOW.ino
+++ b/Firmware/RTK_Everywhere/ESPNOW.ino
@@ -99,7 +99,7 @@ esp_err_t espNowAddPeer(const uint8_t * peerMac)
 void espNowBeginPairing()
 {
     // Start ESP-NOW if necessary
-    wifi.enable(true, wifi.softApRunning(), wifi.stationRunning());
+    wifi.enable(true, wifi.softApRunning(), wifiStationRunning);
 
     // To begin pairing, we must add the broadcast MAC to the peer list
     espNowAddPeer(espNowBroadcastAddr);

--- a/Firmware/RTK_Everywhere/ESPNOW.ino
+++ b/Firmware/RTK_Everywhere/ESPNOW.ino
@@ -99,7 +99,7 @@ esp_err_t espNowAddPeer(const uint8_t * peerMac)
 void espNowBeginPairing()
 {
     // Start ESP-NOW if necessary
-    wifi.enable(true, wifi.softApRunning(), wifiStationRunning);
+    wifi.enable(true, wifiSoftApRunning, wifiStationRunning);
 
     // To begin pairing, we must add the broadcast MAC to the peer list
     espNowAddPeer(espNowBroadcastAddr);

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1390,6 +1390,10 @@ void networkUpdate()
             networkStop(index, settings.debugNetworkLayer);
         }
 
+        // Check for the WiFi station reconnection
+        if ((index == NETWORK_WIFI) && wifiReconnectionTimer)
+            wifiStationReconnectionRequest();
+
         // Handle the network has internet event
         if (networkEventInternetAvailable[index])
         {

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -785,7 +785,6 @@ void networkInterfaceInternetConnectionLost(NetIndex_t index)
             if (networkInterfaceHasInternet(index))
             {
                 // Successfully found an online network
-                networkMulticastDNSStart(index);
                 break;
             }
 
@@ -800,7 +799,13 @@ void networkInterfaceInternetConnectionLost(NetIndex_t index)
         // Set the new network priority
         networkPriority = priority;
         if (priority < NETWORK_OFFLINE)
+        {
             Network.setDefaultInterface(*networkInterfaceTable[index].netif);
+
+            // Start mDNS if this interface is connected to the internet
+            if (networkInterfaceHasInternet(index))
+                networkMulticastDNSStart(index);
+        }
 
         // Display the transition
         if (settings.debugNetworkLayer)

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -131,6 +131,7 @@ NetMask_t networkStarted;     // Track the running networks
 // Active network sequence, may be nullptr
 NETWORK_POLL_SEQUENCE *networkSequence[NETWORK_OFFLINE];
 
+NetMask_t networkMdnsRequests; // Non-zero when one or more interfaces request mDNS
 NetMask_t networkMdnsRunning; // Non-zero when mDNS is running
 
 //----------------------------------------
@@ -263,6 +264,7 @@ void menuTcpUdp()
         else if (incoming == 'm')
         {
             settings.mdnsEnable ^= 1;
+            networkMulticastDNSUpdate();
         }
 
         else if (settings.mdnsEnable && (incoming == 'n'))
@@ -847,82 +849,118 @@ bool networkIsPresent(NetIndex_t index)
 }
 
 //----------------------------------------
-// Change multicast DNS to a given network
-//----------------------------------------
-void networkMulticastDNSSwitch(NetIndex_t startIndex)
-{
-    // Stop mDNS on the other networks
-    for (int index = 0; index < NETWORK_OFFLINE; index++)
-        if (index != startIndex)
-            networkMulticastDNSStop(index);
-
-    // Start mDNS on the requested network
-    networkMulticastDNSStart(startIndex); // Start DNS on the selected network, either WiFi or Ethernet
-}
-
-//----------------------------------------
 // Start multicast DNS
 //----------------------------------------
 bool networkMulticastDNSStart(NetIndex_t index)
 {
-    NetMask_t bitMask;
-    bool started;
+    bool mdnsStarted;
 
-    // Start mDNS if it is enabled and not running on this network
-    started = false;
-    bitMask = 1 << index;
-    if (settings.mdnsEnable && (!(networkMdnsRunning & bitMask)) && (mDNSUse & bitMask))
+    // Verify that this interface uses mDNS
+    mdnsStarted = false;
+    if (networkInterfaceTable[index].mDNS)
     {
-        if (MDNS.begin(&settings.mdnsHostName[0]) ==
-            false) // This should make the device findable from 'rtk.local' in a browser
-            systemPrintln("Error setting up MDNS responder!");
-        else
-        {
-            MDNS.addService("http", "tcp", settings.httpPort); // Add service to MDNS
-            networkMdnsRunning |= bitMask;
-            started = true;
+        // Request mDNS for this interface
+        NetMask_t bitMask = 1 << index;
+        networkMdnsRequests |= bitMask;
 
-            if (settings.debugNetworkLayer)
-                systemPrintf("mDNS started as %s.local\r\n", settings.mdnsHostName);
-        }
+        // Start mDNS on this interface
+        mdnsStarted = networkMulticastDNSUpdate();
     }
-    return started;
+    return mdnsStarted;
 }
 
 //----------------------------------------
 // Stop multicast DNS
 //----------------------------------------
-void networkMulticastDNSStop(NetIndex_t index)
+bool networkMulticastDNSStop(NetIndex_t index)
 {
-    // Stop mDNS if it is running on this network
-    NetMask_t bitMask = 1 << index;
-    if (settings.mdnsEnable && (networkMdnsRunning & bitMask))
+    bool mdnsStopped;
+
+    // Verify that this interface uses mDNS
+    mdnsStopped = false;
+    if (networkInterfaceTable[index].mDNS)
     {
-        MDNS.end();
-        networkMdnsRunning &= ~bitMask;
-        if (settings.debugNetworkLayer)
-            systemPrintln("mDNS stopped");
+        // Request mDNS stop on this interface
+        NetMask_t bitMask = 1 << index;
+        networkMdnsRequests &= ~bitMask;
+
+        // Stop mDNS on this interface
+        mdnsStopped = networkMulticastDNSUpdate();
     }
+    return mdnsStopped;
 }
 
 //----------------------------------------
 // Stop multicast DNS
 //----------------------------------------
-void networkMulticastDNSStop()
+bool networkMulticastDNSStop()
 {
     // Determine the highest priority network
     NetIndex_t startIndex = networkPriority;
     if (startIndex < NETWORK_OFFLINE)
+        // Convert the priority into an index
         startIndex = networkIndexTable[startIndex];
 
     // Stop mDNS on the other networks
     for (int index = 0; index < NETWORK_OFFLINE; index++)
         if (index != startIndex)
-            networkMulticastDNSStop(index);
+            networkMdnsRequests &= ~(1 << index);
 
     // Restart mDNS on the highest priority network
     if (startIndex < NETWORK_OFFLINE)
-        networkMulticastDNSStart(startIndex);
+        networkMdnsRequests |= ~(1 << startIndex);
+    return networkMulticastDNSUpdate();
+}
+
+//----------------------------------------
+// Start multicast DNS
+//----------------------------------------
+bool networkMulticastDNSUpdate()
+{
+    NetMask_t deltaMask;
+    NetMask_t requests;
+    bool status;
+
+    // Determine if mDNS needs to restart
+    status = true;
+    requests = networkMdnsRequests;
+
+    // Update the mDNS state
+    if (settings.mdnsEnable == false)
+        requests = 0;
+
+    // Determine if mDNS needs to restart
+    deltaMask = requests ^ networkMdnsRunning;
+    if (deltaMask)
+    {
+        // Stop mDNS if it is running
+        if (networkMdnsRunning)
+        {
+            MDNS.end();
+            if (settings.debugNetworkLayer)
+                systemPrintln("mDNS stopped");
+        }
+
+        // Restart mDNS if it is needed by any interface
+        if (deltaMask & requests)
+        {
+            // This should make the device findable from 'rtk.local' in a browser
+            if (MDNS.begin(&settings.mdnsHostName[0]) == false)
+            {
+                systemPrintln("Error setting up MDNS responder!");
+                requests = 0;
+                status = false;
+            }
+            else
+            {
+                if (settings.debugNetworkLayer)
+                    systemPrintf("mDNS started as %s.local\r\n", settings.mdnsHostName);
+                MDNS.addService("http", "tcp", settings.httpPort); // Add service to MDNS
+            }
+        }
+        networkMdnsRunning = requests;
+    }
+    return status;
 }
 
 //----------------------------------------
@@ -1438,6 +1476,11 @@ void networkUpdate()
                 pollRoutine(index, sequence->parameter, settings.debugNetworkLayer);
         }
     }
+
+    // Update the network services
+    // Start or stop mDNS
+    if (networkMdnsRequests != networkMdnsRunning)
+        networkMulticastDNSUpdate();
 
     // Update the network services
     DMW_c("mqttClientUpdate");

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -524,7 +524,7 @@ IPAddress networkGetIpAddress()
     IPAddress ip;
 
     // NETIF doesn't capture the IP address of a soft AP
-    if (WIFI_SOFT_AP_RUNNING() == true && WIFI_STATION_RUNNING() == false)
+    if (WIFI_SOFT_AP_RUNNING() == true && wifiStationRunning == false)
         return WiFi.softAPIP();
 
     // Get the networkInterfaceTable index

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -603,6 +603,9 @@ void networkInterfaceEventInternetAvailable(NetIndex_t index)
     // Validate the index
     networkValidateIndex(index);
 
+    // Notify networkUpdate of the change in state
+    if (settings.debugNetworkLayer)
+        systemPrintf("%s internet available event\r\n", networkInterfaceTable[index].name);
     networkEventInternetAvailable[index] = true;
 }
 
@@ -615,6 +618,8 @@ void networkInterfaceEventInternetLost(NetIndex_t index)
     networkValidateIndex(index);
 
     // Notify networkUpdate of the change in state
+    if (settings.debugNetworkLayer)
+        systemPrintf("%s lost internet access event\r\n", networkInterfaceTable[index].name);
     networkEventInternetLost[index] = true;
 }
 
@@ -626,6 +631,9 @@ void networkInterfaceEventStop(NetIndex_t index)
     // Validate the index
     networkValidateIndex(index);
 
+    // Notify networkUpdate of the change in state
+    if (settings.debugNetworkLayer)
+        systemPrintf("%s stop event\r\n", networkInterfaceTable[index].name);
     networkEventStop[index] = true;
 }
 
@@ -658,12 +666,18 @@ void networkInterfaceInternetConnectionLost(NetIndex_t index)
 
     // Check for network offline
     if (networkInterfaceHasInternet(index) == false)
+    {
+        if (settings.debugNetworkLayer)
+            systemPrintf("%s previously lost internet access\r\n", networkInterfaceTable[index].name);
         // Already offline, nothing to do
         return;
+    }
 
     // Mark this network as offline
     bitMask = 1 << index;
     networkHasInternet_bm &= ~bitMask;
+    if (settings.debugNetworkLayer)
+        systemPrintf("%s does NOT have internet access\r\n", networkInterfaceTable[index].name);
 
     // Disable mDNS if necessary
     networkMulticastDNSStop(index);
@@ -731,12 +745,18 @@ void networkInterfaceInternetConnectionAvailable(NetIndex_t index)
     // Check for network online
     previousIndex = index;
     if (networkInterfaceHasInternet(index))
+    {
         // Already online, nothing to do
+        if (settings.debugNetworkLayer)
+            systemPrintf("%s already has internet access\r\n", networkInterfaceTable[index].name);
         return;
+    }
 
     // Mark this network as online
     bitMask = 1 << index;
     networkHasInternet_bm |= bitMask;
+    if (settings.debugNetworkLayer)
+        systemPrintf("%s has internet access\r\n", networkInterfaceTable[index].name);
 
     // Raise the network priority if necessary
     previousPriority = networkPriority;

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -600,6 +600,9 @@ bool networkHasInternet()
 //----------------------------------------
 void networkInterfaceEventInternetAvailable(NetIndex_t index)
 {
+    // Validate the index
+    networkValidateIndex(index);
+
     networkEventInternetAvailable[index] = true;
 }
 
@@ -608,6 +611,9 @@ void networkInterfaceEventInternetAvailable(NetIndex_t index)
 //----------------------------------------
 void networkInterfaceEventInternetLost(NetIndex_t index)
 {
+    // Validate the index
+    networkValidateIndex(index);
+
     // Notify networkUpdate of the change in state
     networkEventInternetLost[index] = true;
 }
@@ -617,6 +623,9 @@ void networkInterfaceEventInternetLost(NetIndex_t index)
 //----------------------------------------
 void networkInterfaceEventStop(NetIndex_t index)
 {
+    // Validate the index
+    networkValidateIndex(index);
+
     networkEventStop[index] = true;
 }
 

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -524,7 +524,7 @@ IPAddress networkGetIpAddress()
     IPAddress ip;
 
     // NETIF doesn't capture the IP address of a soft AP
-    if (WIFI_SOFT_AP_RUNNING() == true && wifiStationRunning == false)
+    if (wifiSoftApRunning == true && wifiStationRunning == false)
         return WiFi.softAPIP();
 
     // Get the networkInterfaceTable index
@@ -1612,7 +1612,7 @@ void networkUpdate()
         if ((networkHasInternet() == false) && (consumerTypes & (1 << NETIF_CELLULAR)))
         {
             // If we're in AP only mode (no internet), don't start cellular
-            if (WIFI_SOFT_AP_RUNNING() == false)
+            if (wifiSoftApRunning == false)
             {
                 // Don't start cellular until WiFi has failed to connect
                 if (wifiUnavailable() == true)

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1447,7 +1447,6 @@ void networkUpdate()
                 systemPrintln("WiFi settings changed, restarting WiFi");
 
             wifiResetThrottleTimeout();
-            WIFI_STOP();
             networkStop(NETWORK_WIFI, settings.debugNetworkLayer);
         }
     }

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -653,6 +653,9 @@ void networkInterfaceInternetConnectionLost(NetIndex_t index)
     // Validate the index
     networkValidateIndex(index);
 
+    // Clear the event flag
+    networkEventInternetLost[index] = false;
+
     // Check for network offline
     if (networkInterfaceHasInternet(index) == false)
         // Already offline, nothing to do
@@ -721,6 +724,9 @@ void networkInterfaceInternetConnectionAvailable(NetIndex_t index)
 
     // Validate the index
     networkValidateIndex(index);
+
+    // Clear the event flag
+    networkEventInternetAvailable[index] = false;
 
     // Check for network online
     previousIndex = index;
@@ -1281,6 +1287,9 @@ void networkStop(NetIndex_t index, bool debug)
     // Validate the index
     networkValidateIndex(index);
 
+    // Clear the event flag
+    networkEventStop[index] = false;
+
     // Only stop networks that exist on the platform
     if (networkIsPresent(index))
     {
@@ -1385,17 +1394,11 @@ void networkUpdate()
 
         // Handle the network lost internet event
         if (networkEventInternetLost[index])
-        {
-            networkEventInternetLost[index] = false;
             networkInterfaceInternetConnectionLost(index);
-        }
 
         // Handle the network stop event
         if (networkEventStop[index])
-        {
-            networkEventStop[index] = false;
             networkStop(index, settings.debugNetworkLayer);
-        }
 
         // Check for the WiFi station reconnection
         if ((index == NETWORK_WIFI) && wifiReconnectionTimer)
@@ -1403,10 +1406,7 @@ void networkUpdate()
 
         // Handle the network has internet event
         if (networkEventInternetAvailable[index])
-        {
-            networkEventInternetAvailable[index] = false;
             networkInterfaceInternetConnectionAvailable(index);
-        }
 
         // Execute any active polling routine
         sequence = networkSequence[index];

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -361,7 +361,6 @@ RTK_WIFI wifi(false);
 #define WIFI_ESPNOW_SET_CHANNEL(chan)   wifi.espNowSetChannel(chan)
 #define WIFI_GET_CHANNEL()              wifi.getChannel()
 #define WIFI_IS_CONNECTED()             wifi.stationOnline()
-#define WIFI_IS_RUNNING()               wifi.running()
 
 #define WIFI_STOP()                                                                                                    \
     {                                                                                                                  \

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -382,6 +382,7 @@ RTK_WIFI wifi(false);
 #endif // COMPILE_WIFI
 
 // WiFi Globals - For other module direct access
+uint32_t wifiReconnectionTimer; // Delay before reconnection, timer running when non-zero
 bool wifiRestartRequested;      // Restart WiFi if user changes anything
 
 #define MQTT_CLIENT_STOP(shutdown)                                                                                     \

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -381,7 +381,8 @@ RTK_WIFI wifi(false);
     }
 #endif // COMPILE_WIFI
 
-bool wifiRestartRequested = false; // Restart WiFi if user changes anything
+// WiFi Globals - For other module direct access
+bool wifiRestartRequested;      // Restart WiFi if user changes anything
 
 #define MQTT_CLIENT_STOP(shutdown)                                                                                     \
     {                                                                                                                  \

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -364,7 +364,6 @@ RTK_WIFI wifi(false);
 #define WIFI_IS_CONNECTED()             wifi.stationOnline()
 #define WIFI_IS_RUNNING()               wifi.running()
 #define WIFI_SOFT_AP_RUNNING()          wifi.softApRunning()
-#define WIFI_STATION_RUNNING()          wifi.stationRunning()
 
 #define WIFI_STOP()                                                                                                    \
     {                                                                                                                  \
@@ -377,6 +376,7 @@ RTK_WIFI wifi(false);
 // WiFi Globals - For other module direct access
 uint32_t wifiReconnectionTimer; // Delay before reconnection, timer running when non-zero
 bool wifiRestartRequested;      // Restart WiFi if user changes anything
+bool wifiStationRunning;        // False: stopped, True: starting, running, stopping
 
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
@@ -685,10 +685,10 @@ float lBandEBNO; // Used on system status menu
     {                                                                                       \
         if (settings.debugEspNow)                                                           \
             systemPrintf("ESPNOW_START called in %s at line %d\r\n", __FILE__, __LINE__);   \
-        wifi.enable(true, wifi.softApRunning(), wifi.stationRunning());                     \
+        wifi.enable(true, wifi.softApRunning(), wifiStationRunning);                     \
     }
 
-#define ESPNOW_STOP()       wifi.enable(false, wifi.softApRunning(), wifi.stationRunning())
+#define ESPNOW_STOP()       wifi.enable(false, wifi.softApRunning(), wifiStationRunning)
 
 #endif // COMPILE_ESPNOW
 

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -359,7 +359,6 @@ int packetRSSI;
 RTK_WIFI wifi(false);
 
 #define WIFI_ESPNOW_SET_CHANNEL(chan)   wifi.espNowSetChannel(chan)
-#define WIFI_GET_CHANNEL()              wifi.getChannel()
 #define WIFI_IS_CONNECTED()             wifi.stationOnline()
 
 #define WIFI_STOP()                                                                                                    \
@@ -371,6 +370,7 @@ RTK_WIFI wifi(false);
 #endif // COMPILE_WIFI
 
 // WiFi Globals - For other module direct access
+WIFI_CHANNEL_t wifiChannel;     // Current WiFi channel number
 bool wifiEspNowRunning;         // False: stopped, True: starting, running, stopping
 uint32_t wifiReconnectionTimer; // Delay before reconnection, timer running when non-zero
 bool wifiRestartRequested;      // Restart WiFi if user changes anything

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -363,7 +363,6 @@ RTK_WIFI wifi(false);
 #define WIFI_GET_CHANNEL()              wifi.getChannel()
 #define WIFI_IS_CONNECTED()             wifi.stationOnline()
 #define WIFI_IS_RUNNING()               wifi.running()
-#define WIFI_SOFT_AP_RUNNING()          wifi.softApRunning()
 
 #define WIFI_STOP()                                                                                                    \
     {                                                                                                                  \
@@ -376,6 +375,7 @@ RTK_WIFI wifi(false);
 // WiFi Globals - For other module direct access
 uint32_t wifiReconnectionTimer; // Delay before reconnection, timer running when non-zero
 bool wifiRestartRequested;      // Restart WiFi if user changes anything
+bool wifiSoftApRunning;         // False: stopped, True: starting, running, stopping
 bool wifiStationRunning;        // False: stopped, True: starting, running, stopping
 
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -685,10 +685,10 @@ float lBandEBNO; // Used on system status menu
     {                                                                                       \
         if (settings.debugEspNow)                                                           \
             systemPrintf("ESPNOW_START called in %s at line %d\r\n", __FILE__, __LINE__);   \
-        wifi.enable(true, wifi.softApRunning(), wifiStationRunning);                     \
+        wifi.enable(true, wifiSoftApRunning, wifiStationRunning);                     \
     }
 
-#define ESPNOW_STOP()       wifi.enable(false, wifi.softApRunning(), wifiStationRunning)
+#define ESPNOW_STOP()       wifi.enable(false, wifiSoftApRunning, wifiStationRunning)
 
 #endif // COMPILE_ESPNOW
 

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -673,13 +673,12 @@ const int updateWebSocketStackSize =
 float lBandEBNO; // Used on system status menu
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
-// ESP NOW for multipoint wireless broadcasting over 2.4GHz
+// ESP-NOW for multipoint wireless broadcasting over 2.4GHz
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 #ifdef COMPILE_ESPNOW
 
 #include <esp_now.h> //Built-in
 
-#define ESPNOW_IS_PAIRED()  espNowIsPaired()
 #define ESPNOW_START()                                                                      \
     {                                                                                       \
         if (settings.debugEspNow)                                                           \
@@ -691,6 +690,7 @@ float lBandEBNO; // Used on system status menu
 
 #endif // COMPILE_ESPNOW
 
+// ESP-NOW Globals - For other module direct access
 bool espNowIncomingRTCM;
 bool espNowOutgoingRTCM;
 int espNowRSSI;

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -352,15 +352,8 @@ bool sdSizeCheckTaskComplete;
 char logFileName[sizeof("SFE_Reference_Station_230101_120101.ubx_plusExtraSpace")] = {0};
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-// Over-the-Air (OTA) update support
+// WiFi support
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-
-#define MQTT_CERT_SIZE 2000
-
-#include <ArduinoJson.h> //http://librarymanager/All#Arduino_JSON_messagepack
-
-#include "esp_ota_ops.h" //Needed for partition counting and updateFromSD
-
 #ifdef COMPILE_WIFI
 int packetRSSI;
 RTK_WIFI wifi(false);
@@ -385,12 +378,25 @@ RTK_WIFI wifi(false);
 uint32_t wifiReconnectionTimer; // Delay before reconnection, timer running when non-zero
 bool wifiRestartRequested;      // Restart WiFi if user changes anything
 
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+// MQTT support
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#define MQTT_CERT_SIZE 2000
+
 #define MQTT_CLIENT_STOP(shutdown)                                                                                     \
     {                                                                                                                  \
         if (settings.debugNetworkLayer || settings.debugMqttClientState)                                               \
             systemPrintf("mqttClientStop(%s) called by %s %d\r\n", shutdown ? "true" : "false", __FILE__, __LINE__);   \
         mqttClientStop(shutdown);                                                                                      \
     }
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+// Over-the-Air (OTA) update support
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#include <ArduinoJson.h> //http://librarymanager/All#Arduino_JSON_messagepack
+
+#include "esp_ota_ops.h" //Needed for partition counting and updateFromSD
 
 #define OTA_FIRMWARE_JSON_URL_LENGTH 128
 //                                                                                                      1         1 1

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -358,7 +358,6 @@ char logFileName[sizeof("SFE_Reference_Station_230101_120101.ubx_plusExtraSpace"
 int packetRSSI;
 RTK_WIFI wifi(false);
 
-#define WIFI_ESPNOW_RUNNING()           wifi.espNowRunning()
 #define WIFI_ESPNOW_SET_CHANNEL(chan)   wifi.espNowSetChannel(chan)
 #define WIFI_GET_CHANNEL()              wifi.getChannel()
 #define WIFI_IS_CONNECTED()             wifi.stationOnline()
@@ -373,6 +372,7 @@ RTK_WIFI wifi(false);
 #endif // COMPILE_WIFI
 
 // WiFi Globals - For other module direct access
+bool wifiEspNowRunning;         // False: stopped, True: starting, running, stopping
 uint32_t wifiReconnectionTimer; // Delay before reconnection, timer running when non-zero
 bool wifiRestartRequested;      // Restart WiFi if user changes anything
 bool wifiSoftApRunning;         // False: stopped, True: starting, running, stopping

--- a/Firmware/RTK_Everywhere/TcpServer.ino
+++ b/Firmware/RTK_Everywhere/TcpServer.ino
@@ -411,7 +411,7 @@ void tcpServerUpdate()
     // Handle client connections and link failures
     case TCP_SERVER_STATE_RUNNING:
         // Determine if the network has failed
-        if ((networkIsConnected(&tcpServerPriority) == false && WIFI_SOFT_AP_RUNNING() == false) || (!settings.enableTcpServer && !settings.baseCasterOverride))
+        if ((networkIsConnected(&tcpServerPriority) == false && wifiSoftApRunning == false) || (!settings.enableTcpServer && !settings.baseCasterOverride))
         {
             if ((settings.debugTcpServer || PERIODIC_DISPLAY(PD_TCP_SERVER_DATA)) && (!inMainMenu))
             {

--- a/Firmware/RTK_Everywhere/UdpServer.ino
+++ b/Firmware/RTK_Everywhere/UdpServer.ino
@@ -337,7 +337,7 @@ void udpServerUpdate()
             udpServerStop();
 
         // Wait until the network is connected
-        else if (networkIsConnected(&udpServerPriority) || WIFI_SOFT_AP_RUNNING())
+        else if (networkIsConnected(&udpServerPriority) || wifiSoftApRunning)
         {
             // Delay before starting the UDP server
             if ((millis() - udpServerTimer) >= (1 * 1000))
@@ -355,7 +355,7 @@ void udpServerUpdate()
     // Handle client connections and link failures
     case UDP_SERVER_STATE_RUNNING:
         // Determine if the network has failed
-        if ((networkIsConnected(&udpServerPriority) == false && WIFI_SOFT_AP_RUNNING() == false) || (!settings.enableUdpServer && !settings.baseCasterOverride))
+        if ((networkIsConnected(&udpServerPriority) == false && wifiSoftApRunning == false) || (!settings.enableUdpServer && !settings.baseCasterOverride))
         {
             if ((settings.debugUdpServer || PERIODIC_DISPLAY(PD_UDP_SERVER_DATA)) && (!inMainMenu))
             {

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -774,7 +774,7 @@ void webServerUpdate()
     // Wait for connection to the network
     case WEBSERVER_STATE_WAIT_FOR_NETWORK:
         // Wait until the network is connected to the internet or has WiFi AP
-        if (networkIsConnected(&webServerPriority) || WIFI_SOFT_AP_RUNNING())
+        if (networkIsConnected(&webServerPriority) || wifiSoftApRunning)
         {
             if (settings.debugWebServer)
                 systemPrintln("Web Server connected to network");
@@ -786,7 +786,7 @@ void webServerUpdate()
     // Start the web server
     case WEBSERVER_STATE_NETWORK_CONNECTED: {
         // Determine if the network has failed
-        if (networkIsConnected(&webServerPriority) == false && WIFI_SOFT_AP_RUNNING() == false)
+        if (networkIsConnected(&webServerPriority) == false && wifiSoftApRunning == false)
             webServerStop();
         if (settings.debugWebServer)
             systemPrintln("Assigning web server resources");
@@ -802,7 +802,7 @@ void webServerUpdate()
     // Allow web services
     case WEBSERVER_STATE_RUNNING:
         // Determine if the network has failed
-        if (networkIsConnected(&webServerPriority) == false && WIFI_SOFT_AP_RUNNING() == false)
+        if (networkIsConnected(&webServerPriority) == false && wifiSoftApRunning == false)
             webServerStop();
 
         // This state is exited when webServerStop() is called

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -678,6 +678,30 @@ void wifiStartThrottled(NetIndex_t index, uintptr_t parameter, bool debug)
 }
 
 //*********************************************************************
+// Handle WiFi station reconnection requests
+void wifiStationReconnectionRequest()
+{
+    uint32_t currentMsec;
+
+    // Has the reconnection delay expired
+    currentMsec = millis();
+    if ((currentMsec - wifiReconnectionTimer) >= WIFI_RECONNECTION_DELAY)
+    {
+        // Stop the reconnection timer
+        wifiReconnectionTimer = 0;
+        if (settings.debugWifiState)
+            systemPrintf("Reconnection timer fired!\r\n");
+
+        // Start the WiFi scan
+        if (wifi.stationRunning())
+        {
+            wifi.clearStarted(WIFI_STA_RECONNECT);
+            wifi.stopStart(WIFI_AP_START_MDNS, WIFI_STA_RECONNECT);
+        }
+    }
+}
+
+//*********************************************************************
 // Stop WiFi, used by wifiStopSequence
 void wifiStop(NetIndex_t index, uintptr_t parameter, bool debug)
 {
@@ -1692,32 +1716,6 @@ bool RTK_WIFI::stationHostName(const char * hostName)
 bool RTK_WIFI::stationOnline()
 {
     return (_started & WIFI_STA_ONLINE) ? true : false;
-}
-
-//*********************************************************************
-// Handle WiFi station reconnection requests
-void RTK_WIFI::stationReconnectionRequest()
-{
-    uint32_t currentMsec;
-
-    // Check for reconnection request
-    currentMsec = millis();
-    if (wifiReconnectionTimer)
-    {
-        if ((currentMsec - wifiReconnectionTimer) >= WIFI_RECONNECTION_DELAY)
-        {
-            wifiReconnectionTimer = 0;
-            if (settings.debugWifiState)
-                systemPrintf("Reconnection timer fired!\r\n");
-
-            // Start the WiFi scan
-            if (stationRunning())
-            {
-                _started = _started & ~WIFI_STA_RECONNECT;
-                stopStart(WIFI_AP_START_MDNS, WIFI_STA_RECONNECT);
-            }
-        }
-    }
 }
 
 //*********************************************************************

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -2309,6 +2309,8 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         // Start the radio operations
         //****************************************
 
+        enabled = false;
+
         // Start the soft AP mode
         if (starting & WIFI_AP_SET_MODE)
         {

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -744,6 +744,18 @@ RTK_WIFI::RTK_WIFI(bool verbose)
 }
 
 //*********************************************************************
+// Clear some of the started components
+// Inputs:
+//   components: Bitmask of components to clear
+// Outputs:
+//   Returns the bitmask of started components
+WIFI_ACTION_t RTK_WIFI::clearStarted(WIFI_ACTION_t components)
+{
+    _started = _started & ~components;
+    return _started;
+}
+
+//*********************************************************************
 // Attempts a connection to all provided SSIDs
 bool RTK_WIFI::connect(unsigned long timeout,
                        bool startAP)

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -1502,14 +1502,6 @@ void RTK_WIFI::stationEventHandler(arduino_event_id_t event, arduino_event_info_
     bool success;
     int type;
 
-    // Take the network offline if necessary
-    if (networkInterfaceHasInternet(NETWORK_WIFI) && (event != ARDUINO_EVENT_WIFI_STA_GOT_IP) &&
-        (event != ARDUINO_EVENT_WIFI_STA_GOT_IP6))
-    {
-        // Stop WiFi to allow it to restart
-        networkInterfaceEventStop(NETWORK_WIFI);
-    }
-
     //------------------------------
     // WiFi Status Values:
     //     WL_CONNECTED: assigned when connected to a WiFi network

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -757,7 +757,7 @@ RTK_WIFI::RTK_WIFI(bool verbose)
       _apGatewayAddress{(uint32_t)0},
       _apIpAddress{IPAddress("192.168.4.1")},
       _apMacAddress{0, 0, 0, 0, 0, 0},
-      _apSubnetMask{IPAddress("255.255.255.0")}, _channel{0},
+      _apSubnetMask{IPAddress("255.255.255.0")},
       _espNowChannel{0},
       _scanRunning{false},
       _staIpAddress{IPAddress((uint32_t)0)}, _staIpType{0},
@@ -766,6 +766,7 @@ RTK_WIFI::RTK_WIFI(bool verbose)
       _started{false}, _stationChannel{0},
       _usingDefaultChannel{true}, _verbose{verbose}
 {
+    wifiChannel = 0;
     wifiEspNowRunning = false;
     wifiReconnectionTimer = 0;
     wifiRestartRequested = false;
@@ -1017,7 +1018,7 @@ void RTK_WIFI::eventHandler(arduino_event_id_t event, arduino_event_info_t info)
 //   Returns the current WiFi channel number
 WIFI_CHANNEL_t RTK_WIFI::getChannel()
 {
-    return _channel;
+    return wifiChannel;
 }
 
 //*********************************************************************
@@ -1463,9 +1464,9 @@ bool RTK_WIFI::stationConnectAP()
         if (settings.debugWifiState)
             systemPrintf("WiFi connecting to %s on channel %d with %s authorization\r\n",
                          _staRemoteApSsid,
-                         _channel,
+                         wifiChannel,
                          (_staAuthType < WIFI_AUTH_MAX) ? wifiAuthorizationName[_staAuthType] : "Unknown");
-        connected = (WiFi.STA.connect(_staRemoteApSsid, _staRemoteApPassword, _channel));
+        connected = (WiFi.STA.connect(_staRemoteApSsid, _staRemoteApPassword, wifiChannel));
         if (!connected)
         {
             if (settings.debugWifiState)
@@ -1476,7 +1477,7 @@ bool RTK_WIFI::stationConnectAP()
         if (settings.debugWifiState)
             systemPrintf("WiFi station connected to %s on channel %d with %s authorization\r\n",
                          _staRemoteApSsid,
-                         _channel,
+                         wifiChannel,
                          (_staAuthType < WIFI_AUTH_MAX) ? wifiAuthorizationName[_staAuthType] : "Unknown");
 
         // Don't delay the next WiFi start request
@@ -1872,10 +1873,10 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
     defaultChannel = _usingDefaultChannel;
     _usingDefaultChannel = false;
     if (((_started & ~stopping) & (WIFI_AP_ONLINE | WIFI_EN_ESP_NOW_ONLINE | WIFI_STA_ONLINE))
-        && _channel && !defaultChannel)
+        && wifiChannel && !defaultChannel)
     {
         // Continue to use the active channel
-        channel = _channel;
+        channel = wifiChannel;
         if (settings.debugWifiState && _verbose)
             systemPrintf("channel: %d, active channel\r\n", channel);
     }
@@ -2192,7 +2193,7 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         // Reset the channel if all components are stopped
         if ((softApOnline() == false) && (stationOnline() == false))
         {
-            _channel = 0;
+            wifiChannel = 0;
             _usingDefaultChannel = true;
         }
 
@@ -2273,8 +2274,8 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
             _started = _started | WIFI_STA_SELECT_REMOTE_AP;
             if (channel == 0)
             {
-                if (_channel)
-                    systemPrintf("WiFi STA: No compatible remote AP found on channel %d!\r\n", _channel);
+                if (wifiChannel)
+                    systemPrintf("WiFi STA: No compatible remote AP found on channel %d!\r\n", wifiChannel);
                 else
                     systemPrintf("WiFi STA: No compatible remote AP found!\r\n");
 
@@ -2298,11 +2299,11 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
             // Use the default channel if necessary
             if (!channel)
                 channel = WIFI_DEFAULT_CHANNEL;
-            _channel = channel;
+            wifiChannel = channel;
 
             // Display the selected channel
             if (settings.debugWifiState)
-                systemPrintf("Channel: %d selected\r\n", _channel);
+                systemPrintf("Channel: %d selected\r\n", wifiChannel);
         }
 
         //****************************************
@@ -2472,7 +2473,7 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
             }
 
             // Set the ESP-NOW channel
-            if (primaryChannel != _channel)
+            if (primaryChannel != wifiChannel)
             {
                 if (settings.debugWifiState && _verbose)
                     systemPrintf("Calling esp_wifi_set_channel\r\n");
@@ -2547,7 +2548,7 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
             systemPrintf("WiFi: ESP-NOW online (%02x:%02x:%02x:%02x:%02x:%02x, channel: %d)\r\n",
                          _staMacAddress[0], _staMacAddress[1], _staMacAddress[2],
                          _staMacAddress[3], _staMacAddress[4], _staMacAddress[5],
-                         _channel);
+                         wifiChannel);
         }
 
         // All components started successfully

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -739,6 +739,7 @@ RTK_WIFI::RTK_WIFI(bool verbose)
       _started{false}, _stationChannel{0},
       _timer{0}, _usingDefaultChannel{true}, _verbose{verbose}
 {
+    wifiRestartRequested = false;
 }
 
 //*********************************************************************

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -1051,13 +1051,6 @@ bool RTK_WIFI::restart(bool always)
 }
 
 //*********************************************************************
-// Determine if any use of WiFi is starting or is online
-bool RTK_WIFI::running()
-{
-    return wifiEspNowRunning | wifiSoftApRunning | wifiStationRunning;
-}
-
-//*********************************************************************
 // Set the WiFi mode
 // Inputs:
 //   setMode: Modes to set

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -681,7 +681,11 @@ void wifiStartThrottled(NetIndex_t index, uintptr_t parameter, bool debug)
 // Stop WiFi, used by wifiStopSequence
 void wifiStop(NetIndex_t index, uintptr_t parameter, bool debug)
 {
-    WIFI_STOP();
+    networkInterfaceInternetConnectionLost(NETWORK_WIFI);
+
+    // Stop WiFi stataion
+    wifi.enable(wifi.espNowRunning(), wifi.softApRunning(), false);
+
     networkSequenceNextEntry(NETWORK_WIFI, settings.debugNetworkLayer);
 }
 

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -560,7 +560,7 @@ void menuRadio()
             systemPrintln("2) Pair radios");
             systemPrintln("3) Forget all radios");
 
-            systemPrintf("4) Current channel: %d\r\n", WIFI_GET_CHANNEL());
+            systemPrintf("4) Current channel: %d\r\n", wifiChannel);
 
             if (settings.debugEspNow == true)
             {
@@ -636,7 +636,7 @@ void menuRadio()
                 WIFI_ESPNOW_SET_CHANNEL(settings.wifiChannel);
                 if (settings.wifiChannel)
                 {
-                    if (settings.wifiChannel == WIFI_GET_CHANNEL())
+                    if (settings.wifiChannel == wifiChannel)
                         systemPrintf("WiFi is already on channel %d.", settings.wifiChannel);
                     else
                     {

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -640,7 +640,7 @@ void menuRadio()
                         systemPrintf("WiFi is already on channel %d.", settings.wifiChannel);
                     else
                     {
-                        if (WIFI_SOFT_AP_RUNNING() || WIFI_STATION_RUNNING())
+                        if (WIFI_SOFT_AP_RUNNING() || wifiStationRunning)
                             systemPrintf("Restart WiFi to use channel %d.", settings.wifiChannel);
                         else if (WIFI_ESPNOW_RUNNING())
                             systemPrintf("Restart ESP-NOW to use channel %d.", settings.wifiChannel);

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -640,7 +640,7 @@ void menuRadio()
                         systemPrintf("WiFi is already on channel %d.", settings.wifiChannel);
                     else
                     {
-                        if (WIFI_SOFT_AP_RUNNING() || wifiStationRunning)
+                        if (wifiSoftApRunning || wifiStationRunning)
                             systemPrintf("Restart WiFi to use channel %d.", settings.wifiChannel);
                         else if (WIFI_ESPNOW_RUNNING())
                             systemPrintf("Restart ESP-NOW to use channel %d.", settings.wifiChannel);

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -619,7 +619,7 @@ void menuRadio()
             byte bContinue = getUserInputCharacterNumber();
             if (bContinue == 'y')
             {
-                if (WIFI_ESPNOW_RUNNING())
+                if (wifiEspNowRunning)
                 {
                     for (int x = 0; x < settings.espnowPeerCount; x++)
                         espNowRemovePeer(settings.espnowPeers[x]);
@@ -642,7 +642,7 @@ void menuRadio()
                     {
                         if (wifiSoftApRunning || wifiStationRunning)
                             systemPrintf("Restart WiFi to use channel %d.", settings.wifiChannel);
-                        else if (WIFI_ESPNOW_RUNNING())
+                        else if (wifiEspNowRunning)
                             systemPrintf("Restart ESP-NOW to use channel %d.", settings.wifiChannel);
                         else
                             systemPrintf("Please start ESP-NOW to use channel %d.", settings.wifiChannel);
@@ -652,7 +652,7 @@ void menuRadio()
         }
         else if (settings.enableEspNow == true && incoming == 5 && settings.debugEspNow == true)
         {
-            if (WIFI_ESPNOW_RUNNING() == false)
+            if (wifiEspNowRunning == false)
                 ESPNOW_START()
 
             uint8_t peer1[] = {0xB8, 0xD6, 0x1A, 0x0D, 0x8F, 0x9C}; // Random MAC
@@ -676,7 +676,7 @@ void menuRadio()
         }
         else if (settings.enableEspNow == true && incoming == 6 && settings.debugEspNow == true)
         {
-            if (WIFI_ESPNOW_RUNNING() == false)
+            if (wifiEspNowRunning == false)
                 ESPNOW_START()
 
             uint8_t espnowData[] =
@@ -689,7 +689,7 @@ void menuRadio()
         }
         else if (settings.enableEspNow == true && incoming == 7 && settings.debugEspNow == true)
         {
-            if (WIFI_ESPNOW_RUNNING() == false)
+            if (wifiEspNowRunning == false)
                 ESPNOW_START()
 
             uint8_t espnowData[] =

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2086,14 +2086,6 @@ class RTK_WIFI
     //   Returns the channel number of the AP
     WIFI_CHANNEL_t stationSelectAP(uint8_t apCount, bool list);
 
-    // Stop and start WiFi components
-    // Inputs:
-    //   stopping: WiFi components that need to be stopped
-    //   starting: WiFi components that neet to be started
-    // Outputs:
-    //   Returns true if the modes were successfully configured
-    bool stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting);
-
     // Handle the WiFi event
     // Inputs:
     //   event: Arduino ESP32 event number found on
@@ -2229,6 +2221,14 @@ class RTK_WIFI
     // Outputs:
     //  Returns true if the WiFi station is being started or is online
     bool stationRunning();
+
+    // Stop and start WiFi components
+    // Inputs:
+    //   stopping: WiFi components that need to be stopped
+    //   starting: WiFi components that neet to be started
+    // Outputs:
+    //   Returns true if the modes were successfully configured
+    bool stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting);
 
     // Test the WiFi modes
     // Inputs:

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1946,7 +1946,6 @@ class RTK_WIFI
     IPAddress _apSubnetMask;    // Subnet mask for soft AP
     WIFI_CHANNEL_t _channel;    // Current WiFi channel number
     WIFI_CHANNEL_t _espNowChannel;  // Channel required for ESPNow, zero (0) use _channel
-    bool _espNowRunning;        // ESPNow started or running
     volatile bool _scanRunning; // Scan running
     int _staAuthType;           // Authorization type for the remote AP
     bool _staConnected;         // True when station is connected
@@ -2131,11 +2130,6 @@ class RTK_WIFI
     // Outputs:
     //   Returns true when ESP-NOW is online and ready for use
     bool espNowOnline();
-
-    // Get the ESP-NOW status
-    // Outputs:
-    //  Returns true if ESP-NOW is being started or is online
-    bool espNowRunning();
 
     // Set the ESP-NOW channel
     // Inputs:

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1914,11 +1914,13 @@ rqXRfboQnoZsG4q5WTP468SQvvG5
 -----END CERTIFICATE-----
 )=====";
 
-#ifdef COMPILE_WIFI
-
 //****************************************
 // WiFi class
 //****************************************
+
+typedef uint8_t WIFI_CHANNEL_t;
+
+#ifdef COMPILE_WIFI
 
 // Handle the WiFi event
 // Inputs:
@@ -1929,14 +1931,13 @@ rqXRfboQnoZsG4q5WTP468SQvvG5
 void wifiEventHandler(arduino_event_id_t event, arduino_event_info_t info);
 
 typedef uint32_t WIFI_ACTION_t;
-typedef uint8_t WIFI_CHANNEL_t;
 
 // Class to simplify WiFi handling
 class RTK_WIFI
 {
   private:
 
-    WIFI_CHANNEL_t _apChannel;  // Channel required for soft AP, zero (0) use _channel
+    WIFI_CHANNEL_t _apChannel;  // Channel required for soft AP, zero (0) use wifiChannel
     int16_t _apCount;           // The number or remote APs detected in the WiFi network
     IPAddress _apDnsAddress;    // DNS IP address to use while translating names into IP addresses
     IPAddress _apFirstDhcpAddress;  // First IP address to use for DHCP
@@ -1944,8 +1945,7 @@ class RTK_WIFI
     IPAddress _apIpAddress;     // IP address of the soft AP
     uint8_t _apMacAddress[6];   // MAC address of the soft AP
     IPAddress _apSubnetMask;    // Subnet mask for soft AP
-    WIFI_CHANNEL_t _channel;    // Current WiFi channel number
-    WIFI_CHANNEL_t _espNowChannel;  // Channel required for ESPNow, zero (0) use _channel
+    WIFI_CHANNEL_t _espNowChannel;  // Channel required for ESPNow, zero (0) use wifiChannel
     volatile bool _scanRunning; // Scan running
     int _staAuthType;           // Authorization type for the remote AP
     bool _staConnected;         // True when station is connected
@@ -1956,7 +1956,7 @@ class RTK_WIFI
     const char * _staRemoteApSsid;      // SSID of remote AP
     const char * _staRemoteApPassword;  // Password of remote AP
     volatile WIFI_ACTION_t _started;    // Components that are started and running
-    WIFI_CHANNEL_t _stationChannel; // Channel required for station, zero (0) use _channel
+    WIFI_CHANNEL_t _stationChannel; // Channel required for station, zero (0) use wifiChannel
     uint32_t _timer;            // Reconnection timer
     bool _usingDefaultChannel;  // Using default WiFi channel
     bool _verbose;              // True causes more debug output to be displayed

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1948,7 +1948,6 @@ class RTK_WIFI
     WIFI_CHANNEL_t _espNowChannel;  // Channel required for ESPNow, zero (0) use _channel
     bool _espNowRunning;        // ESPNow started or running
     volatile bool _scanRunning; // Scan running
-    bool _softApRunning;        // Soft AP is starting or running
     int _staAuthType;           // Authorization type for the remote AP
     bool _staConnected;         // True when station is connected
     bool _staHasIp;             // True when station has IP address
@@ -2194,11 +2193,6 @@ class RTK_WIFI
     // Outputs:
     //   Returns true when the soft AP is ready for use
     bool softApOnline();
-
-    // Determine if the soft AP is being started or is onine
-    // Outputs:
-    //  Returns true if the soft AP is being started or is online
-    bool softApRunning();
 
     // Attempt to start the soft AP mode
     // Inputs:

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2214,9 +2214,6 @@ class RTK_WIFI
     //   Returns true when the WiFi station is online and ready for use
     bool stationOnline();
 
-    // Handle WiFi station reconnection requests
-    void stationReconnectionRequest();
-
     // Get the station status
     // Outputs:
     //  Returns true if the WiFi station is being started or is online

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2158,11 +2158,6 @@ class RTK_WIFI
     //    false upon restart failure
     bool restart(bool always);
 
-    // Determine if any use of WiFi is starting or is online
-    // Outputs:
-    //  Returns true if any WiFi use is being started or is online
-    bool running();
-
     // Configure the soft AP
     // Inputs:
     //   ipAddress: IP address of the soft AP

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1959,7 +1959,6 @@ class RTK_WIFI
     const char * _staRemoteApPassword;  // Password of remote AP
     volatile WIFI_ACTION_t _started;    // Components that are started and running
     WIFI_CHANNEL_t _stationChannel; // Channel required for station, zero (0) use _channel
-    bool _stationRunning;       // True while station is starting or running
     uint32_t _timer;            // Reconnection timer
     bool _usingDefaultChannel;  // Using default WiFi channel
     bool _verbose;              // True causes more debug output to be displayed
@@ -2214,11 +2213,6 @@ class RTK_WIFI
     // Outputs:
     //   Returns true when the WiFi station is online and ready for use
     bool stationOnline();
-
-    // Get the station status
-    // Outputs:
-    //  Returns true if the WiFi station is being started or is online
-    bool stationRunning();
 
     // Stop and start WiFi components
     // Inputs:

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2109,6 +2109,13 @@ class RTK_WIFI
     //   verbose: Set to true to display additional WiFi debug data
     RTK_WIFI(bool verbose = false);
 
+    // Clear some of the started components
+    // Inputs:
+    //   components: Bitmask of components to clear
+    // Outputs:
+    //   Returns the bitmask of started components
+    WIFI_ACTION_t clearStarted(WIFI_ACTION_t components);
+
     // Attempts a connection to all provided SSIDs
     // Inputs:
     //    timeout: Number of milliseconds to wait for the connection

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1810,18 +1810,6 @@ typedef const struct _NETWORK_POLL_SEQUENCE
     const char * description;     // Description of operation
 } NETWORK_POLL_SEQUENCE;
 
-// networkInterfaceTable entry
-typedef struct _NETWORK_TABLE_ENTRY
-{
-    NetworkInterface * netif;       // Network interface object address
-    const char * name;              // Name of the network interface
-    bool * present;                 // Address of present bool or nullptr if always available
-    uint8_t pdState;                // Periodic display state value
-    NETWORK_POLL_SEQUENCE * boot;   // Boot sequence, may be nullptr
-    NETWORK_POLL_SEQUENCE * start;  // Start sequence (Off --> On), may be nullptr
-    NETWORK_POLL_SEQUENCE * stop;   // Stop routine (On --> Off), may be nullptr
-} NETWORK_TABLE_ENTRY;
-
 // Sequence table declarations
 extern NETWORK_POLL_SEQUENCE wifiStartSequence[];
 extern NETWORK_POLL_SEQUENCE wifiStopSequence[];
@@ -1829,29 +1817,42 @@ extern NETWORK_POLL_SEQUENCE laraBootSequence[];
 extern NETWORK_POLL_SEQUENCE laraOffSequence[];
 extern NETWORK_POLL_SEQUENCE laraOnSequence[];
 
+// networkInterfaceTable entry
+typedef struct _NETWORK_TABLE_ENTRY
+{
+    NetworkInterface * netif;       // Network interface object address
+    bool mDNS;                      // Set true to use mDNS service
+    uint8_t pdState;                // Periodic display state value
+    NETWORK_POLL_SEQUENCE * boot;   // Boot sequence, may be nullptr
+    NETWORK_POLL_SEQUENCE * start;  // Start sequence (Off --> On), may be nullptr
+    NETWORK_POLL_SEQUENCE * stop;   // Stop routine (On --> Off), may be nullptr
+    const char * name;              // Name of the network interface
+    bool * present;                 // Address of present bool or nullptr if always available
+} NETWORK_TABLE_ENTRY;
+
 // List of networks
 // Only one network is turned on at a time. The start routine is called as the priority
 // drops to that level. The stop routine is called as the priority rises
 // above that level. The priority will continue to fall or rise until a
 // network is found that is online.
 const NETWORK_TABLE_ENTRY networkInterfaceTable[] =
-{ //     Interface  Name            Present                     Periodic State      Boot Sequence           Start Sequence      Stop Sequence
+{ //     Interface  mDNS    Periodic State      Boot Sequence           Start Sequence      Stop Sequence       Name                    Present
     #ifdef COMPILE_ETHERNET
-        {&ETH,      "Ethernet",     &present.ethernet_ws5500,   PD_ETHERNET_STATE,  nullptr,                nullptr,            nullptr},
+        {&ETH,      true,   PD_ETHERNET_STATE,  nullptr,                nullptr,            nullptr,            "Ethernet",             &present.ethernet_ws5500},
     #else
-        {nullptr,      "Ethernet-NotCompiled",     nullptr,   PD_ETHERNET_STATE,  nullptr,                nullptr,            nullptr},
+        {nullptr,   false,  PD_ETHERNET_STATE,  nullptr,                nullptr,            nullptr,            "Ethernet-NotCompiled", nullptr},
     #endif  // COMPILE_ETHERNET
 
     #ifdef COMPILE_WIFI
-        {&WiFi.STA, "WiFi",         nullptr,                    PD_WIFI_STATE,      nullptr,                wifiStartSequence,  wifiStopSequence},
+        {&WiFi.STA, true,   PD_WIFI_STATE,      nullptr,                wifiStartSequence,  wifiStopSequence,   "WiFi",                 nullptr},
     #else
-        {nullptr,   "WiFi-NotCompiled",     nullptr,            PD_WIFI_STATE,      nullptr,                nullptr,            nullptr},
+        {nullptr,   false,  PD_WIFI_STATE,      nullptr,                nullptr,            nullptr,            "WiFi-NotCompiled",     nullptr},
     #endif  // COMPILE_WIFI
 
     #ifdef  COMPILE_CELLULAR
-        {&PPP,      "Cellular",     &present.cellular_lara,     PD_CELLULAR_STATE,  laraBootSequence,       laraOnSequence,     laraOffSequence},
+        {&PPP,      false,  PD_CELLULAR_STATE,  laraBootSequence,       laraOnSequence,     laraOffSequence,    "Cellular",             &present.cellular_lara},
     #else
-        {nullptr,   "Cellular-NotCompiled",     nullptr,            PD_CELLULAR_STATE,      nullptr,                nullptr,            nullptr},
+        {nullptr,   false,  PD_CELLULAR_STATE,  nullptr,                nullptr,            nullptr,            "Cellular-NotCompiled", nullptr,            },
     #endif  // COMPILE_CELLULAR
 };
 const int networkInterfaceTableEntries = sizeof(networkInterfaceTable) / sizeof(networkInterfaceTable[0]);


### PR DESCRIPTION
RTK: Add headers for WiFi and MQTT support
WiFi: Make RTK_WIFI::_stationRunning a global: wifiStationRunning
WiFi: Make RTK_WIFI::_softApRunning a global: wifiSoftApRunning
WiFi: Make RTK_WIFI::_espNowRunning a global: wifiEspNowRunning
WiFi: Remove WIFI_IS_RUNNING macro and RTK_WIFI::running
WiFi: Make RTK::_channel a global: wifiChannel
ESP-NOW: Use espNowIsPaired instead of ESPNOW_IS_PAIRED macro
