### PR TITLE
Bug fixes

### DIFF
--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -48,6 +48,7 @@ const uint8_t * networkGetMacAddress()
 bool networkHasInternet() {return false;}
 bool networkHasInternet(NetIndex_t index) {return false;}
 bool networkInterfaceHasInternet(NetIndex_t index) {return false;}
+bool networkIsConnected(NetPriority_t * priority) {return false;}
 bool networkIsInterfaceStarted(NetIndex_t index) {return false;}
 void networkMarkOffline(NetIndex_t index) {}
 void networkMarkHasInternet(NetIndex_t index) {}

--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -1964,13 +1964,24 @@ void paintIPAddress()
 
 void displayFullIPAddress(std::vector<iconPropertyBlinking> *iconList) // Bottom left - 128x64 only
 {
+    static IPAddress ipAddress;
+    static NetPriority_t priority;
+    static NetPriority_t previousPriority;
+
     // Max width: 15*6 = 90 pixels (6 pixels per character, nnn.nnn.nnn.nnn)
     if (present.display_type == DISPLAY_128x64)
     {
         char myAddress[16];
 
-        IPAddress ipAddress = networkGetIpAddress();
+        // Reduce calls to networkGetIpAddress
+        networkIsConnected(&priority);
+        if (priority != previousPriority)
+        {
+            previousPriority = priority;
+            ipAddress = networkGetIpAddress();
+        }
 
+        // Display the IP address when it is available
         if (ipAddress != IPAddress((uint32_t)0))
         {
             snprintf(myAddress, sizeof(myAddress), "%s", ipAddress.toString());

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1079,6 +1079,10 @@ void networkSequenceNextEntry(NetIndex_t index, bool debug)
     // Get the previous sequence entry
     next = networkSequence[index];
 
+    // Determine if the sequence has already stopped.
+    if (next == nullptr)
+        return;
+
     // Set the next sequence entry
     next += 1;
     if (next->routine)

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -486,6 +486,14 @@ IPAddress networkGetBroadcastIpAddress()
 }
 
 //----------------------------------------
+// Get the current interface index
+//----------------------------------------
+NetIndex_t networkGetCurrentInterfaceIndex()
+{
+    return networkIndexTable[networkPriority];
+}
+
+//----------------------------------------
 // Get the current interface name
 //----------------------------------------
 const char *networkGetCurrentInterfaceName()

--- a/Firmware/RTK_Everywhere/NtripServer.ino
+++ b/Firmware/RTK_Everywhere/NtripServer.ino
@@ -442,14 +442,20 @@ void ntripServerRestart(int serverIndex)
 // Update the state of the NTRIP server state machine
 void ntripServerSetState(NTRIP_SERVER_DATA *ntripServer, uint8_t newState)
 {
-    int serverIndex = -999;
-    for (int index = 0; index < NTRIP_SERVER_MAX; index++)
+    int index;
+    int serverIndex = 0;
+    for (index = 0; index < NTRIP_SERVER_MAX; index++)
     {
         if (ntripServer == &ntripServerArray[index])
         {
             serverIndex = index;
             break;
         }
+    }
+    if (index >= NTRIP_SERVER_MAX)
+    {
+        systemPrintf("NTRIP Server: %p unknown NTRIP Server structure!\r\n", (void *)ntripServer);
+        return;
     }
 
     // PERIODIC_DISPLAY(PD_NTRIP_SERVER_STATE) is handled by ntripServerUpdate

--- a/Firmware/RTK_Everywhere/States.ino
+++ b/Firmware/RTK_Everywhere/States.ino
@@ -113,7 +113,6 @@ void stateUpdate()
             setMuxport(settings.dataPortChannel); // Return mux to original channel
 
             bluetoothStart(); // Turn on Bluetooth with 'Rover' name
-            ESPNOW_START()    // Start internal radio if enabled, otherwise disable
 
             webServerStop();             // Stop the web config server
             baseCasterDisableOverride(); // Disable casting overrides

--- a/Firmware/RTK_Everywhere/TcpClient.ino
+++ b/Firmware/RTK_Everywhere/TcpClient.ino
@@ -310,6 +310,8 @@ bool tcpClientStart()
             tcpClient = client;
             tcpClientWriteError = false;
             online.tcpClient = true;
+            if (settings.debugTcpClient)
+                systemPrintln("TCP client online");
             return true;
         }
         else
@@ -332,6 +334,8 @@ void tcpClientStop()
     if (client)
     {
         // Delay to allow the UART task to finish with the tcpClient
+        if (settings.debugTcpClient && online.tcpClient)
+            systemPrintln("TCP client offline");
         online.tcpClient = false;
         delay(5);
 
@@ -350,8 +354,6 @@ void tcpClientStop()
 
     // Initialize the TCP client
     tcpClientWriteError = false;
-    if (settings.debugTcpClient)
-        systemPrintln("TCP client offline");
     tcpClientSetState(TCP_CLIENT_STATE_OFF);
 }
 

--- a/Firmware/RTK_Everywhere/TcpClient.ino
+++ b/Firmware/RTK_Everywhere/TcpClient.ino
@@ -433,29 +433,31 @@ void tcpClientUpdate()
         // Wait until the network is connected
         else if (networkIsConnected(&tcpClientPriority))
         {
-#ifdef COMPILE_WIFI
-            // Determine if WiFi is required
-            if ((!strlen(settings.tcpClientHost)) && (!networkInterfaceHasInternet(NETWORK_WIFI)))
+            NetIndex_t index = networkGetCurrentInterfaceIndex();
+
+            // Check for a valid configuration
+            if (!networkInterfaceHasInternet(index))
             {
-                // Wrong network type, WiFi is required but another network is being used
+                // Valid configurations
+                // 1.  Phone: connection via WiFi, no host name, use gateway
+                //     IP address as phone IP address
+                // 2.  Host address, name or IP address of the server
+                bool usingPhone = (index == NETWORK_WIFI_STATION)
+                                && (!strlen(settings.tcpClientHost));
+
+                // Invalid configuration, display a message on a regular
+                // basis until the issue is resolved
                 if ((millis() - timer) >= (15 * 1000))
                 {
                     timer = millis();
-                    systemPrintln("TCP Client must connect via WiFi when no host is specified");
+                    if (usingPhone)
+                        systemPrintln("TCP Client must connect via WiFi when no host is specified");
+                    else
+                        systemPrintln("TCP Client requires host name to be specified!");
                 }
             }
-#else  // COMPILE_WIFI
-            if (!strlen(settings.tcpClientHost))
-            {
-                // Wrong network type
-                if ((millis() - timer) >= (15 * 1000))
-                {
-                    timer = millis();
-                    systemPrintln("TCP Client requires host name to be specified!");
-                }
-            }
-#endif // COMPILE_WIFI
-       // The network type and host provide a valid configuration
+
+            // The network type and host provide a valid configuration
             else
             {
                 timer = millis();

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -1831,11 +1831,12 @@ WIFI_CHANNEL_t RTK_WIFI::stationSelectAP(uint8_t apCount, bool list)
 //   Returns true if the modes were successfully configured
 bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
 {
+    const WIFI_ACTION_t allOnline = WIFI_AP_ONLINE | WIFI_EN_ESP_NOW_ONLINE | WIFI_STA_ONLINE;
     int authIndex;
     WIFI_CHANNEL_t channel;
     bool defaultChannel;
     WIFI_ACTION_t delta;
-    bool enabled;
+    WIFI_ACTION_t expected;
     WIFI_ACTION_t mask;
     WIFI_ACTION_t notStarted;
     uint8_t primaryChannel;
@@ -1847,7 +1848,6 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
 
     // Determine the next actions
     notStarted = 0;
-    enabled = true;
 
     // Display the parameters
     if (settings.debugWifiState && _verbose)
@@ -1872,8 +1872,7 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
     // Determine if there is an active channel
     defaultChannel = _usingDefaultChannel;
     _usingDefaultChannel = false;
-    if (((_started & ~stopping) & (WIFI_AP_ONLINE | WIFI_EN_ESP_NOW_ONLINE | WIFI_STA_ONLINE))
-        && wifiChannel && !defaultChannel)
+    if ((allOnline & _started & ~stopping) && wifiChannel && !defaultChannel)
     {
         // Continue to use the active channel
         channel = wifiChannel;
@@ -1948,6 +1947,9 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
     // Only stop the started components
     stopping &= _started;
 
+    // Determine the components that are being started
+    expected = starting & allOnline;
+
     // Determine which components are being restarted
     restarting = _started & stopping & starting;
     if (settings.debugWifiState && _verbose)
@@ -1955,7 +1957,8 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         systemPrintf("0x%08x: _started\r\n", _started);
         systemPrintf("0x%08x: stopping\r\n", stopping);
         systemPrintf("0x%08x: starting\r\n", starting);
-        systemPrintf("0x%08x: restarting\r\n", starting);
+        systemPrintf("0x%08x: restarting\r\n", restarting);
+        systemPrintf("0x%08x: expected\r\n", expected);
     }
 
     // Don't start components that are already running and are not being
@@ -1991,6 +1994,10 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
                          stopStation ? "Station" : "",
                          stop ? ")" : "");
     }
+
+    //****************************************
+    // Determine which components should end up online
+    //****************************************
 
     // Stop the components
     startingNow = starting;
@@ -2216,8 +2223,6 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         //****************************************
         // Start the radio operations
         //****************************************
-
-        enabled = false;
 
         // Start the soft AP mode
         if (starting & WIFI_AP_SET_MODE)
@@ -2550,9 +2555,6 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
                          _staMacAddress[3], _staMacAddress[4], _staMacAddress[5],
                          wifiChannel);
         }
-
-        // All components started successfully
-        enabled = true;
     } while (0);
 
     //****************************************
