### PR TITLE
MQTT_Client: Add new WiFi and network consumer support

### DIFF
--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -133,6 +133,7 @@ bool mqttClientIsConnected() {return false;}
 bool mqttClientNeedsNetwork() {return false;}
 void mqttClientPrintStatus() {}
 void mqttClientRestart() {}
+void mqttClientStartEnabled() {}
 void mqttClientUpdate() {}
 void mqttClientValidateTables() {}
 

--- a/Firmware/RTK_Everywhere/MQTT_Client.ino
+++ b/Firmware/RTK_Everywhere/MQTT_Client.ino
@@ -142,6 +142,7 @@ static NetPriority_t mqttClientPriority = NETWORK_OFFLINE;
 
 static NetworkClientSecure *mqttSecureClient;
 
+static bool mqttClientStartRequested;
 static volatile uint8_t mqttClientState = MQTT_CLIENT_OFF;
 
 // MQTT client timer usage:
@@ -234,7 +235,7 @@ bool mqttClientEnabled()
             break;
 
         // All conditions support running the MQTT client
-        enableMqttClient = true;
+        enableMqttClient = mqttClientStartRequested;
     } while (0);
     return enableMqttClient;
 }
@@ -681,7 +682,18 @@ void mqttClientSetState(uint8_t newState)
 //----------------------------------------
 void mqttClientShutdown()
 {
+    mqttClientStartRequested = false;
     MQTT_CLIENT_STOP(true);
+}
+
+//----------------------------------------
+// Start the MQTT client
+//----------------------------------------
+void mqttClientStartEnabled()
+{
+    if (settings.debugMqttClientState)
+        systemPrintf("MQTT_Client: Start enabled\r\n");
+    mqttClientStartRequested = true;
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/MQTT_Client.ino
+++ b/Firmware/RTK_Everywhere/MQTT_Client.ino
@@ -960,8 +960,15 @@ void mqttClientUpdate()
         // Determine if the network has failed
         if (!networkIsConnected(&mqttClientPriority))
         {
+            // The connection was previously successful, allow more retries
+            // in the future
+            mqttClientConnectionAttempts = 0;
+
             // Failed to connect to the network, attempt to restart the network
             mqttClientRestart();
+
+            // Since the previous connection was successful, retry immediately
+            mqttClientConnectionAttemptTimeout = 0;
             break;
         }
 

--- a/Firmware/RTK_Everywhere/MQTT_Client.ino
+++ b/Firmware/RTK_Everywhere/MQTT_Client.ino
@@ -210,6 +210,26 @@ bool mqttClientConnectLimitReached()
 }
 
 //----------------------------------------
+// Determine if the client is connected to the services
+//----------------------------------------
+bool mqttClientIsConnected()
+{
+    if (mqttClientState == MQTT_CLIENT_SERVICES_CONNECTED)
+        return true;
+    return false;
+}
+
+//----------------------------------------
+// Return true if we are in states that require network access
+//----------------------------------------
+bool mqttClientNeedsNetwork()
+{
+    if (mqttClientState >= MQTT_CLIENT_WAIT_FOR_NETWORK && mqttClientState <= MQTT_CLIENT_SERVICES_CONNECTED)
+        return true;
+    return false;
+}
+
+//----------------------------------------
 // Print the MQTT client state summary
 //----------------------------------------
 void mqttClientPrintStateSummary()
@@ -680,16 +700,6 @@ void mqttClientStop(bool shutdown)
 }
 
 //----------------------------------------
-// Return true if we are in states that require network access
-//----------------------------------------
-bool mqttClientNeedsNetwork()
-{
-    if (mqttClientState >= MQTT_CLIENT_WAIT_FOR_NETWORK && mqttClientState <= MQTT_CLIENT_SERVICES_CONNECTED)
-        return true;
-    return false;
-}
-
-//----------------------------------------
 // Check for the arrival of any correction data. Push it to the GNSS.
 // Stop task if the connection has dropped or if we receive no data for
 // MQTT_CLIENT_RECEIVE_DATA_TIMEOUT
