### PR TITLE
New network consumer support, first part

### DIFF
--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -205,7 +205,7 @@ uint32_t wifiGetStartTimeout()                  {return 0;}
 int wifiNetworkCount()                          {return 0;}
 void wifiResetThrottleTimeout()                 {}
 void wifiResetTimeout()                         {}
-bool wifiStart()                                {return false;}
+bool wifiStationOn(bool on)                     {return !on;}
 void wifiStopAll()                              {}
 
 #endif // COMPILE_WIFI

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -33,9 +33,6 @@ void ntpServerStop() {}
 
 void menuTcpUdp() {systemPrint("**Network not compiled**");}
 void networkBegin() {}
-uint8_t networkConsumers() {return(0);}
-uint16_t networkGetConsumerTypes() {return(0);}
-NetIndex_t networkGetCurrentInterfaceIndex() {return NETWORK_OFFLINE;}
 IPAddress networkGetIpAddress() {return("0.0.0.0");}
 const uint8_t * networkGetMacAddress()
 {
@@ -210,7 +207,6 @@ void wifiResetThrottleTimeout()                 {}
 void wifiResetTimeout()                         {}
 bool wifiStart()                                {return false;}
 #define WIFI_STOP()                             {}
-bool wifiUnavailable()                          {return true;}
 
 #endif // COMPILE_WIFI
 

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -200,6 +200,7 @@ void espNowUpdate()                     {}
 #ifndef COMPILE_WIFI
 
 void menuWiFi()                 {systemPrintln("**WiFi not compiled**");}
+bool wifiEspNowOn(bool on)                      {return !on;}
 #define WIFI_ESPNOW_SET_CHANNEL(chan)
 uint32_t wifiGetStartTimeout()                  {return 0;}
 int wifiNetworkCount()                          {return 0;}

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -206,7 +206,7 @@ int wifiNetworkCount()                          {return 0;}
 void wifiResetThrottleTimeout()                 {}
 void wifiResetTimeout()                         {}
 bool wifiStart()                                {return false;}
-#define WIFI_STOP()                             {}
+void wifiStopAll()                              {}
 
 #endif // COMPILE_WIFI
 

--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -830,7 +830,7 @@ void setRadioIcons(std::vector<iconPropertyBlinking> *iconList)
 #endif // COMPILE_ETHERNET
 
 #ifdef COMPILE_WIFI
-            if (networkInterfaceHasInternet(NETWORK_WIFI))
+            if (networkInterfaceHasInternet(NETWORK_WIFI_STATION))
                 networkHasInternet = true;
 #endif // COMPILE_WIFI
 
@@ -1099,7 +1099,7 @@ void setESPNowIcon_TwoRadios(std::vector<iconPropertyBlinking> *iconList)
 void setWiFiIcon_TwoRadios(std::vector<iconPropertyBlinking> *iconList)
 {
 #ifdef COMPILE_WIFI
-    if (networkInterfaceHasInternet(NETWORK_WIFI))
+    if (networkInterfaceHasInternet(NETWORK_WIFI_STATION))
     {
         if (netIncomingRTCM || netOutgoingRTCM || mqttClientDataReceived)
         {
@@ -1169,7 +1169,7 @@ void setWiFiIcon_TwoRadios(std::vector<iconPropertyBlinking> *iconList)
 void setWiFiIcon_ThreeRadios(std::vector<iconPropertyBlinking> *iconList)
 {
 #ifdef COMPILE_WIFI
-    if (networkInterfaceHasInternet(NETWORK_WIFI))
+    if (networkInterfaceHasInternet(NETWORK_WIFI_STATION))
     {
         if (netIncomingRTCM || netOutgoingRTCM || mqttClientDataReceived)
         {
@@ -1248,7 +1248,7 @@ void setWiFiIcon(std::vector<iconPropertyBlinking> *iconList)
         icon.icon.yPos = 0;
 
 #ifdef COMPILE_WIFI
-        if (networkInterfaceHasInternet(NETWORK_WIFI))
+        if (networkInterfaceHasInternet(NETWORK_WIFI_STATION))
             icon.duty = 0b11111111;
         else
 #endif // COMPILE_WIFI

--- a/Firmware/RTK_Everywhere/ESPNOW.ino
+++ b/Firmware/RTK_Everywhere/ESPNOW.ino
@@ -99,7 +99,7 @@ esp_err_t espNowAddPeer(const uint8_t * peerMac)
 void espNowBeginPairing()
 {
     // Start ESP-NOW if necessary
-    wifi.enable(true, wifiSoftApRunning, wifiStationRunning);
+    ESPNOW_START();
 
     // To begin pairing, we must add the broadcast MAC to the peer list
     espNowAddPeer(espNowBroadcastAddr);

--- a/Firmware/RTK_Everywhere/Ethernet.ino
+++ b/Firmware/RTK_Everywhere/Ethernet.ino
@@ -188,9 +188,6 @@ void ethernetEvent(arduino_event_id_t event, arduino_event_info_t info)
     case ARDUINO_EVENT_ETH_DISCONNECTED:
         if (settings.enablePrintEthernetDiag && (!inMainMenu))
             systemPrintln("ETH Disconnected");
-
-        wifiResetTimeout(); // If we loose ethernet, allow WiFi to immediately try to start
-
         break;
 
     case ARDUINO_EVENT_ETH_STOP:

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1754,7 +1754,12 @@ void networkUpdate()
 
         // Handle the network lost internet event
         if (networkEventInternetLost[index])
+        {
             networkInterfaceInternetConnectionLost(index);
+
+            // Start the failover processing
+            networkStartNextInterface(index);
+        }
 
         // Handle the network stop event
         if (networkEventStop[index])

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -802,7 +802,7 @@ const uint8_t *networkGetMacAddress()
         return btMACAddress;
 #endif // COMPILE_BT
 #ifdef COMPILE_WIFI
-    if (networkInterfaceHasInternet(NETWORK_WIFI))
+    if (networkInterfaceHasInternet(NETWORK_WIFI_STATION))
         return wifiMACAddress;
 #endif // COMPILE_WIFI
 #ifdef COMPILE_ETHERNET
@@ -1790,12 +1790,12 @@ void networkUpdate()
         wifiResetThrottleTimeout();
 
         // Break existing WiFi connection if necessary
-        if (networkInterfaceHasInternet(NETWORK_WIFI))
+        if (networkInterfaceHasInternet(NETWORK_WIFI_STATION))
         {
             if (settings.debugNetworkLayer)
                 systemPrintln("WiFi settings changed, restarting WiFi");
 
-            networkStop(NETWORK_WIFI, settings.debugNetworkLayer);
+            networkStop(NETWORK_WIFI_STATION, settings.debugNetworkLayer);
         }
     }
 
@@ -1860,7 +1860,7 @@ void networkUpdate()
             else if (networkInterfaceTable[index].netif->started())
                 systemPrintf("%s: Started\r\n", networkInterfaceTable[index].name);
 
-            else if (index == NETWORK_WIFI && (WiFi.getMode() == WIFI_AP || WiFi.getMode() == WIFI_AP_STA))
+            else if (index == NETWORK_WIFI_STATION && (WiFi.getMode() == WIFI_AP || WiFi.getMode() == WIFI_AP_STA))
             {
                 // NETIF doesn't capture the IP address of a soft AP
                 ipAddress = WiFi.softAPIP();

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1316,6 +1316,24 @@ void networkSequenceExit(NetIndex_t index, bool debug)
 }
 
 //----------------------------------------
+// Determine if a sequence is running
+//----------------------------------------
+bool networkSequenceIsRunning()
+{
+    // Determine if there are any pending sequences
+    if (networkSeqStarting || networkSeqStopping)
+        return true;
+
+    // Determine if there is an active sequence
+    for (int index = 0; index < NETWORK_MAX; index++)
+        if (networkSequence[index])
+            return true;
+
+    // No sequences are running
+    return false;
+}
+
+//----------------------------------------
 // Select the next entry in the sequence
 //----------------------------------------
 void networkSequenceNextEntry(NetIndex_t index, bool debug)

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1605,6 +1605,39 @@ void networkStart(NetIndex_t index, bool debug)
 }
 
 //----------------------------------------
+// Start the next lower priority network interface
+//----------------------------------------
+void networkStartNextInterface(NetIndex_t index)
+{
+    NetMask_t bitMask;
+    NetPriority_t priority;
+
+    // Verify that a network consumer is requesting the network
+    if (networkConsumerCount)
+    {
+        // Validate the index
+        networkValidateIndex(index);
+
+        // Get the priority of the specified interface
+        priority = networkPriorityTable[index];
+
+        // Determine if there is another interface available
+        for (priority = priority + 1; priority < NETWORK_MAX; priority += 1)
+        {
+            index = networkIndexTable[priority];
+            bitMask = 1 << index;
+            if (networkIsPresent(index))
+            {
+                if (((networkStarted | networkSeqStarting) & bitMask) == 0)
+                    // Start this network interface
+                    networkStart(index, settings.debugNetworkLayer);
+                break;
+            }
+        }
+    }
+}
+
+//----------------------------------------
 // Stop a network interface
 //----------------------------------------
 void networkStop(NetIndex_t index, bool debug)

--- a/Firmware/RTK_Everywhere/NtripClient.ino
+++ b/Firmware/RTK_Everywhere/NtripClient.ino
@@ -464,7 +464,7 @@ void ntripClientSetState(uint8_t newState)
     {
         if (newState >= NTRIP_CLIENT_STATE_MAX)
         {
-            systemPrintf("Unknown client state: %d\r\n", newState);
+            systemPrintf("Unknown NTRIP Client state: %d\r\n", newState);
             reportFatalError("Unknown NTRIP Client state");
         }
         else
@@ -487,6 +487,7 @@ void ntripClientStart()
 
     // Start the NTRIP client
     systemPrintln("NTRIP Client start");
+    networkConsumerAdd(NETCONSUMER_NTRIP_CLIENT, NETWORK_ANY);
     ntripClientStop(false);
 }
 
@@ -518,6 +519,7 @@ void ntripClientStop(bool shutdown)
     netIncomingRTCM = false;
     if (shutdown)
     {
+        networkConsumerRemove(NETCONSUMER_NTRIP_CLIENT, NETWORK_ANY);
         ntripClientSetState(NTRIP_CLIENT_OFF);
         ntripClientConnectionAttempts = 0;
         ntripClientConnectionAttemptTimeout = 0;

--- a/Firmware/RTK_Everywhere/NtripClient.ino
+++ b/Firmware/RTK_Everywhere/NtripClient.ino
@@ -546,12 +546,7 @@ void ntripClientUpdate()
     if (NEQ_RTK_MODE(ntripClientMode) || (!settings.enableNtripClient))
     {
         if (ntripClientState > NTRIP_CLIENT_OFF)
-        {
-            ntripClientStop(true); // Was false - #StopVsRestart
-            ntripClientConnectionAttempts = 0;
-            ntripClientConnectionAttemptTimeout = 0;
-            ntripClientSetState(NTRIP_CLIENT_OFF);
-        }
+            ntripClientStop(true);
     }
 
     // Enable the network and the NTRIP client if requested
@@ -600,7 +595,7 @@ void ntripClientUpdate()
         // Determine if the network has failed
         if (!networkIsConnected(&ntripClientPriority))
             // Failed to connect to to the network, attempt to restart the network
-            ntripClientStop(true); // Was ntripClientRestart(); - #StopVsRestart
+            ntripClientRestart();
 
         // If GGA transmission is enabled, wait for GNSS lock before connecting to NTRIP Caster
         // If GGA transmission is not enabled, start connecting to NTRIP Caster
@@ -633,7 +628,7 @@ void ntripClientUpdate()
         // Determine if the network has failed
         if (!networkIsConnected(&ntripClientPriority))
             // Failed to connect to to the network, attempt to restart the network
-            ntripClientStop(true); // Was ntripClientRestart(); - #StopVsRestart
+            ntripClientRestart();
 
         // Check for no response from the caster service
         else if (ntripClientReceiveDataAvailable() <
@@ -754,7 +749,7 @@ void ntripClientUpdate()
         // Determine if the network has failed
         if (!networkIsConnected(&ntripClientPriority))
             // Failed to connect to to the network, attempt to restart the network
-            ntripClientStop(true); // Was ntripClientRestart(); - #StopVsRestart
+            ntripClientRestart();
 
         // Check for a broken connection
         else if (!ntripClient->connected())

--- a/Firmware/RTK_Everywhere/NtripServer.ino
+++ b/Firmware/RTK_Everywhere/NtripServer.ino
@@ -493,6 +493,7 @@ void ntripServerStart(int serverIndex)
 
     // Start the NTRIP server
     systemPrintf("NTRIP Server %d start\r\n", serverIndex);
+    networkConsumerAdd(NETCONSUMER_NTRIP_CLIENT, NETWORK_ANY);
     ntripServerStop(serverIndex, false);
 }
 
@@ -539,6 +540,7 @@ void ntripServerStop(int serverIndex, bool shutdown)
             if (settings.debugNtripServerState && (!settings.ntripServer_MountPoint[serverIndex][0]))
                 systemPrintf("NTRIP Server %d mount point not configured!\r\n", serverIndex);
         }
+        networkConsumerRemove(NETCONSUMER_NTRIP_SERVER, NETWORK_ANY);
         ntripServerSetState(ntripServer, NTRIP_SERVER_OFF);
         ntripServer->connectionAttempts = 0;
         ntripServer->connectionAttemptTimeout = 0;
@@ -592,12 +594,7 @@ void ntripServerUpdate(int serverIndex)
     if (NEQ_RTK_MODE(ntripServerMode) || (!settings.enableNtripServer))
     {
         if (ntripServer->state > NTRIP_SERVER_OFF)
-        {
-            ntripServerStop(serverIndex, true); // Was false - #StopVsRestart
-            ntripServer->connectionAttempts = 0;
-            ntripServer->connectionAttemptTimeout = 0;
-            ntripServerSetState(ntripServer, NTRIP_SERVER_OFF);
-        }
+            ntripServerStop(serverIndex, true);
     }
 
     // Enable the network and the NTRIP server if requested

--- a/Firmware/RTK_Everywhere/NtripServer.ino
+++ b/Firmware/RTK_Everywhere/NtripServer.ino
@@ -652,7 +652,7 @@ void ntripServerUpdate(int serverIndex)
         // Determine if the network has failed
         if (!networkIsConnected(&ntripServerPriority))
             // Failed to connect to to the network, attempt to restart the network
-            ntripServerStop(serverIndex, true); // Was ntripServerRestart(serverIndex); - #StopVsRestart
+            ntripServerRestart(serverIndex);
 
         else if (settings.enableNtripServer &&
                  (millis() - ntripServer->lastConnectionAttempt > ntripServer->connectionAttemptTimeout))
@@ -670,7 +670,7 @@ void ntripServerUpdate(int serverIndex)
         // Determine if the network has failed
         if (!networkIsConnected(&ntripServerPriority))
             // Failed to connect to to the network, attempt to restart the network
-            ntripServerStop(serverIndex, true); // Was ntripServerRestart(serverIndex); - #StopVsRestart
+            ntripServerRestart(serverIndex);
 
         // State change handled in ntripServerProcessRTCM
         break;
@@ -680,7 +680,7 @@ void ntripServerUpdate(int serverIndex)
         // Determine if the network has failed
         if (!networkIsConnected(&ntripServerPriority))
             // Failed to connect to to the network, attempt to restart the network
-            ntripServerStop(serverIndex, true); // Was ntripServerRestart(serverIndex); - #StopVsRestart
+            ntripServerRestart(serverIndex);
 
         // Delay before opening the NTRIP server connection
         else if ((millis() - ntripServer->timer) >= ntripServer->connectionAttemptTimeout)
@@ -708,7 +708,7 @@ void ntripServerUpdate(int serverIndex)
         // Determine if the network has failed
         if (!networkIsConnected(&ntripServerPriority))
             // Failed to connect to to the network, attempt to restart the network
-            ntripServerStop(serverIndex, true); // Was ntripServerRestart(serverIndex); - #StopVsRestart
+            ntripServerRestart(serverIndex);
 
         // Check if caster service responded
         else if (ntripServer->networkClient->available() <
@@ -802,7 +802,7 @@ void ntripServerUpdate(int serverIndex)
         // Determine if the network has failed
         if (!networkIsConnected(&ntripServerPriority))
             // Failed to connect to the network, attempt to restart the network
-            ntripServerStop(serverIndex, true); // Was ntripServerRestart(serverIndex); - #StopVsRestart
+            ntripServerRestart(serverIndex);
 
         // Check for a broken connection
         else if (!ntripServer->networkClient->connected())

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -359,14 +359,6 @@ int packetRSSI;
 RTK_WIFI wifi(false);
 
 #define WIFI_ESPNOW_SET_CHANNEL(chan)   wifi.espNowSetChannel(chan)
-#define WIFI_IS_CONNECTED()             wifi.stationOnline()
-
-#define WIFI_STOP()                                                                                                    \
-    {                                                                                                                  \
-        if (settings.debugWifiState)                                                                                   \
-            systemPrintf("WIFI_STOP called by %s %d\r\n", __FILE__, __LINE__);                                         \
-        wifiStopAll();                                                                                                 \
-    }
 #endif // COMPILE_WIFI
 
 // WiFi Globals - For other module direct access

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -675,10 +675,10 @@ float lBandEBNO; // Used on system status menu
     {                                                                                       \
         if (settings.debugEspNow)                                                           \
             systemPrintf("ESPNOW_START called in %s at line %d\r\n", __FILE__, __LINE__);   \
-        wifi.enable(true, wifiSoftApRunning, wifiStationRunning);                     \
+        wifiEspNowOn(true);                     \
     }
 
-#define ESPNOW_STOP()       wifi.enable(false, wifiSoftApRunning, wifiStationRunning)
+#define ESPNOW_STOP()       wifiEspNowOn(false)
 
 #endif // COMPILE_ESPNOW
 

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -423,7 +423,7 @@ void menuWiFi()
 {
     while (1)
     {
-        networkDisplayInterface(NETWORK_WIFI);
+        networkDisplayInterface(NETWORK_WIFI_STATION);
 
         systemPrintln();
         systemPrintln("Menu: WiFi Networks");
@@ -498,10 +498,10 @@ void menuWiFi()
 // Display the WiFi state
 void wifiDisplayState()
 {
-    systemPrintf("WiFi: %s\r\n", networkInterfaceHasInternet(NETWORK_WIFI) ? "Online" : "Offline");
+    systemPrintf("WiFi: %s\r\n", networkInterfaceHasInternet(NETWORK_WIFI_STATION) ? "Online" : "Offline");
     systemPrintf("    MAC Address: %02X:%02X:%02X:%02X:%02X:%02X\r\n", wifiMACAddress[0], wifiMACAddress[1],
                  wifiMACAddress[2], wifiMACAddress[3], wifiMACAddress[4], wifiMACAddress[5]);
-    if (networkInterfaceHasInternet(NETWORK_WIFI))
+    if (networkInterfaceHasInternet(NETWORK_WIFI_STATION))
     {
         // Get the DNS addresses
         IPAddress dns1 = WiFi.STA.dnsIP(0);
@@ -630,7 +630,7 @@ bool wifiStart()
 void wifiStartThrottled(NetIndex_t index, uintptr_t parameter, bool debug)
 {
     if (wifiStationReconnectionRequest())
-        networkSequenceNextEntry(NETWORK_WIFI, debug);
+        networkSequenceNextEntry(NETWORK_WIFI_STATION, debug);
 
     // Check for network shutdown
     else if (networkConsumerCount == 0)
@@ -638,7 +638,7 @@ void wifiStartThrottled(NetIndex_t index, uintptr_t parameter, bool debug)
         // Stop the connection attempts
         wifiResetThrottleTimeout();
         wifiResetTimeout();
-        networkSequenceStopPolling(NETWORK_WIFI, debug, true);
+        networkSequenceStopPolling(NETWORK_WIFI_STATION, debug, true);
     }
 }
 
@@ -671,7 +671,7 @@ bool wifiStationReconnectionRequest()
         connected = true;
         if (settings.debugWifiState)
             systemPrintf("WiFi: WiFi station successfully started\r\n");
-        networkSequenceNextEntry(NETWORK_WIFI, settings.debugNetworkLayer);
+        networkSequenceNextEntry(NETWORK_WIFI_STATION, settings.debugNetworkLayer);
         wifiFailedConnectionAttempts = 0;
     }
     else
@@ -685,7 +685,7 @@ bool wifiStationReconnectionRequest()
 
         // Start the next network interface if necessary
         if (wifiFailedConnectionAttempts >= 2)
-            networkStartNextInterface(NETWORK_WIFI);
+            networkStartNextInterface(NETWORK_WIFI_STATION);
 
         // Increase the timeout
         wifiStartTimeout <<= 1;
@@ -708,12 +708,12 @@ bool wifiStationReconnectionRequest()
 // Stop WiFi, used by wifiStopSequence
 void wifiStop(NetIndex_t index, uintptr_t parameter, bool debug)
 {
-    networkInterfaceInternetConnectionLost(NETWORK_WIFI);
+    networkInterfaceInternetConnectionLost(NETWORK_WIFI_STATION);
 
     // Stop WiFi stataion
     wifi.enable(wifiEspNowRunning, wifiSoftApRunning, false);
 
-    networkSequenceNextEntry(NETWORK_WIFI, settings.debugNetworkLayer);
+    networkSequenceNextEntry(NETWORK_WIFI_STATION, settings.debugNetworkLayer);
 }
 
 //*********************************************************************
@@ -727,7 +727,7 @@ void wifiStopAll()
     wifi.enable(false, false, false);
 
     // Take the network offline
-    networkInterfaceEventInternetLost(NETWORK_WIFI);
+    networkInterfaceEventInternetLost(NETWORK_WIFI_STATION);
 
     // Display the heap state
     reportHeapNow(settings.debugWifiState);
@@ -1536,7 +1536,7 @@ void RTK_WIFI::stationEventHandler(arduino_event_id_t event, arduino_event_info_
         if (event == ARDUINO_EVENT_WIFI_STA_DISCONNECTED)
         {
             wifiReconnectRequest = true;
-            networkStart(NETWORK_WIFI, settings.debugWifiState);
+            networkStart(NETWORK_WIFI_STATION, settings.debugWifiState);
         }
 
         // Fall through
@@ -1597,7 +1597,7 @@ void RTK_WIFI::stationEventHandler(arduino_event_id_t event, arduino_event_info_
         if (settings.debugWifiState)
             systemPrintf("WiFi: Got IPv%c address %s\r\n",
                          type, _staIpAddress.toString().c_str());
-        networkInterfaceEventInternetAvailable(NETWORK_WIFI);
+        networkInterfaceEventInternetAvailable(NETWORK_WIFI_STATION);
         break;
     }   // End of switch
 }

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -672,6 +672,10 @@ bool wifiStationReconnectionRequest()
         // Account for this connection attempt
         wifiFailedConnectionAttempts++;
 
+        // Start the next network interface if necessary
+        if (wifiFailedConnectionAttempts >= 2)
+            networkStartNextInterface(NETWORK_WIFI);
+
         // Increase the timeout
         wifiStartTimeout <<= 1;
         if (!wifiStartTimeout)
@@ -739,6 +743,7 @@ RTK_WIFI::RTK_WIFI(bool verbose)
 {
     wifiChannel = 0;
     wifiEspNowRunning = false;
+    wifiFailedConnectionAttempts = 0;
     wifiRestartRequested = false;
     wifiStationRunning = false;
     wifiSoftApRunning = false;

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -615,14 +615,11 @@ void wifiResetTimeout()
 }
 
 //*********************************************************************
-// Starts the WiFi connection state machine (moves from WIFI_STATE_OFF to WIFI_STATE_CONNECTING)
-// Sets the appropriate protocols (WiFi + ESP-Now)
-// If radio is off entirely, start WiFi
-// If ESP-Now is active, only add the LR protocol
-// Returns true if WiFi has connected and false otherwise
-bool wifiStart()
+// Start or stop the WiFi station
+// Returns true if successful and false upon failure
+bool wifiStationOn(bool on)
 {
-    return wifi.enable(wifiEspNowRunning, wifiSoftApRunning, true);
+    return wifi.enable(wifiEspNowRunning, wifiSoftApRunning, on);
 }
 
 //*********************************************************************
@@ -665,7 +662,7 @@ bool wifiStationReconnectionRequest()
     }
 
     // Attempt to start WiFi station
-    if (wifiStart())
+    if (wifiStationOn(true))
     {
         // Successfully connected to a remote AP
         connected = true;

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -628,7 +628,8 @@ bool wifiStart()
 // Start WiFi with throttling, used by wifiStopSequence
 void wifiStartThrottled(NetIndex_t index, uintptr_t parameter, bool debug)
 {
-    wifiStationReconnectionRequest();
+    if (wifiStationReconnectionRequest())
+        networkSequenceNextEntry(NETWORK_WIFI, debug);
 }
 
 //*********************************************************************

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -719,20 +719,6 @@ void wifiStopAll()
 }
 
 //*********************************************************************
-// Returns true if we deem WiFi is not going to connect
-// Used to allow cellular to start
-bool wifiUnavailable()
-{
-    if(wifiNetworkCount() == 0)
-        return true;
-
-    if (wifiFailedConnectionAttempts > 2)
-        return true;
-
-    return false;
-}
-
-//*********************************************************************
 // Constructor
 // Inputs:
 //   verbose: Set to true to display additional WiFi debug data

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -531,6 +531,14 @@ void wifiDisplayState()
 }
 
 //*********************************************************************
+// Start or stop ESP-NOW
+// Returns true if successful and false upon failure
+bool wifiEspNowOn(bool on)
+{
+    return wifi.enable(on, wifiSoftApRunning, wifiStationRunning);
+}
+
+//*********************************************************************
 // Return the start timeout in milliseconds
 uint32_t wifiGetStartTimeout()
 {

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -630,6 +630,15 @@ void wifiStartThrottled(NetIndex_t index, uintptr_t parameter, bool debug)
 {
     if (wifiStationReconnectionRequest())
         networkSequenceNextEntry(NETWORK_WIFI, debug);
+
+    // Check for network shutdown
+    else if (networkConsumerCount == 0)
+    {
+        // Stop the connection attempts
+        wifiResetThrottleTimeout();
+        wifiResetTimeout();
+        networkSequenceStopPolling(NETWORK_WIFI, debug, true);
+    }
 }
 
 //*********************************************************************

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -463,6 +463,7 @@ void menuWiFi()
 
             // If we are modifying the SSID table, force restart of WiFi
             wifiRestartRequested = true;
+            wifiFailedConnectionAttempts = 0;
         }
         else if (incoming == 'a')
         {

--- a/Firmware/RTK_Everywhere/menuCommands.ino
+++ b/Firmware/RTK_Everywhere/menuCommands.ino
@@ -1294,11 +1294,8 @@ SettingValueResponse updateSettingWithValue(bool inCommands, const char *setting
         // Web Config immediately of success or failure
 
         // If we're in AP only mode (no internet), try WiFi with current SSIDs
-        if (networkIsInterfaceStarted(NETWORK_WIFI_STATION)
-            && networkInterfaceHasInternet(NETWORK_WIFI_STATION) == false)
-        {
-            wifiStart();
-        }
+        if (networkIsInterfaceStarted(NETWORK_WIFI_STATION) == false)
+            wifiStationOn(true);
 
         // Get firmware version from server
         char newVersionCSV[40];

--- a/Firmware/RTK_Everywhere/menuCommands.ino
+++ b/Firmware/RTK_Everywhere/menuCommands.ino
@@ -1294,15 +1294,15 @@ SettingValueResponse updateSettingWithValue(bool inCommands, const char *setting
         // Web Config immediately of success or failure
 
         // If we're in AP only mode (no internet), try WiFi with current SSIDs
-        if (networkIsInterfaceStarted(NETWORK_WIFI)
-            && networkInterfaceHasInternet(NETWORK_WIFI) == false)
+        if (networkIsInterfaceStarted(NETWORK_WIFI_STATION)
+            && networkInterfaceHasInternet(NETWORK_WIFI_STATION) == false)
         {
             wifiStart();
         }
 
         // Get firmware version from server
         char newVersionCSV[40];
-        if (networkInterfaceHasInternet(NETWORK_WIFI) == false)
+        if (networkInterfaceHasInternet(NETWORK_WIFI_STATION) == false)
         {
             // No internet. Report error.
             if (settings.debugWebServer == true)

--- a/Firmware/RTK_Everywhere/menuFirmware.ino
+++ b/Firmware/RTK_Everywhere/menuFirmware.ino
@@ -263,7 +263,7 @@ void updateFromSD(const char *firmwareFileName)
 
     // Turn off any tasks so that we are not disrupted
     ESPNOW_STOP();
-    WIFI_STOP();
+    wifiStopAll();
     bluetoothStop();
 
     // Delete tasks if running

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -570,14 +570,20 @@ enum
 {
     NETCONSUMER_NTRIP_CLIENT = 0,
     NETCONSUMER_NTRIP_SERVER,
+    NETCONSUMER_OTA_CLIENT,
+    NETCONSUMER_PPL_KEY_UPDATE,
+    NETCONSUMER_PPL_MQTT_CLIENT,
     NETCONSUMER_TCP_CLIENT,
     NETCONSUMER_TCP_SERVER,
     NETCONSUMER_UDP_SERVER,
-    NETCONSUMER_PPL_KEY_UPDATE,
-    NETCONSUMER_PPL_MQTT_CLIENT,
-    NETCONSUMER_OTA_CLIENT,
     NETCONSUMER_WEB_CONFIG,
+    // Add new consumers just before this line
+    // Also add them to the networkConsumerTable
+    NETCONSUMER_MAX
 };
+
+typedef uint8_t NETCONSUMER_t;
+typedef uint16_t NETCONSUMER_MASK_t;
 
 // This is all the settings that can be set on RTK Product. It's recorded to NVM and the config file.
 // Avoid reordering. The order of these variables is mimicked in NVM/record/parse/create/update/get
@@ -1791,7 +1797,8 @@ enum NetworkTypes
     NETWORK_WIFI = 1,
     NETWORK_CELLULAR = 2,
     // Add new networks here
-    NETWORK_MAX
+    NETWORK_MAX,
+    NETWORK_ANY = NETWORK_MAX,
 };
 
 #ifdef  COMPILE_NETWORK

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -552,19 +552,6 @@ const int numRegionalAreas = sizeof(Regional_Information_Table) / sizeof(Regiona
 
 #define NTRIP_SERVER_STRING_SIZE        50
 
-//Bitfield for describing the type of network the consumer can use
-enum
-{
-    NETIF_NONE = 0, // No consumers
-    NETIF_WIFI_STA, // The consumer can use STA
-    NETIF_WIFI_AP, // The consumer can use AP
-    NETIF_CELLULAR, // The consumer can use Cellular
-    NETIF_ETHERNET, // The consumer can use Ethernet
-    NETIF_UNKNOWN
-};
-
-#define NETWORK_EWC ((1 << NETIF_ETHERNET) | (1 << NETIF_WIFI_STA) | (1 << NETIF_CELLULAR))
-
 // Bitfield for describing the network consumers
 enum
 {

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1781,7 +1781,7 @@ enum NetworkTypes
 {
     NETWORK_NONE = -1,  // The values below must start at zero and be sequential
     NETWORK_ETHERNET = 0,
-    NETWORK_WIFI = 1,
+    NETWORK_WIFI_STATION = 1,
     NETWORK_CELLULAR = 2,
     // Add new networks here
     NETWORK_MAX,


### PR DESCRIPTION
Network: Add updated network consumer support
Network: Use new networkConsumer routines to start/stop the network
NtripClient: Start using networkConsumer services
NtripClient: Switch back to using *ClientRestart instead of *ClientStop
NtripServer: Switch back to using *ServerRestart instead of *ServerStop
OtaClient: Start/stop network layer
Network: Add networkStartNextInterface routine to initiate failover
Network: Use networkStartNextInterface to initiate failover
WiFi: Stop the start sequence once WiFi station starts
WiFi: Stop WiFi reconnection attempts when no network consumers
WiFi: Perform 2 connection attempts with new SSID/pass before failover
menuFirmware: Use wifiStopAll instead of WIFI_STOP
Network: Rename NETWORK_WIFI to NETWORK_WIFI_STATION
WiFi: Rename wifiStart to wifiStationOn and add on parameter
WiFi: Add wifiEspNowOn routine to turn on/of ESP-NOW
ESP-NOW: Switch to using wifiEspNowOn
Network: Add networkSequenceIsRunning routine