@@ -2599,6 +2601,7 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         displayComponents("Started items", _started);
 
     // Return the enable status
+    bool enabled = ((_started & allOnline) == expected);
     if (!enabled)
         systemPrintf("ERROR: RTK_WIFI::stopStart failed!\r\n");
     if (settings.debugWifiState && _verbose)

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -1022,36 +1022,6 @@ WIFI_CHANNEL_t RTK_WIFI::getChannel()
 }
 
 //*********************************************************************
-// Restart WiFi
-bool RTK_WIFI::restart(bool always)
-{
-    // Determine if restart should be perforrmed
-    if (always || wifiRestartRequested)
-    {
-        wifiRestartRequested = false;
-
-        // Determine how WiFi is being used
-        bool started = false;
-        bool espNowRunning = wifiEspNowRunning;
-        bool softApRunning = wifiSoftApRunning;
-
-        // Stop the WiFi layer
-        started = enable(false, false, false);
-
-        // Restart the WiFi layer
-        if (started)
-            started = enable(espNowRunning,
-                             softApRunning,
-                             networkConsumers() ? true : false);
-
-        // Return the started state
-        return started;
-    }
-    else
-        return false;
-}
-
-//*********************************************************************
 // Set the WiFi mode
 // Inputs:
 //   setMode: Modes to set