@@ -1068,16 +1078,6 @@ void mqttClientValidateTables()
 {
     if (mqttClientStateNameEntries != MQTT_CLIENT_STATE_MAX)
         reportFatalError("Fix mqttClientStateNameEntries to match MQTTClientState");
-}
-
-//----------------------------------------
-// Determine if the client is connected to the services
-//----------------------------------------
-bool mqttClientIsConnected()
-{
-    if (mqttClientState == MQTT_CLIENT_SERVICES_CONNECTED)
-        return true;
-    return false;
 }
 
 #endif // COMPILE_MQTT_CLIENT

--- a/Firmware/RTK_Everywhere/MQTT_Client.ino
+++ b/Firmware/RTK_Everywhere/MQTT_Client.ino
@@ -999,6 +999,8 @@ void mqttClientUpdate()
                 {
                     breakOut = true; // Break out of this state as we have successfully subscribed
                     mqttClientSubscribedTopics.push_back(topic);
+                    if (settings.debugMqttClientState)
+                        systemPrintf("MQTT_Client successfully subscribed to topic %s\r\n", topic.c_str());
                 }
                 else
                 {

--- a/Firmware/RTK_Everywhere/MQTT_Client.ino
+++ b/Firmware/RTK_Everywhere/MQTT_Client.ino
@@ -155,7 +155,9 @@ static uint32_t mqttClientTimer;
 // MQTT Client Routines
 //----------------------------------------
 
+//----------------------------------------
 // Determine if another connection is possible or if the limit has been reached
+//----------------------------------------
 bool mqttClientConnectLimitReached()
 {
     bool limitReached;
@@ -207,7 +209,9 @@ bool mqttClientConnectLimitReached()
     return limitReached;
 }
 
+//----------------------------------------
 // Print the MQTT client state summary
+//----------------------------------------
 void mqttClientPrintStateSummary()
 {
     switch (mqttClientState)
@@ -234,7 +238,9 @@ void mqttClientPrintStateSummary()
     }
 }
 
+//----------------------------------------
 // Print the MQTT Client status
+//----------------------------------------
 void mqttClientPrintStatus()
 {
     uint32_t days;
@@ -292,7 +298,9 @@ void mqttClientPrintStatus()
     }
 }
 
+//----------------------------------------
 // Called when a subscribed message arrives
+//----------------------------------------
 void mqttClientReceiveMessage(int messageSize)
 {
     // The Level 3 localized distribution dictionary topic can be up to 25KB
@@ -556,7 +564,9 @@ void mqttClientReceiveMessage(int messageSize)
     }
 }
 
+//----------------------------------------
 // Restart the MQTT client
+//----------------------------------------
 void mqttClientRestart()
 {
     // Save the previous uptime value
@@ -565,7 +575,9 @@ void mqttClientRestart()
     mqttClientConnectLimitReached();
 }
 
+//----------------------------------------
 // Update the state of the MQTT client state machine
+//----------------------------------------
 void mqttClientSetState(uint8_t newState)
 {
     if (settings.debugMqttClientState || PERIODIC_DISPLAY(PD_MQTT_CLIENT_STATE))
@@ -589,13 +601,17 @@ void mqttClientSetState(uint8_t newState)
     }
 }
 
+//----------------------------------------
 // Shutdown the MQTT client
+//----------------------------------------
 void mqttClientShutdown()
 {
     MQTT_CLIENT_STOP(true);
 }
 
+//----------------------------------------
 // Shutdown or restart the MQTT client
+//----------------------------------------
 void mqttClientStop(bool shutdown)
 {
     // Display the uptime
@@ -663,7 +679,9 @@ void mqttClientStop(bool shutdown)
         mqttClientSetState(MQTT_CLIENT_ON);
 }
 
+//----------------------------------------
 // Return true if we are in states that require network access
+//----------------------------------------
 bool mqttClientNeedsNetwork()
 {
     if (mqttClientState >= MQTT_CLIENT_WAIT_FOR_NETWORK && mqttClientState <= MQTT_CLIENT_SERVICES_CONNECTED)
@@ -671,9 +689,11 @@ bool mqttClientNeedsNetwork()
     return false;
 }
 
+//----------------------------------------
 // Check for the arrival of any correction data. Push it to the GNSS.
 // Stop task if the connection has dropped or if we receive no data for
 // MQTT_CLIENT_RECEIVE_DATA_TIMEOUT
+//----------------------------------------
 void mqttClientUpdate()
 {
     bool enableMqttClient = true;
@@ -1041,13 +1061,18 @@ void mqttClientUpdate()
         mqttClientSetState(mqttClientState);
 }
 
+//----------------------------------------
 // Verify the MQTT client tables
+//----------------------------------------
 void mqttClientValidateTables()
 {
     if (mqttClientStateNameEntries != MQTT_CLIENT_STATE_MAX)
         reportFatalError("Fix mqttClientStateNameEntries to match MQTTClientState");
 }
 
+//----------------------------------------
+// Determine if the client is connected to the services
+//----------------------------------------
 bool mqttClientIsConnected()
 {
     if (mqttClientState == MQTT_CLIENT_SERVICES_CONNECTED)

--- a/Firmware/RTK_Everywhere/MQTT_Client.ino
+++ b/Firmware/RTK_Everywhere/MQTT_Client.ino
@@ -210,6 +210,40 @@ bool mqttClientConnectLimitReached()
 }
 
 //----------------------------------------
+// Determine if the MQTT client may be enabled
+//----------------------------------------
+bool mqttClientEnabled()
+{
+    bool enableMqttClient;
+
+    do
+    {
+        enableMqttClient = false;
+
+        // MQTT requires use of point perfect corrections
+        if (settings.enablePointPerfectCorrections == false)
+            break;
+
+        // Only support MQTT clients in rover mode
+        if (NEQ_RTK_MODE(mqttClientMode))
+            break;
+
+        // For the mosaic-X5, settings.enablePointPerfectCorrections will be true if
+        // we are using the PPL and getting keys via ZTP. BUT the Facet mosaic-X5
+        // uses the L-Band (only) plan. It should not and can not subscribe to PP IP
+        // MQTT corrections. So, if present.gnss_mosaicX5 is true, set enableMqttClient
+        // to false.
+        // TODO : review this. This feels like a bit of a hack...
+        if (present.gnss_mosaicX5)
+            break;
+
+        // All conditions support running the MQTT client
+        enableMqttClient = true;
+    } while (0);
+    return enableMqttClient;
+}
+
+//----------------------------------------
 // Determine if the client is connected to the services
 //----------------------------------------
 bool mqttClientIsConnected()

--- a/Firmware/RTK_Everywhere/MQTT_Client.ino
+++ b/Firmware/RTK_Everywhere/MQTT_Client.ino
@@ -755,6 +755,7 @@ void mqttClientStop(bool shutdown)
     mqttClientDataReceived = false;
     if (shutdown)
     {
+        networkConsumerRemove(NETCONSUMER_PPL_MQTT_CLIENT, NETWORK_ANY);
         mqttClientConnectionAttempts = 0;
         mqttClientConnectionAttemptTimeout = 0;
         mqttClientSetState(MQTT_CLIENT_OFF);
@@ -792,6 +793,7 @@ void mqttClientUpdate()
             // Start the MQTT client
             if (settings.debugMqttClientState)
                 systemPrintln("MQTT Client start");
+            networkConsumerAdd(NETCONSUMER_PPL_MQTT_CLIENT, NETWORK_ANY);
             mqttClientStop(false);
         }
         break;

--- a/Firmware/RTK_Everywhere/menuPP.ino
+++ b/Firmware/RTK_Everywhere/menuPP.ino
@@ -427,6 +427,9 @@ bool checkCertificates()
         systemPrintf("Stored certificates are %svalid\r\n", validCertificates ? "" : "NOT ");
     }
 
+    // Enable MQTT once the certificates are available and valid
+    if (validCertificates)
+        mqttClientStartEnabled();
     return (validCertificates);
 }
 


### PR DESCRIPTION
MQTT_Client: Separate routines
MQTT_Client: Alphabetize routines
MQTT_Client: Add mqttClientEnabled routine
MQTT_Client: Use the mqttClientEnabled routine for consistent checks
MQTT_Client: Break up the mqttClientReceiveMessage routine
MQTT_Client: Create one place for MQTT start/stop
MQTT_Client: Enable MQTT start and stop
MQTT_Client: Use networkConsumer routines to start and stop the network
MQTT_Client: Restart immediately after connected and network failure
MQTT_Client: Add debug message upon successful subscription