--- a/Firmware/RTK_Everywhere/menuFirmware.ino
+++ b/Firmware/RTK_Everywhere/menuFirmware.ino
@@ -878,6 +878,7 @@ void otaUpdate()
                 if ((isReportedVersionNewer(otaReportedVersion, &currentVersion[1]) == true) ||
                     (currentVersion[0] == 'd') || (FIRMWARE_VERSION_MAJOR == 99))
                 {
+                    newOTAFirmwareAvailable = true;
                     systemPrintf("Version Check: New firmware version available: %s\r\n", otaReportedVersion);
 
                     // If we are doing just a version check, set version number, turn off network request and stop

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2151,15 +2151,6 @@ class RTK_WIFI
     //   Returns the current WiFi channel number
     WIFI_CHANNEL_t getChannel();
 
-    // Restart WiFi
-    // Inputs:
-    //   always: Set true if this routine should always restart WiFi,
-    //           when false determine restart using _restartRequest
-    // Outputs:
-    //    Returns true if the WiFi layer was successfully restarted and
-    //    false upon restart failure
-    bool restart(bool always);
-
     // Configure the soft AP
     // Inputs:
     //   ipAddress: IP address of the soft AP

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1913,6 +1913,7 @@ o/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU
 rqXRfboQnoZsG4q5WTP468SQvvG5
 -----END CERTIFICATE-----
 )=====";
+#endif  // COMPILE_NETWORK
 
 //****************************************
 // WiFi class
@@ -1920,6 +1921,7 @@ rqXRfboQnoZsG4q5WTP468SQvvG5
 
 typedef uint8_t WIFI_CHANNEL_t;
 
+#ifdef COMPILE_NETWORK
 #ifdef COMPILE_WIFI
 
 // Handle the WiFi event


### PR DESCRIPTION
Fix error when COMPILE_NETWORK is commented out
ESP-NOW: Don't start immediately in STATE_ROVER_NOT_STARTED
Display: Reduce calls to networkGetIpAddress
WiFi: Return the correct status from RTK_WIFI::stopStart
NtripServer: Don't use invalid index, validate index upon exit
WiFi: Remove dead code
OTA: Set firmware available flag when new firmware is found
Network: Add networkGetCurrentInterfaceIndex routine
TCP Client: Properly display online and offline messages
TCP Client: Don't require a host name, support Vespucci on phone
Network: Prevent crash by verifying the next sequence pointer
