### PR TITLE
WebServer: Add new WiFi and network consumer support

### DIFF
--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -207,6 +207,7 @@ uint32_t wifiGetStartTimeout()                  {return 0;}
 int wifiNetworkCount()                          {return 0;}
 void wifiResetThrottleTimeout()                 {}
 void wifiResetTimeout()                         {}
+bool wifiSoftApOn(bool on)                      {return !on;}
 bool wifiStationOn(bool on)                     {return !on;}
 void wifiStopAll()                              {}
 

--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -80,9 +80,6 @@
 
 static QwiicCustomOLED *oled = nullptr;
 
-unsigned long ssidDisplayTimer = 0;
-bool ssidDisplayFirstHalf = false;
-
 // Fonts
 #include <res/qw_fnt_5x7.h>
 #include <res/qw_fnt_8x16.h>
@@ -3057,11 +3054,12 @@ void displayWebConfigNotStarted()
 
 void displayConfigViaWiFi()
 {
-    int yPos = WiFi_Symbol_Height + 2;
-    int fontHeight = 8;
-
     // Characters before pixels start getting cut off. 11 characters can cut off a few pixels.
     const int displayMaxCharacters = (present.display_type == DISPLAY_64x48) ? 10 : 21;
+    int fontHeight = 8;
+    static bool ssidDisplayFirstHalf;
+    static unsigned long ssidDisplayTimer;
+    int yPos = WiFi_Symbol_Height + 2;
 
     printTextCenter("SSID:", yPos, QW_FONT_5X7, 1, false); // text, y, font type, kerning, inverted
 

--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -3052,6 +3052,20 @@ void displayWebConfigNotStarted()
     displayMessage("Web Config", 0);
 }
 
+int displayEthernetIcon()
+{
+    static bool blink;
+    uint8_t xPos = (oled->getWidth() - Ethernet_Icon_Width) / 2;
+    int yPos = Ethernet_Icon_Height / 2; // yPos is 6
+
+    blink ^= 1;
+    if (ETH.linkUp() || blink)
+        displayBitmap(xPos, yPos, Ethernet_Icon_Width, Ethernet_Icon_Height, Ethernet_Icon);
+
+    yPos += Ethernet_Icon_Height * 1.5; // yPos is now 24
+    return yPos;
+}
+
 void displayConfigViaWiFi()
 {
     // Characters before pixels start getting cut off. 11 characters can cut off a few pixels.

--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -3058,7 +3058,7 @@ void displayConfigViaWiFi()
     const int displayMaxCharacters = (present.display_type == DISPLAY_64x48) ? 10 : 21;
     int fontHeight = 8;
     char myIP[20] = {'\0'};
-    char mySSID[50] = {'\0'};
+    char mySSID[SSID_LENGTH + 1] = {'\0'};
     static bool ssidDisplayFirstHalf;
     static unsigned long ssidDisplayTimer;
     int yPos = WiFi_Symbol_Height + 2;
@@ -3092,7 +3092,7 @@ void displayConfigViaWiFi()
     strcpy(mySSID, "!Compiled");
     strcpy(myIP, "0.0.0.0");
 #endif // COMPILE_WIFI
-    mySSID[sizeof(mySSID) - 1] = 0;
+    mySSID[SSID_LENGTH] = 0;
 
     // Trim SSID to a max length
     if ((strlen(mySSID) > displayMaxCharacters) && !ssidDisplayFirstHalf)

--- a/Firmware/RTK_Everywhere/Ethernet.ino
+++ b/Firmware/RTK_Everywhere/Ethernet.ino
@@ -197,7 +197,7 @@ void ethernetEvent(arduino_event_id_t event, arduino_event_info_t info)
     }
 
     // Take the network offline if necessary
-    if (networkInterfaceHasInternet(NETWORK_ETHERNET) && (event != ARDUINO_EVENT_ETH_GOT_IP))
+    if (event != ARDUINO_EVENT_ETH_GOT_IP)
     {
         networkInterfaceEventInternetLost((NetIndex_t)NETWORK_ETHERNET);
     }

--- a/Firmware/RTK_Everywhere/GNSS.h
+++ b/Firmware/RTK_Everywhere/GNSS.h
@@ -105,6 +105,18 @@ class GNSS
     //   Returns true if successfully configured and false upon failure
     virtual bool configureRover();
 
+    // Responds with the messages supported on this platform
+    // Inputs:
+    //   returnText: String to receive message names
+    // Returns message names in the returnText string
+    virtual void createMessageList(String &returnText);
+
+    // Responds with the RTCM/Base messages supported on this platform
+    // Inputs:
+    //   returnText: String to receive message names
+    // Returns message names in the returnText string
+    virtual void createMessageListBase(String &returnText);
+
     virtual void debuggingDisable();
 
     virtual void debuggingEnable();

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.h
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.h
@@ -34,7 +34,7 @@ typedef struct
 // Rate = Output once every N position fix(es).
 const lg290pMsg lgMessagesNMEA[] = {
     {"RMC", 1, 0}, {"GGA", 1, 0}, {"GSV", 1, 0}, {"GSA", 1, 0}, {"VTG", 1, 0}, {"GLL", 1, 0},
-    {"GBS", 0, 4}, {"GNS", 0, 4}, {"GST", 1, 4}, {"ZDA", 0, 4}, 
+    {"GBS", 0, 4}, {"GNS", 0, 4}, {"GST", 1, 4}, {"ZDA", 0, 4},
 };
 
 const lg290pMsg lgMessagesRTCM[] = {
@@ -161,6 +161,18 @@ class GNSS_LG290P : GNSS
     // Outputs:
     //   Returns true if successfully configured and false upon failure
     bool configureRover();
+
+    // Responds with the messages supported on this platform
+    // Inputs:
+    //   returnText: String to receive message names
+    // Returns message names in the returnText string
+    void createMessageList(String &returnText);
+
+    // Responds with the RTCM/Base messages supported on this platform
+    // Inputs:
+    //   returnText: String to receive message names
+    // Returns message names in the returnText string
+    void createMessageListBase(String &returnText);
 
     void debuggingDisable();
 

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -433,6 +433,26 @@ bool GNSS_LG290P::configureBase()
 }
 
 //----------------------------------------
+// Responds with the messages supported on this platform
+// Inputs:
+//   returnText: String to receive message names
+// Returns message names in the returnText string
+//----------------------------------------
+void GNSS_LG290P::createMessageList(String &returnText)
+{
+}
+
+//----------------------------------------
+// Responds with the RTCM/Base messages supported on this platform
+// Inputs:
+//   returnText: String to receive message names
+// Returns message names in the returnText string
+//----------------------------------------
+void GNSS_LG290P::createMessageListBase(String &returnText)
+{
+}
+
+//----------------------------------------
 // Return the survey-in mode from PQTMCFGSVIN
 // 0 - Disabled, 1 - Survey-in mode, 2 - Fixed mode
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.h
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.h
@@ -329,7 +329,7 @@ const mosaicNMEAMsg mosaicMessagesNMEA[] = {
 
 /* Do we need RTCMv2?
 
-typedef struct 
+typedef struct
 {
     const char msgName[10];
     const uint16_t defaultZCountOrInterval;
@@ -347,7 +347,7 @@ const mosaicRTCMv2Msg mosaicMessagesRTCMv2[] = {
 
     {"RTCM1", 2, true, false},  {"RTCM3", 2, true, false}, {"RTCM9", 2, true, false},
     {"RTCM16", 2, true, false}, {"RTCM17", 2, true, false},
-    {"RTCM18|19", 1, false, false}, {"RTCM20|21", 1, false, false}, 
+    {"RTCM18|19", 1, false, false}, {"RTCM20|21", 1, false, false},
     {"RTCM22", 2, true, false},  {"RTCM23|24", 2, true, false}, {"RTCM31", 2, true, false},
     {"RTCM32", 2, true, false},
 };
@@ -418,7 +418,7 @@ const mosaicRTCMv3MsgIntervalGroup mosaicRTCMv3MsgIntervalGroups[] = {
 
 #define MAX_MOSAIC_RTCM_V3_INTERVAL_GROUPS (sizeof(mosaicRTCMv3MsgIntervalGroups) / sizeof(mosaicRTCMv3MsgIntervalGroup))
 
-typedef struct 
+typedef struct
 {
     const char name[9];
     const uint8_t intervalGroup;
@@ -454,7 +454,7 @@ const mosaicRTCMv3Msg mosaicMessagesRTCMv3[] = {
     {"MSM4", MOSAIC_RTCM_V3_INTERVAL_GROUP_MSM4, true},
     {"MSM5", MOSAIC_RTCM_V3_INTERVAL_GROUP_MSM5, false},
     {"MSM6", MOSAIC_RTCM_V3_INTERVAL_GROUP_MSM6, false},
-    {"MSM7", MOSAIC_RTCM_V3_INTERVAL_GROUP_MSM7, false},    
+    {"MSM7", MOSAIC_RTCM_V3_INTERVAL_GROUP_MSM7, false},
 /*
     {"RTCM1071", MOSAIC_RTCM_V3_INTERVAL_GROUP_MSM1, false},
     {"RTCM1072", MOSAIC_RTCM_V3_INTERVAL_GROUP_MSM2, false},
@@ -558,7 +558,7 @@ class GNSS_MOSAIC : GNSS
     // Record NrBytesReceived so we can tell if Radio Ext (COM2) is receiving correction data.
     // On the mosaic, we know that InputLink will arrive at 1Hz. But on the ZED, UBX-MON-COMMS
     // is tied to the navigation rate. To keep it simple, record the last time NrBytesReceived
-    // was seen to increase and use that for corrections timeout. This is updated by the SBF 
+    // was seen to increase and use that for corrections timeout. This is updated by the SBF
     // InputLink message. isCorrRadioExtPortActive returns true if the bytes-received has
     // increased in the previous settings.correctionsSourcesLifetime_s
     uint32_t _radioExtBytesReceived_millis;
@@ -566,7 +566,7 @@ class GNSS_MOSAIC : GNSS
     // See notes at GNSS_MOSAIC::setCorrRadioExtPort
     uint32_t previousNrBytesReceived = 0;
     bool firstTimeNrBytesReceived = true;
-    
+
     // Setup the general configuration of the GNSS
     // Not Rover or Base specific (ie, baud rates)
     // Outputs:
@@ -649,6 +649,18 @@ class GNSS_MOSAIC : GNSS
     // Outputs:
     //   Returns true if successfully configured and false upon failure
     bool configureRover();
+
+    // Responds with the messages supported on this platform
+    // Inputs:
+    //   returnText: String to receive message names
+    // Returns message names in the returnText string
+    void createMessageList(String &returnText);
+
+    // Responds with the RTCM/Base messages supported on this platform
+    // Inputs:
+    //   returnText: String to receive message names
+    // Returns message names in the returnText string
+    void createMessageListBase(String &returnText);
 
     void debuggingDisable();
 

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
@@ -693,6 +693,56 @@ bool GNSS_MOSAIC::configureRover()
 }
 
 //----------------------------------------
+// Responds with the messages supported on this platform
+// Inputs:
+//   returnText: String to receive message names
+// Returns message names in the returnText string
+//----------------------------------------
+void GNSS_MOSAIC::createMessageList(String &returnText)
+{
+    for (int messageNumber = 0; messageNumber < MAX_MOSAIC_NMEA_MSG; messageNumber++)
+    {
+        returnText += "messageStreamNMEA_" + String(mosaicMessagesNMEA[messageNumber].msgTextName) + "," +
+                      String(settings.mosaicMessageStreamNMEA[messageNumber]) + ",";
+    }
+    for (int stream = 0; stream < MOSAIC_NUM_NMEA_STREAMS; stream++)
+    {
+        returnText +=
+            "streamIntervalNMEA_" + String(stream) + "," + String(settings.mosaicStreamIntervalsNMEA[stream]) + ",";
+    }
+    for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_INTERVAL_GROUPS; messageNumber++)
+    {
+        returnText += "messageIntervalRTCMRover_" + String(mosaicRTCMv3MsgIntervalGroups[messageNumber].name) +
+                      "," + String(settings.mosaicMessageIntervalsRTCMv3Rover[messageNumber]) + ",";
+    }
+    for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_MSG; messageNumber++)
+    {
+        returnText += "messageEnabledRTCMRover_" + String(mosaicMessagesRTCMv3[messageNumber].name) + "," +
+                      (settings.mosaicMessageEnabledRTCMv3Rover[messageNumber] ? "true" : "false") + ",";
+    }
+}
+
+//----------------------------------------
+// Responds with the RTCM/Base messages supported on this platform
+// Inputs:
+//   returnText: String to receive message names
+// Returns message names in the returnText string
+//----------------------------------------
+void GNSS_MOSAIC::createMessageListBase(String &returnText)
+{
+    for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_INTERVAL_GROUPS; messageNumber++)
+    {
+        returnText += "messageIntervalRTCMBase_" + String(mosaicRTCMv3MsgIntervalGroups[messageNumber].name) + "," +
+                      String(settings.mosaicMessageIntervalsRTCMv3Base[messageNumber]) + ",";
+    }
+    for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_MSG; messageNumber++)
+    {
+        returnText += "messageEnabledRTCMBase_" + String(mosaicMessagesRTCMv3[messageNumber].name) + "," +
+                      (settings.mosaicMessageEnabledRTCMv3Base[messageNumber] ? "true" : "false") + ",";
+    }
+}
+
+//----------------------------------------
 void GNSS_MOSAIC::debuggingDisable()
 {
     // TODO
@@ -2497,7 +2547,7 @@ void GNSS_MOSAIC::storeBlock4059(SEMP_PARSE_STATE *parse)
         return;
 
     uint64_t diskUsage = (diskUsageMSB * 4294967296) + diskUsageLSB;
-    
+
     sdCardSize = diskSizeMB * 1048576; // Convert to bytes
 
     sdFreeSpace = sdCardSize - diskUsage;

--- a/Firmware/RTK_Everywhere/GNSS_None.h
+++ b/Firmware/RTK_Everywhere/GNSS_None.h
@@ -101,6 +101,22 @@ class GNSS_None : public GNSS
         return false;
     }
 
+    // Responds with the messages supported on this platform
+    // Inputs:
+    //   returnText: String to receive message names
+    // Returns message names in the returnText string
+    void getMessageList(String &returnText)
+    {
+    }
+
+    // Responds with the RTCM/Base messages supported on this platform
+    // Inputs:
+    //   returnText: String to receive message names
+    // Returns message names in the returnText string
+    void getMessageListBase(String &returnText)
+    {
+    }
+
     void debuggingDisable()
     {
     }

--- a/Firmware/RTK_Everywhere/GNSS_UM980.h
+++ b/Firmware/RTK_Everywhere/GNSS_UM980.h
@@ -208,6 +208,18 @@ class GNSS_UM980 : GNSS
     //   Returns true if successfully configured and false upon failure
     bool configureRover();
 
+    // Responds with the messages supported on this platform
+    // Inputs:
+    //   returnText: String to receive message names
+    // Returns message names in the returnText string
+    void createMessageList(String &returnText);
+
+    // Responds with the RTCM/Base messages supported on this platform
+    // Inputs:
+    //   returnText: String to receive message names
+    // Returns message names in the returnText string
+    void createMessageListBase(String &returnText);
+
     void debuggingDisable();
 
     void debuggingEnable();

--- a/Firmware/RTK_Everywhere/GNSS_UM980.ino
+++ b/Firmware/RTK_Everywhere/GNSS_UM980.ino
@@ -382,6 +382,41 @@ bool GNSS_UM980::configureRover()
 }
 
 //----------------------------------------
+// Responds with the messages supported on this platform
+// Inputs:
+//   returnText: String to receive message names
+// Returns message names in the returnText string
+//----------------------------------------
+void GNSS_UM980::createMessageList(String &returnText)
+{
+    for (int messageNumber = 0; messageNumber < MAX_UM980_NMEA_MSG; messageNumber++)
+    {
+        returnText += "messageRateNMEA_" + String(umMessagesNMEA[messageNumber].msgTextName) + "," +
+                      String(settings.um980MessageRatesNMEA[messageNumber]) + ",";
+    }
+    for (int messageNumber = 0; messageNumber < MAX_UM980_RTCM_MSG; messageNumber++)
+    {
+        returnText += "messageRateRTCMRover_" + String(umMessagesRTCM[messageNumber].msgTextName) + "," +
+                      String(settings.um980MessageRatesRTCMRover[messageNumber]) + ",";
+    }
+}
+
+//----------------------------------------
+// Responds with the RTCM/Base messages supported on this platform
+// Inputs:
+//   returnText: String to receive message names
+// Returns message names in the returnText string
+//----------------------------------------
+void GNSS_UM980::createMessageListBase(String &returnText)
+{
+    for (int messageNumber = 0; messageNumber < MAX_UM980_RTCM_MSG; messageNumber++)
+    {
+        returnText += "messageRateRTCMBase_" + String(umMessagesRTCM[messageNumber].msgTextName) + "," +
+                      String(settings.um980MessageRatesRTCMBase[messageNumber]) + ",";
+    }
+}
+
+//----------------------------------------
 void GNSS_UM980::debuggingDisable()
 {
     if (online.gnss)

--- a/Firmware/RTK_Everywhere/GNSS_ZED.h
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.h
@@ -432,6 +432,18 @@ class GNSS_ZED : GNSS
     //   Returns true if successfully configured and false upon failure
     bool configureRover();
 
+    // Responds with the messages supported on this platform
+    // Inputs:
+    //   returnText: String to receive message names
+    // Returns message names in the returnText string
+    void createMessageList(String &returnText);
+
+    // Responds with the RTCM/Base messages supported on this platform
+    // Inputs:
+    //   returnText: String to receive message names
+    // Returns message names in the returnText string
+    void createMessageListBase(String &returnText);
+
     void debuggingDisable();
 
     void debuggingEnable();

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -836,6 +836,41 @@ bool GNSS_ZED::configureRover()
 }
 
 //----------------------------------------
+// Responds with the messages supported on this platform
+// Inputs:
+//   returnText: String to receive message names
+// Returns message names in the returnText string
+//----------------------------------------
+void GNSS_ZED::createMessageList(String &returnText)
+{
+    for (int messageNumber = 0; messageNumber < MAX_UBX_MSG; messageNumber++)
+    {
+        if (messageSupported(messageNumber) == true)
+            returnText += "ubxMessageRate_" + String(ubxMessages[messageNumber].msgTextName) + "," +
+                          String(settings.ubxMessageRates[messageNumber]) + ",";
+    }
+}
+
+//----------------------------------------
+// Responds with the RTCM/Base messages supported on this platform
+// Inputs:
+//   returnText: String to receive message names
+// Returns message names in the returnText string
+//----------------------------------------
+void GNSS_ZED::createMessageListBase(String &returnText)
+{
+    GNSS_ZED *zed = (GNSS_ZED *)gnss;
+    int firstRTCMRecord = zed->getMessageNumberByName("RTCM_1005");
+
+    for (int messageNumber = 0; messageNumber < MAX_UBX_MSG_RTCM; messageNumber++)
+    {
+        if (messageSupported(firstRTCMRecord + messageNumber) == true)
+            returnText += "ubxMessageRateBase_" + String(ubxMessages[messageNumber + firstRTCMRecord].msgTextName) +
+                          "," + String(settings.ubxMessageRatesBase[messageNumber]) + ","; // UBX_RTCM_1074Base,4,
+    }
+}
+
+//----------------------------------------
 void GNSS_ZED::debuggingDisable()
 {
     if (online.gnss)

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1669,19 +1669,14 @@ void networkSequenceStopPolling(NetIndex_t index, bool debug, bool forcedStop)
 //----------------------------------------
 void networkStart(NetIndex_t index, bool debug)
 {
-    NetMask_t bitMask;
-
     // Validate the index
     networkValidateIndex(index);
 
     // Only start networks that exist on the platform
     if (networkIsPresent(index) && networkConsumerCount)
     {
-        // Get the network bit
-        bitMask = (1 << index);
-
         // If a network has a start sequence, and it is not started, start it
-        if (networkInterfaceTable[index].start && (!(networkStarted & bitMask)))
+        if (networkInterfaceTable[index].start && (!networkIsStarted(index)))
         {
             if (debug)
                 systemPrintf("Starting network: %s\r\n", networkGetNameByIndex(index));

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1856,10 +1856,13 @@ void networkUpdate()
             // Attempt to restart WiFi
             if ((index == NETWORK_WIFI_STATION) && (networkIsHighestPriority(index)))
             {
-                if (settings.debugNetworkLayer)
-                    systemPrintf("Network: Calling networkStop(%s) from %s at line %d\r\n",
-                                 networkInterfaceTable[index].name, __FILE__, __LINE__);
-                networkStop(index, settings.debugWifiState);
+                if (networkIsStarted(index))
+                {
+                    if (settings.debugNetworkLayer)
+                        systemPrintf("Network: Calling networkStop(%s) from %s at line %d\r\n",
+                                     networkInterfaceTable[index].name, __FILE__, __LINE__);
+                    networkStop(index, settings.debugWifiState);
+                }
                 if (settings.debugNetworkLayer)
                 {
                     networkDisplayStatus();

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -408,9 +408,14 @@ void networkConsumerAdd(NETCONSUMER_t consumer, NetIndex_t network)
 
                         // Determine if the network has started
                         if (networkIsStarted(index) == false)
+                        {
                             // Attempt to start the highest priority network
                             // The network layer will start the lower priority networks
+                            if (settings.debugNetworkLayer)
+                                systemPrintf("Network: Calling networkStart(%s) from %s at line %d\r\n",
+                                             networkInterfaceTable[index].name, __FILE__, __LINE__);
                             networkStart(index, settings.debugNetworkLayer);
+                        }
                         break;
                     }
                 }
@@ -538,8 +543,13 @@ void networkConsumerRemove(NETCONSUMER_t consumer, NetIndex_t network)
 
                 // Verify that this interface is started
                 if (networkIsStarted(index))
+                {
                     // Attempt to stop this network interface
+                    if (settings.debugNetworkLayer)
+                        systemPrintf("Network: Calling networkStop(%s) from %s at line %d\r\n",
+                                     networkInterfaceTable[index].name, __FILE__, __LINE__);
                     networkStop(index, settings.debugNetworkLayer);
+                }
             }
 
             // Update the network priority
@@ -1053,6 +1063,9 @@ void networkInterfaceInternetConnectionLost(NetIndex_t index)
 
                 // Interface not connected to the internet
                 // Start this interface
+                if (settings.debugNetworkLayer)
+                    systemPrintf("Network: Calling networkStart(%s) from %s at line %d\r\n",
+                                 networkInterfaceTable[index].name, __FILE__, __LINE__);
                 networkStart(index, settings.debugNetworkLayer);
             }
         }
@@ -1655,6 +1668,13 @@ void networkStart(NetIndex_t index, bool debug)
             networkSequenceStart(index, debug);
         }
     }
+    else if (debug)
+    {
+        if (networkIsPresent(index))
+            systemPrintf("Network: No consumers, shutting down\r\n");
+        else
+            systemPrintf("Network: %s not present\r\n", networkInterfaceTable[index].name);
+    }
 }
 
 //----------------------------------------
@@ -1682,8 +1702,13 @@ void networkStartNextInterface(NetIndex_t index)
             if (networkIsPresent(index))
             {
                 if (((networkStarted | networkSeqStarting) & bitMask) == 0)
+                {
                     // Start this network interface
+                    if (settings.debugNetworkLayer)
+                        systemPrintf("Network: Calling networkStart(%s) from %s at line %d\r\n",
+                                     networkInterfaceTable[index].name, __FILE__, __LINE__);
                     networkStart(index, settings.debugNetworkLayer);
+                }
                 break;
             }
         }
@@ -1766,6 +1791,9 @@ void networkStartDelayed(NetIndex_t index, uintptr_t parameter, bool debug)
 
             // Only lower priority interfaces or none running
             // Start this network interface
+            if (settings.debugNetworkLayer)
+                systemPrintf("Network: Calling networkStart(%s) from %s at line %d\r\n",
+                             networkInterfaceTable[index].name, __FILE__, __LINE__);
             networkStart(index, settings.debugNetworkLayer);
         }
         else if (debug)
@@ -1813,14 +1841,28 @@ void networkUpdate()
             // Attempt to restart WiFi
             if ((index == NETWORK_WIFI_STATION) && (networkIsHighestPriority(index)))
             {
+                if (settings.debugNetworkLayer)
+                    systemPrintf("Network: Calling networkStop(%s) from %s at line %d\r\n",
+                                 networkInterfaceTable[index].name, __FILE__, __LINE__);
                 networkStop(index, settings.debugWifiState);
+                if (settings.debugNetworkLayer)
+                {
+                    networkDisplayStatus();
+                    systemPrintf("Network: Calling networkStart(%s) from %s at line %d\r\n",
+                                 networkInterfaceTable[index].name, __FILE__, __LINE__);
+                }
                 networkStart(index, settings.debugWifiState);
             }
         }
 
         // Handle the network stop event
         if (networkEventStop[index])
+        {
+            if (settings.debugNetworkLayer)
+                systemPrintf("Network: Calling networkStop(%s) from %s at line %d\r\n",
+                             networkInterfaceTable[index].name, __FILE__, __LINE__);
             networkStop(index, settings.debugNetworkLayer);
+        }
 
         // Handle the network has internet event
         if (networkEventInternetAvailable[index])
@@ -1852,6 +1894,9 @@ void networkUpdate()
             if (settings.debugNetworkLayer)
                 systemPrintln("WiFi settings changed, restarting WiFi");
 
+            if (settings.debugNetworkLayer)
+                systemPrintf("Network: Calling networkStop(%s) from %s at line %d\r\n",
+                             networkInterfaceTable[index].name, __FILE__, __LINE__);
             networkStop(NETWORK_WIFI_STATION, settings.debugNetworkLayer);
         }
     }

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -521,40 +521,33 @@ void networkConsumerRemove(NETCONSUMER_t consumer, NetIndex_t network)
         // Display the network consumers
         if (settings.debugNetworkLayer)
             networkConsumerDisplay();
-    }
-    else
-    {
-        systemPrintf("ERROR: Network consumer %s removed more than once from network %s\r\n",
-                     networkConsumerTable[consumer],
-                     networkInterfaceTable[index]);
-        reportFatalError("Network consumer removed more than once!");
-    }
 
-    // Stop the networks when the consumer count reaches zero
-    if (consumers && (networkConsumerCount == 0))
-    {
-        // Display the consumer
-        if (settings.debugNetworkLayer)
-            systemPrintf("Network: Stopping the networks\r\n");
-
-        // Walk the networks in increasing priority
-        // Turn off the lower priority networks first to eliminate failover
-        for (priority = NETWORK_MAX - 1; priority >= 0; priority -= 1)
+        // Stop the networks when the consumer count reaches zero
+        if (networkConsumerCount == 0)
         {
-            // Translate the priority into an interface index
-            index = networkIndexTable[priority];
+            // Display the consumer
+            if (settings.debugNetworkLayer)
+                systemPrintf("Network: Stopping the networks\r\n");
 
-            // Verify that this interface is started
-            if (networkIsStarted(index))
-                // Attempt to stop this network interface
-                networkStop(index, settings.debugNetworkLayer);
+            // Walk the networks in increasing priority
+            // Turn off the lower priority networks first to eliminate failover
+            for (priority = NETWORK_MAX - 1; priority >= 0; priority -= 1)
+            {
+                // Translate the priority into an interface index
+                index = networkIndexTable[priority];
+
+                // Verify that this interface is started
+                if (networkIsStarted(index))
+                    // Attempt to stop this network interface
+                    networkStop(index, settings.debugNetworkLayer);
+            }
+
+            // Update the network priority
+            networkPriority = NETWORK_OFFLINE;
+
+            // Let other tasks handle the network failure
+            delay(100);
         }
-
-        // Update the network priority
-        networkPriority = NETWORK_OFFLINE;
-
-        // Let other tasks handle the network failure
-        delay(100);
     }
 }
 

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -334,7 +334,15 @@ void networkBegin()
 #ifdef COMPILE_ETHERNET
     // Start Ethernet
     if (present.ethernet_ws5500)
+    {
         ethernetStart();
+        if (settings.debugNetworkLayer)
+            systemPrintf("Network: Calling networkStart(%s) from %s at line %d\r\n",
+                         networkInterfaceTable[index].name, __FILE__, __LINE__);
+        networkStart(NETWORK_ETHERNET, settings.enablePrintEthernetDiag);
+        if (settings.debugNetworkLayer)
+            networkDisplayStatus();
+    }
 #endif // COMPILE_ETHERNET
 
     // WiFi and cellular networks are started/stopped as consumers and come online/offline in networkUpdate()
@@ -420,6 +428,8 @@ void networkConsumerAdd(NETCONSUMER_t consumer, NetIndex_t network)
                     }
                 }
             }
+            if (settings.debugNetworkLayer)
+                networkDisplayStatus();
         }
     }
     else
@@ -991,6 +1001,10 @@ void networkInterfaceInternetConnectionAvailable(NetIndex_t index)
                 networkSequenceStop(index, settings.debugNetworkLayer);
             }
         }
+
+        // Display the interface status
+        if (settings.debugNetworkLayer)
+            networkDisplayStatus();
     }
 
     // Only start mDNS on the highest priority network
@@ -1033,7 +1047,10 @@ void networkInterfaceInternetConnectionLost(NetIndex_t index)
 
     // Display offline message
     if (settings.debugNetworkLayer)
+    {
+        networkDisplayStatus();
         systemPrintf("--------------- %s Offline ---------------\r\n", networkGetNameByIndex(index));
+    }
 
     // Did the highest priority network just fail?
     if (networkPriorityTable[index] == networkPriority)
@@ -1083,8 +1100,11 @@ void networkInterfaceInternetConnectionLost(NetIndex_t index)
 
         // Display the transition
         if (settings.debugNetworkLayer)
+        {
             systemPrintf("Default Network Interface: %s --> %s\r\n", networkGetNameByPriority(previousPriority),
                          networkGetNameByPriority(priority));
+            networkDisplayStatus();
+        }
     }
 }
 

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -369,6 +369,9 @@ bool wifiRestartRequested;      // Restart WiFi if user changes anything
 bool wifiSoftApRunning;         // False: stopped, True: starting, running, stopping
 bool wifiStationRunning;        // False: stopped, True: starting, running, stopping
 
+const char * wifiSoftApSsid = "RTK Config";
+const char * wifiSoftApPassword = nullptr;
+
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 // MQTT support

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -363,10 +363,13 @@ RTK_WIFI wifi(false);
 
 // WiFi Globals - For other module direct access
 WIFI_CHANNEL_t wifiChannel;     // Current WiFi channel number
+bool wifiEspNowOnline;          // ESP-Now started successfully
 bool wifiEspNowRunning;         // False: stopped, True: starting, running, stopping
 uint32_t wifiReconnectionTimer; // Delay before reconnection, timer running when non-zero
 bool wifiRestartRequested;      // Restart WiFi if user changes anything
+bool wifiSoftApOnline;          // WiFi soft AP started successfully
 bool wifiSoftApRunning;         // False: stopped, True: starting, running, stopping
+bool wifiStationOnline;         // WiFi station started successfully
 bool wifiStationRunning;        // False: stopped, True: starting, running, stopping
 
 const char * wifiSoftApSsid = "RTK Config";

--- a/Firmware/RTK_Everywhere/States.ino
+++ b/Firmware/RTK_Everywhere/States.ino
@@ -439,19 +439,6 @@ void stateUpdate()
             ESPNOW_STOP();    // We don't need ESP-NOW during web config
 
             // The GNSS UART task is left running to allow GNSS receivers to obtain LLh data for 1Hz page updates
-
-#ifdef COMPILE_WIFI
-            // If the AP is already running, check that the name is correct
-            if ((WiFi.getMode() == WIFI_AP) || (WiFi.getMode() == WIFI_AP_STA))
-            {
-                if (strcmp(WiFi.softAPSSID().c_str(), "RTK Config") != 0)
-                {
-                    // The AP name cannot be changed while it is running. WiFi must be restarted.
-                    wifiRestartRequested = true; // Tell network layer to restart WiFi
-                }
-            }
-#endif // COMPILE_WIFI
-
             // Stop any running NTRIP Client or Server
             ntripClientStop(true); // Do not allocate new wifiClient
             for (int serverIndex = 0; serverIndex < NTRIP_SERVER_MAX; serverIndex++)

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -1035,6 +1035,7 @@ bool webServerAssignResources(int httpPort = 80)
             systemPrintln("Web Socket Server Started");
         reportHeapNow(false);
 
+        online.webServer = true;
         return true;
     } while (0);
 
@@ -1084,6 +1085,8 @@ void webServerReleaseResources()
     do
         delay(10);
     while (task.updateWebServerTaskRunning);
+
+    online.webServer = false;
 
     webServerStopSockets();      // Release socket resources
 
@@ -1200,8 +1203,6 @@ void webServerStop()
 {
     if (webServerState != WEBSERVER_STATE_OFF)
     {
-        online.webServer = false;
-
         webServerReleaseResources(); // Release web server resources
 
         // Stop network
@@ -1261,10 +1262,7 @@ void webServerUpdate()
             systemPrintln("Assigning web server resources");
 
         if (webServerAssignResources(settings.httpPort) == true)
-        {
-            online.webServer = true;
             webServerSetState(WEBSERVER_STATE_RUNNING);
-        }
     }
     break;
 

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -1195,10 +1195,10 @@ void webServerStart()
 //----------------------------------------
 void webServerStop()
 {
-    online.webServer = false;
-
     if (webServerState != WEBSERVER_STATE_OFF)
     {
+        online.webServer = false;
+
         webServerStopSockets();      // Release socket resources
         webServerReleaseResources(); // Release web server resources
 
@@ -1209,6 +1209,9 @@ void webServerStop()
         webServerSetState(WEBSERVER_STATE_OFF);
         if (settings.debugWebServer)
             systemPrintln("Web Server: Stopped");
+
+        // Display the heap state
+        reportHeapNow(settings.debugWebServer);
     }
 }
 

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -1187,6 +1187,12 @@ void webServerStart()
 
     if (settings.debugWebServer)
         systemPrintln("Web Server: Starting");
+
+    // Start the network
+    if (settings.wifiConfigOverAP)
+        wifiSoftApOn(true);
+    else
+        networkConsumerAdd(NETCONSUMER_WEB_CONFIG, NETWORK_ANY);
     webServerSetState(WEBSERVER_STATE_WAIT_FOR_NETWORK);
 }
 
@@ -1204,6 +1210,10 @@ void webServerStop()
 
         // Stop network
         systemPrintln("Web Server releasing network request");
+        if (settings.wifiConfigOverAP)
+            wifiSoftApOn(false);
+        else
+            networkConsumerRemove(NETCONSUMER_WEB_CONFIG, NETWORK_ANY);
 
         // Stop the machine
         webServerSetState(WEBSERVER_STATE_OFF);

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -1028,11 +1028,7 @@ bool webServerAssignResources(int httpPort = 80)
         {
             if (settings.debugWebServer == true)
                 systemPrintln("Web Sockets failed to start");
-
-            webServerStopSockets();
-            webServerReleaseResources();
-
-            return (false);
+            break;
         }
 
         if (settings.debugWebServer == true)
@@ -1043,7 +1039,6 @@ bool webServerAssignResources(int httpPort = 80)
     } while (0);
 
     // Release the resources
-    webServerStopSockets();
     webServerReleaseResources();
     return false;
 }
@@ -1089,6 +1084,8 @@ void webServerReleaseResources()
     do
         delay(10);
     while (task.updateWebServerTaskRunning);
+
+    webServerStopSockets();      // Release socket resources
 
     if (webServer != nullptr)
     {
@@ -1205,7 +1202,6 @@ void webServerStop()
     {
         online.webServer = false;
 
-        webServerStopSockets();      // Release socket resources
         webServerReleaseResources(); // Release web server resources
 
         // Stop network

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -201,61 +201,7 @@ void createFirmwareVersionString(char *settingsCSV)
 void createMessageList(String &returnText)
 {
     returnText = "";
-
-    if (present.gnss_zedf9p)
-    {
-#ifdef COMPILE_ZED
-        for (int messageNumber = 0; messageNumber < MAX_UBX_MSG; messageNumber++)
-        {
-            if (messageSupported(messageNumber) == true)
-                returnText += "ubxMessageRate_" + String(ubxMessages[messageNumber].msgTextName) + "," +
-                              String(settings.ubxMessageRates[messageNumber]) + ",";
-        }
-#endif // COMPILE_ZED
-    }
-
-#ifdef COMPILE_UM980
-    else if (present.gnss_um980)
-    {
-        for (int messageNumber = 0; messageNumber < MAX_UM980_NMEA_MSG; messageNumber++)
-        {
-            returnText += "messageRateNMEA_" + String(umMessagesNMEA[messageNumber].msgTextName) + "," +
-                          String(settings.um980MessageRatesNMEA[messageNumber]) + ",";
-        }
-        for (int messageNumber = 0; messageNumber < MAX_UM980_RTCM_MSG; messageNumber++)
-        {
-            returnText += "messageRateRTCMRover_" + String(umMessagesRTCM[messageNumber].msgTextName) + "," +
-                          String(settings.um980MessageRatesRTCMRover[messageNumber]) + ",";
-        }
-    }
-#endif // COMPILE_UM980
-
-#ifdef COMPILE_MOSAICX5
-    else if (present.gnss_mosaicX5)
-    {
-        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_NMEA_MSG; messageNumber++)
-        {
-            returnText += "messageStreamNMEA_" + String(mosaicMessagesNMEA[messageNumber].msgTextName) + "," +
-                          String(settings.mosaicMessageStreamNMEA[messageNumber]) + ",";
-        }
-        for (int stream = 0; stream < MOSAIC_NUM_NMEA_STREAMS; stream++)
-        {
-            returnText +=
-                "streamIntervalNMEA_" + String(stream) + "," + String(settings.mosaicStreamIntervalsNMEA[stream]) + ",";
-        }
-        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_INTERVAL_GROUPS; messageNumber++)
-        {
-            returnText += "messageIntervalRTCMRover_" + String(mosaicRTCMv3MsgIntervalGroups[messageNumber].name) +
-                          "," + String(settings.mosaicMessageIntervalsRTCMv3Rover[messageNumber]) + ",";
-        }
-        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_MSG; messageNumber++)
-        {
-            returnText += "messageEnabledRTCMRover_" + String(mosaicMessagesRTCMv3[messageNumber].name) + "," +
-                          (settings.mosaicMessageEnabledRTCMv3Rover[messageNumber] ? "true" : "false") + ",";
-        }
-    }
-#endif // COMPILE_MOSAICX5
-
+    gnss->createMessageList(returnText);
     if (settings.debugWebServer == true)
         systemPrintf("returnText (%d bytes): %s\r\n", returnText.length(), returnText.c_str());
 }
@@ -267,49 +213,7 @@ void createMessageList(String &returnText)
 void createMessageListBase(String &returnText)
 {
     returnText = "";
-
-    if (present.gnss_zedf9p)
-    {
-#ifdef COMPILE_ZED
-        GNSS_ZED *zed = (GNSS_ZED *)gnss;
-        int firstRTCMRecord = zed->getMessageNumberByName("RTCM_1005");
-
-        for (int messageNumber = 0; messageNumber < MAX_UBX_MSG_RTCM; messageNumber++)
-        {
-            if (messageSupported(firstRTCMRecord + messageNumber) == true)
-                returnText += "ubxMessageRateBase_" + String(ubxMessages[messageNumber + firstRTCMRecord].msgTextName) +
-                              "," + String(settings.ubxMessageRatesBase[messageNumber]) + ","; // UBX_RTCM_1074Base,4,
-        }
-#endif // COMPILE_ZED
-    }
-
-#ifdef COMPILE_UM980
-    else if (present.gnss_um980)
-    {
-        for (int messageNumber = 0; messageNumber < MAX_UM980_RTCM_MSG; messageNumber++)
-        {
-            returnText += "messageRateRTCMBase_" + String(umMessagesRTCM[messageNumber].msgTextName) + "," +
-                          String(settings.um980MessageRatesRTCMBase[messageNumber]) + ",";
-        }
-    }
-#endif // COMPILE_UM980
-
-#ifdef COMPILE_MOSAICX5
-    else if (present.gnss_mosaicX5)
-    {
-        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_INTERVAL_GROUPS; messageNumber++)
-        {
-            returnText += "messageIntervalRTCMBase_" + String(mosaicRTCMv3MsgIntervalGroups[messageNumber].name) + "," +
-                          String(settings.mosaicMessageIntervalsRTCMv3Base[messageNumber]) + ",";
-        }
-        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_MSG; messageNumber++)
-        {
-            returnText += "messageEnabledRTCMBase_" + String(mosaicMessagesRTCMv3[messageNumber].name) + "," +
-                          (settings.mosaicMessageEnabledRTCMv3Base[messageNumber] ? "true" : "false") + ",";
-        }
-    }
-#endif // COMPILE_MOSAICX5
-
+    gnss->createMessageListBase(returnText);
     if (settings.debugWebServer == true)
         systemPrintf("returnText (%d bytes): %s\r\n", returnText.length(), returnText.c_str());
 }

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -47,6 +47,8 @@ bool websocketConnected = false;
 // https://github.com/mo-thunderz/Esp32WifiPart2/blob/main/Arduino/ESP32WebserverWebsocket/ESP32WebserverWebsocket.ino
 // https://www.youtube.com/watch?v=15X0WvGaVg8
 
+//----------------------------------------
+//----------------------------------------
 void sendStringToWebsocket(const char *stringToSend)
 {
     if (!websocketConnected)
@@ -83,6 +85,8 @@ void sendStringToWebsocket(const char *stringToSend)
     }
 }
 
+//----------------------------------------
+//----------------------------------------
 static esp_err_t ws_handler(httpd_req_t *req)
 {
     // Log the req, so we can reuse it for httpd_ws_send_frame
@@ -186,6 +190,8 @@ static esp_err_t ws_handler(httpd_req_t *req)
     return ret;
 }
 
+//----------------------------------------
+//----------------------------------------
 static const httpd_uri_t ws = {.uri = "/ws",
                                .method = HTTP_GET,
                                .handler = ws_handler,
@@ -194,6 +200,8 @@ static const httpd_uri_t ws = {.uri = "/ws",
                                .handle_ws_control_frames = true,
                                .supported_subprotocol = NULL};
 
+//----------------------------------------
+//----------------------------------------
 bool websocketServerStart(void)
 {
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
@@ -224,8 +232,10 @@ bool websocketServerStart(void)
     return false;
 }
 
+//----------------------------------------
 // ===== Request Handler class used to answer more complex requests =====
 // https://github.com/espressif/arduino-esp32/blob/master/libraries/WebServer/examples/WebServer/WebServer.ino
+//----------------------------------------
 class CaptiveRequestHandler : public RequestHandler
 {
   public:
@@ -271,7 +281,9 @@ class CaptiveRequestHandler : public RequestHandler
     }
 };
 
+//----------------------------------------
 // Create the web server and web sockets
+//----------------------------------------
 bool webServerAssignResources(int httpPort = 80)
 {
     do
@@ -545,7 +557,9 @@ bool webServerAssignResources(int httpPort = 80)
     return false;
 }
 
+//----------------------------------------
 // Start the Web Server state machine
+//----------------------------------------
 void webServerStart()
 {
     // Display the heap state
@@ -555,7 +569,9 @@ void webServerStart()
     webServerSetState(WEBSERVER_STATE_WAIT_FOR_NETWORK);
 }
 
+//----------------------------------------
 // Stop the web config state machine
+//----------------------------------------
 void webServerStop()
 {
     online.webServer = false;
@@ -576,7 +592,9 @@ void webServerStop()
     }
 }
 
+//----------------------------------------
 // Return true if we are in a state that requires network access
+//----------------------------------------
 bool webServerNeedsNetwork()
 {
     if (webServerState >= WEBSERVER_STATE_WAIT_FOR_NETWORK && webServerState <= WEBSERVER_STATE_RUNNING)
@@ -584,6 +602,8 @@ bool webServerNeedsNetwork()
     return false;
 }
 
+//----------------------------------------
+//----------------------------------------
 void webServerStopSockets()
 {
     websocketConnected = false;
@@ -596,7 +616,9 @@ void webServerStopSockets()
     }
 }
 
+//----------------------------------------
 // Set the next webconfig state
+//----------------------------------------
 void webServerSetState(uint8_t newState)
 {
     char string1[40];
@@ -647,7 +669,9 @@ void webServerSetState(uint8_t newState)
         reportFatalError("Invalid web config state");
 }
 
+//----------------------------------------
 // Get the webconfig state name
+//----------------------------------------
 const char *webServerGetStateName(uint8_t state, char *string)
 {
     if (state < WEBSERVER_STATE_MAX)
@@ -656,6 +680,8 @@ const char *webServerGetStateName(uint8_t state, char *string)
     return string;
 }
 
+//----------------------------------------
+//----------------------------------------
 bool webServerIsRunning()
 {
     if (webServerState == WEBSERVER_STATE_RUNNING)
@@ -663,6 +689,8 @@ bool webServerIsRunning()
     return (false);
 }
 
+//----------------------------------------
+//----------------------------------------
 void updateWebServerTask(void *e)
 {
     // Start notification
@@ -694,6 +722,8 @@ void updateWebServerTask(void *e)
     vTaskDelete(updateWebServerTaskHandle);
 }
 
+//----------------------------------------
+//----------------------------------------
 void stopWebServer()
 {
     if (task.updateWebServerTaskRunning)
@@ -724,6 +754,8 @@ void stopWebServer()
     }
 }
 
+//----------------------------------------
+//----------------------------------------
 void webServerReleaseResources()
 {
     if (task.updateWebServerTaskRunning)
@@ -754,7 +786,9 @@ void webServerReleaseResources()
     }
 }
 
+//----------------------------------------
 // State machine to handle the starting/stopping of the web server
+//----------------------------------------
 void webServerUpdate()
 {
     // Walk the state machine
@@ -811,6 +845,8 @@ void webServerUpdate()
     }
 }
 
+//----------------------------------------
+//----------------------------------------
 void notFound()
 {
     String logmessage = "notFound: Client:" + webServer->client().remoteIP().toString() + " " + webServer->uri();
@@ -818,7 +854,9 @@ void notFound()
     webServer->send(404, "text/plain", "Not found");
 }
 
+//----------------------------------------
 // Handler for firmware file downloads
+//----------------------------------------
 static void handleFileManager()
 {
     // This section does not tolerate semaphore transactions
@@ -947,7 +985,9 @@ static void handleFileManager()
     }
 }
 
+//----------------------------------------
 // Handler for firmware file upload
+//----------------------------------------
 static void handleFirmwareFileUpload()
 {
     String fileName = "";
@@ -1044,8 +1084,10 @@ static void handleFirmwareFileUpload()
     }
 }
 
+//----------------------------------------
 // Report back to the web config page with a CSV that contains the either CURRENT or
 // the latest version as obtained by the OTA state machine
+//----------------------------------------
 void createFirmwareVersionString(char *settingsCSV)
 {
     char newVersionCSV[100];
@@ -1075,7 +1117,9 @@ void createFirmwareVersionString(char *settingsCSV)
     strcat(settingsCSV, "\0");
 }
 
+//----------------------------------------
 // Create a csv string with the dynamic data to update (current coordinates, battery level, etc)
+//----------------------------------------
 void createDynamicDataString(char *settingsCSV)
 {
     settingsCSV[0] = '\0'; // Erase current settings string
@@ -1138,9 +1182,11 @@ void createDynamicDataString(char *settingsCSV)
     strcat(settingsCSV, "\0");
 }
 
+//----------------------------------------
 // Break CSV into setting constituents
 // Can't use strtok because we may have two commas next to each other, ie
 // measurementRateHz,4.00,measurementRateSec,,dynamicModel,0,
+//----------------------------------------
 bool parseIncomingSettings()
 {
     char settingName[100] = {'\0'};
@@ -1195,8 +1241,10 @@ bool parseIncomingSettings()
     return (true);
 }
 
+//----------------------------------------
 // When called, responds with the root folder list of files on SD card
 // Name and size are formatted in CSV, formatted to html by JS
+//----------------------------------------
 void getFileList(String &returnText)
 {
     returnText = "";
@@ -1254,8 +1302,10 @@ void getFileList(String &returnText)
         systemPrintf("returnText (%d bytes): %s\r\n", returnText.length(), returnText.c_str());
 }
 
+//----------------------------------------
 // When called, responds with the messages supported on this platform
 // Message name and current rate are formatted in CSV, formatted to html by JS
+//----------------------------------------
 void createMessageList(String &returnText)
 {
     returnText = "";
@@ -1318,8 +1368,10 @@ void createMessageList(String &returnText)
         systemPrintf("returnText (%d bytes): %s\r\n", returnText.length(), returnText.c_str());
 }
 
+//----------------------------------------
 // When called, responds with the RTCM/Base messages supported on this platform
 // Message name and current rate are formatted in CSV, formatted to html by JS
+//----------------------------------------
 void createMessageListBase(String &returnText)
 {
     returnText = "";
@@ -1370,8 +1422,10 @@ void createMessageListBase(String &returnText)
         systemPrintf("returnText (%d bytes): %s\r\n", returnText.length(), returnText.c_str());
 }
 
+//----------------------------------------
 // Handles uploading of user files to SD
 // https://github.com/espressif/arduino-esp32/blob/master/libraries/WebServer/examples/FSBrowser/FSBrowser.ino
+//----------------------------------------
 void handleUpload()
 {
     HTTPUpload &upload = webServer->upload();
@@ -1460,7 +1514,9 @@ void handleUpload()
     }
 }
 
+//----------------------------------------
 // Verify the web server tables
+//----------------------------------------
 void webServerVerifyTables()
 {
     if (webServerStateEntries != WEBSERVER_STATE_MAX)

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -787,7 +787,7 @@ bool webServerAssignResources(int httpPort = 80)
 
         if (!incomingSettings)
         {
-            systemPrintln("ERROR: Failed to allocate incomingSettings");
+            systemPrintln("ERROR: Web server failed to allocate incomingSettings");
             break;
         }
         memset(incomingSettings, 0, AP_CONFIG_SETTING_SIZE);
@@ -801,7 +801,7 @@ bool webServerAssignResources(int httpPort = 80)
 
         if (!settingsCSV)
         {
-            systemPrintln("ERROR: Failed to allocate settingsCSV");
+            systemPrintln("ERROR: Web server failed to allocate settingsCSV");
             break;
         }
         createSettingsString(settingsCSV);
@@ -817,7 +817,7 @@ bool webServerAssignResources(int httpPort = 80)
         webServer = new WebServer(httpPort);
         if (!webServer)
         {
-            systemPrintln("ERROR: Failed to allocate webServer");
+            systemPrintln("ERROR: Web server failed to allocate webServer");
             break;
         }
 
@@ -1020,7 +1020,7 @@ bool webServerAssignResources(int httpPort = 80)
                 &updateWebServerTaskHandle); // Task handle
 
         if (settings.debugWebServer == true)
-            systemPrintln("Web Server Started");
+            systemPrintln("Web Server: Started");
         reportHeapNow(false);
 
         // Start the web socket server on port 81 using <esp_http_server.h>
@@ -1055,7 +1055,7 @@ const char *webServerGetStateName(uint8_t state, char *string)
 {
     if (state < WEBSERVER_STATE_MAX)
         return webServerStateNames[state];
-    sprintf(string, "Unknown state (%d)", state);
+    sprintf(string, "Web Server: Unknown state (%d)", state);
     return string;
 }
 
@@ -1174,7 +1174,7 @@ void webServerSetState(uint8_t newState)
 
     // Validate the state
     if (newState >= WEBSERVER_STATE_MAX)
-        reportFatalError("Invalid web config state");
+        reportFatalError("Web Server: Invalid web config state");
 }
 
 //----------------------------------------
@@ -1185,7 +1185,8 @@ void webServerStart()
     // Display the heap state
     reportHeapNow(settings.debugWebServer);
 
-    systemPrintln("Web Server start");
+    if (settings.debugWebServer)
+        systemPrintln("Web Server: Starting");
     webServerSetState(WEBSERVER_STATE_WAIT_FOR_NETWORK);
 }
 
@@ -1195,9 +1196,6 @@ void webServerStart()
 void webServerStop()
 {
     online.webServer = false;
-
-    if (settings.debugWebServer)
-        systemPrintln("webServerStop called");
 
     if (webServerState != WEBSERVER_STATE_OFF)
     {
@@ -1209,6 +1207,8 @@ void webServerStop()
 
         // Stop the machine
         webServerSetState(WEBSERVER_STATE_OFF);
+        if (settings.debugWebServer)
+            systemPrintln("Web Server: Stopped");
     }
 }
 

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -48,191 +48,6 @@ bool websocketConnected = false;
 // https://www.youtube.com/watch?v=15X0WvGaVg8
 
 //----------------------------------------
-//----------------------------------------
-void sendStringToWebsocket(const char *stringToSend)
-{
-    if (!websocketConnected)
-    {
-        systemPrintf("sendStringToWebsocket: not connected - could not send: %s\r\n", stringToSend);
-        return;
-    }
-
-    // To send content to the webServer, we would call: webServer->sendContent(stringToSend);
-    // But here we want to send content to the websocket (wsserver)...
-
-    httpd_ws_frame_t ws_pkt;
-    memset(&ws_pkt, 0, sizeof(httpd_ws_frame_t));
-    ws_pkt.payload = (uint8_t *)stringToSend;
-    ws_pkt.len = strlen(stringToSend);
-    ws_pkt.type = HTTPD_WS_TYPE_TEXT;
-
-    // If we use httpd_ws_send_frame, it requires a req.
-    // esp_err_t ret = httpd_ws_send_frame(last_ws_req, &ws_pkt);
-    // if (ret != ESP_OK) {
-    //    ESP_LOGE(TAG, "httpd_ws_send_frame failed with %d", ret);
-    //}
-
-    // If we use httpd_ws_send_frame_async, it requires a fd.
-    esp_err_t ret = httpd_ws_send_frame_async(*wsserver, last_ws_fd, &ws_pkt);
-    if (ret != ESP_OK)
-    {
-        systemPrintf("httpd_ws_send_frame failed with %d\r\n", ret);
-    }
-    else
-    {
-        if (settings.debugWebServer == true)
-            systemPrintf("sendStringToWebsocket: %s\r\n", stringToSend);
-    }
-}
-
-//----------------------------------------
-//----------------------------------------
-static esp_err_t ws_handler(httpd_req_t *req)
-{
-    // Log the req, so we can reuse it for httpd_ws_send_frame
-    // TODO: do we need to be cleverer about this?
-    // last_ws_req = req;
-
-    if (req->method == HTTP_GET)
-    {
-        // Log the fd, so we can reuse it for httpd_ws_send_frame_async
-        // TODO: do we need to be cleverer about this?
-        last_ws_fd = httpd_req_to_sockfd(req);
-
-        if (settings.debugWebServer == true)
-            systemPrintf("Handshake done, the new ws connection was opened with fd %d\r\n", last_ws_fd);
-
-        websocketConnected = true;
-        lastDynamicDataUpdate = millis();
-        sendStringToWebsocket(settingsCSV);
-
-        return ESP_OK;
-    }
-
-    httpd_ws_frame_t ws_pkt;
-    uint8_t *buf = NULL;
-    memset(&ws_pkt, 0, sizeof(httpd_ws_frame_t));
-    ws_pkt.type = HTTPD_WS_TYPE_TEXT;
-    /* Set max_len = 0 to get the frame len */
-    esp_err_t ret = httpd_ws_recv_frame(req, &ws_pkt, 0);
-    if (ret != ESP_OK)
-    {
-        systemPrintf("httpd_ws_recv_frame failed to get frame len with %d\r\n", ret);
-        return ret;
-    }
-    if (settings.debugWebServer == true)
-        systemPrintf("frame len is %d\r\n", ws_pkt.len);
-    if (ws_pkt.len)
-    {
-        /* ws_pkt.len + 1 is for NULL termination as we are expecting a string */
-        if (online.psram == true)
-            buf = (uint8_t *)ps_malloc(ws_pkt.len + 1);
-        else
-            buf = (uint8_t *)malloc(ws_pkt.len + 1);
-
-        if (buf == NULL)
-        {
-            systemPrintln("Failed to malloc memory for buf");
-            return ESP_ERR_NO_MEM;
-        }
-        ws_pkt.payload = buf;
-        /* Set max_len = ws_pkt.len to get the frame payload */
-        ret = httpd_ws_recv_frame(req, &ws_pkt, ws_pkt.len);
-        if (ret != ESP_OK)
-        {
-            systemPrintf("httpd_ws_recv_frame failed with %d\r\n", ret);
-            free(buf);
-            return ret;
-        }
-    }
-    if (settings.debugWebServer == true)
-        systemPrintf("Packet type: %d\r\n", ws_pkt.type);
-    // HTTPD_WS_TYPE_CONTINUE   = 0x0,
-    // HTTPD_WS_TYPE_TEXT       = 0x1,
-    // HTTPD_WS_TYPE_BINARY     = 0x2,
-    // HTTPD_WS_TYPE_CLOSE      = 0x8,
-    // HTTPD_WS_TYPE_PING       = 0x9,
-    // HTTPD_WS_TYPE_PONG       = 0xA
-
-    if (ws_pkt.type == HTTPD_WS_TYPE_TEXT)
-    {
-        if (settings.debugWebServer == true)
-        {
-            systemPrintf("Got packet with message: %s\r\n", ws_pkt.payload);
-            dumpBuffer(ws_pkt.payload, ws_pkt.len);
-        }
-
-        if (currentlyParsingData == false)
-        {
-            for (int i = 0; i < ws_pkt.len; i++)
-            {
-                incomingSettings[incomingSettingsSpot++] = ws_pkt.payload[i];
-                incomingSettingsSpot %= AP_CONFIG_SETTING_SIZE;
-            }
-            timeSinceLastIncomingSetting = millis();
-        }
-        else
-        {
-            if (settings.debugWebServer == true)
-                systemPrintln("Ignoring packet due to parsing block");
-        }
-    }
-    else if (ws_pkt.type == HTTPD_WS_TYPE_CLOSE)
-    {
-        if (settings.debugWebServer == true)
-            systemPrintln("Client closed or refreshed the web page");
-
-        createSettingsString(settingsCSV);
-        websocketConnected = false;
-    }
-
-    free(buf);
-    return ret;
-}
-
-//----------------------------------------
-//----------------------------------------
-static const httpd_uri_t ws = {.uri = "/ws",
-                               .method = HTTP_GET,
-                               .handler = ws_handler,
-                               .user_ctx = NULL,
-                               .is_websocket = true,
-                               .handle_ws_control_frames = true,
-                               .supported_subprotocol = NULL};
-
-//----------------------------------------
-//----------------------------------------
-bool websocketServerStart(void)
-{
-    httpd_config_t config = HTTPD_DEFAULT_CONFIG();
-
-    // Use different ports for websocket and webServer - use port 81 for the websocket - also defined in main.js
-    config.server_port = 81;
-
-    // Increase the stack size from 4K to ~15K
-    config.stack_size = updateWebSocketStackSize;
-
-    // Start the httpd server
-    if (settings.debugWebServer == true)
-        systemPrintf("Starting wsserver on port: %d\r\n", config.server_port);
-
-    if (wsserver == nullptr)
-        wsserver = new httpd_handle_t;
-
-    if (httpd_start(wsserver, &config) == ESP_OK)
-    {
-        // Registering the ws handler
-        if (settings.debugWebServer == true)
-            systemPrintln("Registering URI handlers");
-        httpd_register_uri_handler(*wsserver, &ws);
-        return true;
-    }
-
-    systemPrintln("Error starting wsserver!");
-    return false;
-}
-
-//----------------------------------------
 // ===== Request Handler class used to answer more complex requests =====
 // https://github.com/espressif/arduino-esp32/blob/master/libraries/WebServer/examples/WebServer/WebServer.ino
 //----------------------------------------
@@ -280,6 +95,778 @@ class CaptiveRequestHandler : public RequestHandler
         return true;
     }
 };
+
+//----------------------------------------
+// Create a csv string with the dynamic data to update (current coordinates, battery level, etc)
+//----------------------------------------
+void createDynamicDataString(char *settingsCSV)
+{
+    settingsCSV[0] = '\0'; // Erase current settings string
+
+    // Current coordinates come from HPPOSLLH call back
+    stringRecord(settingsCSV, "geodeticLat", gnss->getLatitude(), haeNumberOfDecimals);
+    stringRecord(settingsCSV, "geodeticLon", gnss->getLongitude(), haeNumberOfDecimals);
+    stringRecord(settingsCSV, "geodeticAlt", gnss->getAltitude(), 3);
+
+    double ecefX = 0;
+    double ecefY = 0;
+    double ecefZ = 0;
+
+    geodeticToEcef(gnss->getLatitude(), gnss->getLongitude(), gnss->getAltitude(), &ecefX, &ecefY, &ecefZ);
+
+    stringRecord(settingsCSV, "ecefX", ecefX, 3);
+    stringRecord(settingsCSV, "ecefY", ecefY, 3);
+    stringRecord(settingsCSV, "ecefZ", ecefZ, 3);
+
+    if (online.batteryFuelGauge == false) // Product has no battery
+    {
+        stringRecord(settingsCSV, "batteryIconFileName", (char *)"src/BatteryBlank.png");
+        stringRecord(settingsCSV, "batteryPercent", (char *)" ");
+    }
+    else
+    {
+        // Determine battery icon
+        int iconLevel = 0;
+        if (batteryLevelPercent < 25)
+            iconLevel = 0;
+        else if (batteryLevelPercent < 50)
+            iconLevel = 1;
+        else if (batteryLevelPercent < 75)
+            iconLevel = 2;
+        else // batt level > 75
+            iconLevel = 3;
+
+        char batteryIconFileName[sizeof("src/Battery2_Charging.png__")]; // sizeof() includes 1 for \0 termination
+
+        if (isCharging())
+            snprintf(batteryIconFileName, sizeof(batteryIconFileName), "src/Battery%d_Charging.png", iconLevel);
+        else
+            snprintf(batteryIconFileName, sizeof(batteryIconFileName), "src/Battery%d.png", iconLevel);
+
+        stringRecord(settingsCSV, "batteryIconFileName", batteryIconFileName);
+
+        // Limit batteryLevelPercent to sane levels
+        if (batteryLevelPercent > 100)
+            batteryLevelPercent = 100;
+
+        // Determine battery percent
+        char batteryPercent[sizeof("+100%__")];
+        if (isCharging())
+            snprintf(batteryPercent, sizeof(batteryPercent), "+%d%%", batteryLevelPercent);
+        else
+            snprintf(batteryPercent, sizeof(batteryPercent), "%d%%", batteryLevelPercent);
+        stringRecord(settingsCSV, "batteryPercent", batteryPercent);
+    }
+
+    strcat(settingsCSV, "\0");
+}
+
+//----------------------------------------
+// Report back to the web config page with a CSV that contains the either CURRENT or
+// the latest version as obtained by the OTA state machine
+//----------------------------------------
+void createFirmwareVersionString(char *settingsCSV)
+{
+    char newVersionCSV[100];
+
+    settingsCSV[0] = '\0'; // Erase current settings string
+
+    // Create a string of the unit's current firmware version
+    char currentVersion[21];
+    getFirmwareVersion(currentVersion, sizeof(currentVersion), enableRCFirmware);
+
+    // Compare the unit's version against the reported version from OTA
+    if (isReportedVersionNewer(otaReportedVersion, currentVersion) == true)
+    {
+        if (settings.debugWebServer == true)
+            systemPrintln("New version detected");
+        snprintf(newVersionCSV, sizeof(newVersionCSV), "%s,", otaReportedVersion);
+    }
+    else
+    {
+        if (settings.debugWebServer == true)
+            systemPrintln("No new firmware available");
+        snprintf(newVersionCSV, sizeof(newVersionCSV), "CURRENT,");
+    }
+
+    stringRecord(settingsCSV, "newFirmwareVersion", newVersionCSV);
+
+    strcat(settingsCSV, "\0");
+}
+
+//----------------------------------------
+// When called, responds with the messages supported on this platform
+// Message name and current rate are formatted in CSV, formatted to html by JS
+//----------------------------------------
+void createMessageList(String &returnText)
+{
+    returnText = "";
+
+    if (present.gnss_zedf9p)
+    {
+#ifdef COMPILE_ZED
+        for (int messageNumber = 0; messageNumber < MAX_UBX_MSG; messageNumber++)
+        {
+            if (messageSupported(messageNumber) == true)
+                returnText += "ubxMessageRate_" + String(ubxMessages[messageNumber].msgTextName) + "," +
+                              String(settings.ubxMessageRates[messageNumber]) + ",";
+        }
+#endif // COMPILE_ZED
+    }
+
+#ifdef COMPILE_UM980
+    else if (present.gnss_um980)
+    {
+        for (int messageNumber = 0; messageNumber < MAX_UM980_NMEA_MSG; messageNumber++)
+        {
+            returnText += "messageRateNMEA_" + String(umMessagesNMEA[messageNumber].msgTextName) + "," +
+                          String(settings.um980MessageRatesNMEA[messageNumber]) + ",";
+        }
+        for (int messageNumber = 0; messageNumber < MAX_UM980_RTCM_MSG; messageNumber++)
+        {
+            returnText += "messageRateRTCMRover_" + String(umMessagesRTCM[messageNumber].msgTextName) + "," +
+                          String(settings.um980MessageRatesRTCMRover[messageNumber]) + ",";
+        }
+    }
+#endif // COMPILE_UM980
+
+#ifdef COMPILE_MOSAICX5
+    else if (present.gnss_mosaicX5)
+    {
+        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_NMEA_MSG; messageNumber++)
+        {
+            returnText += "messageStreamNMEA_" + String(mosaicMessagesNMEA[messageNumber].msgTextName) + "," +
+                          String(settings.mosaicMessageStreamNMEA[messageNumber]) + ",";
+        }
+        for (int stream = 0; stream < MOSAIC_NUM_NMEA_STREAMS; stream++)
+        {
+            returnText +=
+                "streamIntervalNMEA_" + String(stream) + "," + String(settings.mosaicStreamIntervalsNMEA[stream]) + ",";
+        }
+        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_INTERVAL_GROUPS; messageNumber++)
+        {
+            returnText += "messageIntervalRTCMRover_" + String(mosaicRTCMv3MsgIntervalGroups[messageNumber].name) +
+                          "," + String(settings.mosaicMessageIntervalsRTCMv3Rover[messageNumber]) + ",";
+        }
+        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_MSG; messageNumber++)
+        {
+            returnText += "messageEnabledRTCMRover_" + String(mosaicMessagesRTCMv3[messageNumber].name) + "," +
+                          (settings.mosaicMessageEnabledRTCMv3Rover[messageNumber] ? "true" : "false") + ",";
+        }
+    }
+#endif // COMPILE_MOSAICX5
+
+    if (settings.debugWebServer == true)
+        systemPrintf("returnText (%d bytes): %s\r\n", returnText.length(), returnText.c_str());
+}
+
+//----------------------------------------
+// When called, responds with the RTCM/Base messages supported on this platform
+// Message name and current rate are formatted in CSV, formatted to html by JS
+//----------------------------------------
+void createMessageListBase(String &returnText)
+{
+    returnText = "";
+
+    if (present.gnss_zedf9p)
+    {
+#ifdef COMPILE_ZED
+        GNSS_ZED *zed = (GNSS_ZED *)gnss;
+        int firstRTCMRecord = zed->getMessageNumberByName("RTCM_1005");
+
+        for (int messageNumber = 0; messageNumber < MAX_UBX_MSG_RTCM; messageNumber++)
+        {
+            if (messageSupported(firstRTCMRecord + messageNumber) == true)
+                returnText += "ubxMessageRateBase_" + String(ubxMessages[messageNumber + firstRTCMRecord].msgTextName) +
+                              "," + String(settings.ubxMessageRatesBase[messageNumber]) + ","; // UBX_RTCM_1074Base,4,
+        }
+#endif // COMPILE_ZED
+    }
+
+#ifdef COMPILE_UM980
+    else if (present.gnss_um980)
+    {
+        for (int messageNumber = 0; messageNumber < MAX_UM980_RTCM_MSG; messageNumber++)
+        {
+            returnText += "messageRateRTCMBase_" + String(umMessagesRTCM[messageNumber].msgTextName) + "," +
+                          String(settings.um980MessageRatesRTCMBase[messageNumber]) + ",";
+        }
+    }
+#endif // COMPILE_UM980
+
+#ifdef COMPILE_MOSAICX5
+    else if (present.gnss_mosaicX5)
+    {
+        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_INTERVAL_GROUPS; messageNumber++)
+        {
+            returnText += "messageIntervalRTCMBase_" + String(mosaicRTCMv3MsgIntervalGroups[messageNumber].name) + "," +
+                          String(settings.mosaicMessageIntervalsRTCMv3Base[messageNumber]) + ",";
+        }
+        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_MSG; messageNumber++)
+        {
+            returnText += "messageEnabledRTCMBase_" + String(mosaicMessagesRTCMv3[messageNumber].name) + "," +
+                          (settings.mosaicMessageEnabledRTCMv3Base[messageNumber] ? "true" : "false") + ",";
+        }
+    }
+#endif // COMPILE_MOSAICX5
+
+    if (settings.debugWebServer == true)
+        systemPrintf("returnText (%d bytes): %s\r\n", returnText.length(), returnText.c_str());
+}
+
+//----------------------------------------
+// When called, responds with the root folder list of files on SD card
+// Name and size are formatted in CSV, formatted to html by JS
+//----------------------------------------
+void getFileList(String &returnText)
+{
+    returnText = "";
+
+    // Update the SD Size and Free Space
+    String cardSize;
+    stringHumanReadableSize(cardSize, sdCardSize);
+    returnText += "sdSize," + cardSize + ",";
+    String freeSpace;
+    stringHumanReadableSize(freeSpace, sdFreeSpace);
+    returnText += "sdFreeSpace," + freeSpace + ",";
+
+    char fileName[50]; // Handle long file names
+
+    // Attempt to gain access to the SD card
+    if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
+    {
+        markSemaphore(FUNCTION_FILEMANAGER_UPLOAD1);
+
+        SdFile root;
+        root.open("/"); // Open root
+        SdFile file;
+        uint16_t fileCount = 0;
+
+        while (file.openNext(&root, O_READ))
+        {
+            if (file.isFile())
+            {
+                fileCount++;
+
+                file.getName(fileName, sizeof(fileName));
+
+                String fileSize;
+                stringHumanReadableSize(fileSize, file.fileSize());
+                returnText += "fmName," + String(fileName) + ",fmSize," + fileSize + ",";
+            }
+        }
+
+        root.close();
+        file.close();
+
+        xSemaphoreGive(sdCardSemaphore);
+    }
+    else
+    {
+        char semaphoreHolder[50];
+        getSemaphoreFunction(semaphoreHolder);
+
+        // This is an error because the current settings no longer match the settings
+        // on the microSD card, and will not be restored to the expected settings!
+        systemPrintf("sdCardSemaphore failed to yield, held by %s, Form.ino line %d\r\n", semaphoreHolder, __LINE__);
+    }
+
+    if (settings.debugWebServer == true)
+        systemPrintf("returnText (%d bytes): %s\r\n", returnText.length(), returnText.c_str());
+}
+
+//----------------------------------------
+// Handler for firmware file downloads
+//----------------------------------------
+static void handleFileManager()
+{
+    // This section does not tolerate semaphore transactions
+    String logmessage =
+        "handleFileManager: Client:" + webServer->client().remoteIP().toString() + " " + webServer->uri();
+
+    if (webServer->hasArg("name") && webServer->hasArg("action"))
+    {
+        String fileName = webServer->arg("name");
+        String fileAction = webServer->arg("action");
+
+        logmessage = "Client:" + webServer->client().remoteIP().toString() + " " + webServer->uri() +
+                     "?name=" + fileName + "&action=" + fileAction;
+
+        char slashFileName[60];
+        snprintf(slashFileName, sizeof(slashFileName), "/%s", fileName.c_str());
+
+        bool fileExists = sd->exists(slashFileName);
+
+        if (fileExists == false)
+        {
+            logmessage += " ERROR: file ";
+            logmessage += slashFileName;
+            logmessage += " does not exist";
+            webServer->send(400, "text/plain", "ERROR: file does not exist");
+        }
+        else
+        {
+            logmessage += " file exists";
+
+            if (fileAction == "download")
+            {
+                logmessage += " downloaded";
+
+                // This would be SO much easier with webServer->streamFile
+                // except streamFile only works with File - not SdFile...
+                // TODO: if we ever upgrade to SD from SdFat, replace this with streamFile
+
+                if (managerFileOpen == false)
+                {
+                    // Allocate the managerTempFile
+                    if (!managerTempFile)
+                    {
+                        managerTempFile = new SdFile;
+                        if (!managerTempFile)
+                        {
+                            systemPrintln("Failed to allocate managerTempFile!");
+                            return;
+                        }
+                    }
+
+                    if (managerTempFile->open(slashFileName, O_READ) == true)
+                        managerFileOpen = true;
+                    else
+                        systemPrintln("Error: File Manager failed to open file");
+                }
+                else
+                {
+                    // File is already in use. Wait your turn.
+                    webServer->send(202, "text/plain", "ERROR: File already downloading");
+                }
+
+                const size_t maxLen = 8192;
+                uint8_t *buf = new uint8_t[maxLen];
+
+                size_t dataAvailable = managerTempFile->size();
+
+                bool firstSend = true;
+
+                while (dataAvailable > 0)
+                {
+                    size_t sending;
+
+                    if (dataAvailable > maxLen)
+                    {
+                        sending = managerTempFile->read(buf, maxLen);
+                    }
+                    else
+                    {
+                        sending = managerTempFile->read(buf, dataAvailable);
+                    }
+
+                    if (firstSend) // First send?
+                    {
+                        webServer->setContentLength(dataAvailable);
+                        webServer->sendHeader("Cache-Control", "no-cache");
+                        webServer->sendHeader("Content-Disposition", "attachment; filename=" + String(fileName));
+                        webServer->sendHeader("Access-Control-Allow-Origin", "*");
+                        webServer->send(200, "application/octet-stream", "");
+                        firstSend = false;
+                    }
+
+                    webServer->sendContent((const char *)buf, sending);
+
+                    if (sending < maxLen) // Last send?
+                    {
+                        managerTempFile->close();
+
+                        managerFileOpen = false;
+
+                        sendStringToWebsocket("fmNext,1,"); // Tell browser to send next file if needed
+                    }
+
+                    dataAvailable -= sending;
+                }
+
+                delete[] buf;
+            }
+            else if (fileAction == "delete")
+            {
+                logmessage += " deleted";
+                sd->remove(slashFileName);
+                webServer->send(200, "text/plain", "Deleted File: " + fileName);
+            }
+            else
+            {
+                logmessage += " ERROR: invalid action param supplied";
+                webServer->send(400, "text/plain", "ERROR: invalid action param supplied");
+            }
+        }
+        systemPrintln(logmessage);
+    }
+    else
+    {
+        webServer->send(400, "text/plain", "ERROR: name and action params required");
+    }
+}
+
+//----------------------------------------
+// Handler for firmware file upload
+//----------------------------------------
+static void handleFirmwareFileUpload()
+{
+    String fileName = "";
+
+    HTTPUpload &upload = webServer->upload();
+
+    if (upload.status == UPLOAD_FILE_START)
+    {
+        // Check file name against valid firmware names
+        const char *BIN_EXT = "bin";
+        const char *BIN_HEADER = "RTK_Everywhere_Firmware";
+
+        fileName = upload.filename;
+
+        int fnameLen = fileName.length();
+        char fname[fnameLen + 2] = {'/'}; // Filename must start with / or VERY bad things happen on SD_MMC
+        fileName.toCharArray(&fname[1], fnameLen + 1);
+        fname[fnameLen + 1] = '\0'; // Terminate array
+
+        // Check 'bin' extension
+        if (strcmp(BIN_EXT, &fname[strlen(fname) - strlen(BIN_EXT)]) == 0)
+        {
+            // Check for 'RTK_Everywhere_Firmware' start of file name
+            if (strncmp(fname, BIN_HEADER, strlen(BIN_HEADER)) == 0)
+            {
+                // Begin update process
+                if (!Update.begin(UPDATE_SIZE_UNKNOWN))
+                {
+                    Update.printError(Serial);
+                    webServer->send(400, "text/plain", "OTA could not begin");
+                    return;
+                }
+            }
+            else
+            {
+                systemPrintf("handleFirmwareFileUpload: Unknown: %s\r\n", fname);
+                webServer->send(400, "text/html", "<b>Error:</b> Unknown file type");
+                return;
+            }
+        }
+        else
+        {
+            systemPrintf("handleFirmwareFileUpload: Unknown: %s\r\n", fname);
+            webServer->send(400, "text/html", "<b>Error:</b> Unknown file type");
+            return;
+        }
+    }
+
+    // Write chunked data to the free sketch space
+    else if (upload.status == UPLOAD_FILE_WRITE)
+    {
+        if (Update.write(upload.buf, upload.currentSize) != upload.currentSize)
+        {
+            webServer->send(400, "text/plain", "OTA could not begin");
+            return;
+        }
+        else
+        {
+            binBytesSent = upload.currentSize;
+
+            // Send an update to browser every 100k
+            if (binBytesSent - binBytesLastUpdate > 100000)
+            {
+                binBytesLastUpdate = binBytesSent;
+
+                char bytesSentMsg[100];
+                snprintf(bytesSentMsg, sizeof(bytesSentMsg), "%'d bytes sent", binBytesSent);
+
+                char statusMsg[200] = {'\0'};
+                stringRecord(statusMsg, "firmwareUploadStatus",
+                             bytesSentMsg); // Convert to "firmwareUploadMsg,11214 bytes sent,"
+
+                systemPrintf("msg: %s\r\n", statusMsg);
+                sendStringToWebsocket(statusMsg);
+            }
+        }
+    }
+
+    else if (upload.status == UPLOAD_FILE_END)
+    {
+        if (!Update.end(true))
+        {
+            Update.printError(Serial);
+            webServer->send(400, "text/plain", "Could not end OTA");
+            return;
+        }
+        else
+        {
+            sendStringToWebsocket("firmwareUploadComplete,1,");
+            systemPrintln("Firmware update complete. Restarting");
+            delay(500);
+            ESP.restart();
+        }
+    }
+}
+
+//----------------------------------------
+// Handles uploading of user files to SD
+// https://github.com/espressif/arduino-esp32/blob/master/libraries/WebServer/examples/FSBrowser/FSBrowser.ino
+//----------------------------------------
+void handleUpload()
+{
+    HTTPUpload &upload = webServer->upload();
+
+    if (upload.status == UPLOAD_FILE_START)
+    {
+        String filename = upload.filename;
+
+        String logmessage = "Upload Start: " + filename;
+
+        int fileNameLen = filename.length();
+        char tempFileName[fileNameLen + 2] = {'/'}; // Filename must start with / or VERY bad things happen on SD_MMC
+        filename.toCharArray(&tempFileName[1], fileNameLen + 1);
+        tempFileName[fileNameLen + 1] = '\0'; // Terminate array
+
+        // Allocate the managerTempFile
+        if (!managerTempFile)
+        {
+            managerTempFile = new SdFile;
+            if (!managerTempFile)
+            {
+                systemPrintln("Failed to allocate managerTempFile!");
+                return;
+            }
+        }
+
+        if (managerFileOpen == false)
+        {
+            // Attempt to gain access to the SD card
+            if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
+            {
+                markSemaphore(FUNCTION_FILEMANAGER_UPLOAD1);
+
+                if (managerTempFile->open(tempFileName, O_CREAT | O_APPEND | O_WRITE) == true)
+                    managerFileOpen = true;
+                else
+                    systemPrintln("Error: handleUpload failed to open file");
+
+                xSemaphoreGive(sdCardSemaphore);
+            }
+        }
+        else
+        {
+            // File is already in use. Wait your turn.
+            webServer->send(202, "text/plain", "ERROR: File already uploading");
+        }
+
+        systemPrintln(logmessage);
+    }
+
+    else if (upload.status == UPLOAD_FILE_WRITE)
+    {
+        // Attempt to gain access to the SD card
+        if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
+        {
+            markSemaphore(FUNCTION_FILEMANAGER_UPLOAD2);
+
+            managerTempFile->write(upload.buf, upload.currentSize); // stream the incoming chunk to the opened file
+
+            xSemaphoreGive(sdCardSemaphore);
+        }
+    }
+
+    else if (upload.status == UPLOAD_FILE_END)
+    {
+        String logmessage = "Upload Complete: " + String(upload.filename) + ", size: " + String(upload.totalSize);
+
+        // Attempt to gain access to the SD card
+        if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
+        {
+            markSemaphore(FUNCTION_FILEMANAGER_UPLOAD3);
+
+            sdUpdateFileCreateTimestamp(managerTempFile); // Update the file create time & date
+
+            managerTempFile->close();
+            managerFileOpen = false;
+
+            xSemaphoreGive(sdCardSemaphore);
+        }
+
+        systemPrintln(logmessage);
+
+        // Redirect to "/"
+        webServer->sendHeader("Location", "/");
+        webServer->send(302, "text/plain", "");
+    }
+}
+
+//----------------------------------------
+//----------------------------------------
+void notFound()
+{
+    String logmessage = "notFound: Client:" + webServer->client().remoteIP().toString() + " " + webServer->uri();
+    systemPrintln(logmessage);
+    webServer->send(404, "text/plain", "Not found");
+}
+
+//----------------------------------------
+// Break CSV into setting constituents
+// Can't use strtok because we may have two commas next to each other, ie
+// measurementRateHz,4.00,measurementRateSec,,dynamicModel,0,
+//----------------------------------------
+bool parseIncomingSettings()
+{
+    char settingName[100] = {'\0'};
+    char valueStr[150] = {'\0'}; // stationGeodetic1,ANameThatIsTooLongToBeDisplayed 40.09029479 -105.18505761 1560.089
+
+    char *commaPtr = incomingSettings;
+    char *headPtr = incomingSettings;
+
+    int counter = 0;
+    int maxAttempts = 500;
+    while (*headPtr) // Check if we've reached the end of the string
+    {
+        // Spin to first comma
+        commaPtr = strstr(headPtr, ",");
+        if (commaPtr != nullptr)
+        {
+            *commaPtr = '\0';
+            strcpy(settingName, headPtr);
+            headPtr = commaPtr + 1;
+        }
+
+        commaPtr = strstr(headPtr, ",");
+        if (commaPtr != nullptr)
+        {
+            *commaPtr = '\0';
+            strcpy(valueStr, headPtr);
+            headPtr = commaPtr + 1;
+        }
+
+        if (settings.debugWebServer == true)
+            systemPrintf("settingName: %s value: %s\r\n", settingName, valueStr);
+
+        updateSettingWithValue(false, settingName, valueStr);
+
+        // Avoid infinite loop if response is malformed
+        counter++;
+        if (counter == maxAttempts)
+        {
+            systemPrintln("Error: Incoming settings malformed.");
+            break;
+        }
+    }
+
+    if (counter < maxAttempts)
+    {
+        // Confirm receipt
+        if (settings.debugWebServer == true)
+            systemPrintln("Sending receipt confirmation of settings");
+        sendStringToWebsocket("confirmDataReceipt,1,");
+    }
+
+    return (true);
+}
+
+//----------------------------------------
+//----------------------------------------
+void sendStringToWebsocket(const char *stringToSend)
+{
+    if (!websocketConnected)
+    {
+        systemPrintf("sendStringToWebsocket: not connected - could not send: %s\r\n", stringToSend);
+        return;
+    }
+
+    // To send content to the webServer, we would call: webServer->sendContent(stringToSend);
+    // But here we want to send content to the websocket (wsserver)...
+
+    httpd_ws_frame_t ws_pkt;
+    memset(&ws_pkt, 0, sizeof(httpd_ws_frame_t));
+    ws_pkt.payload = (uint8_t *)stringToSend;
+    ws_pkt.len = strlen(stringToSend);
+    ws_pkt.type = HTTPD_WS_TYPE_TEXT;
+
+    // If we use httpd_ws_send_frame, it requires a req.
+    // esp_err_t ret = httpd_ws_send_frame(last_ws_req, &ws_pkt);
+    // if (ret != ESP_OK) {
+    //    ESP_LOGE(TAG, "httpd_ws_send_frame failed with %d", ret);
+    //}
+
+    // If we use httpd_ws_send_frame_async, it requires a fd.
+    esp_err_t ret = httpd_ws_send_frame_async(*wsserver, last_ws_fd, &ws_pkt);
+    if (ret != ESP_OK)
+    {
+        systemPrintf("httpd_ws_send_frame failed with %d\r\n", ret);
+    }
+    else
+    {
+        if (settings.debugWebServer == true)
+            systemPrintf("sendStringToWebsocket: %s\r\n", stringToSend);
+    }
+}
+
+//----------------------------------------
+//----------------------------------------
+void stopWebServer()
+{
+    if (task.updateWebServerTaskRunning)
+        task.updateWebServerTaskStopRequest = true;
+
+    // Wait for task to stop running
+    do
+        delay(10);
+    while (task.updateWebServerTaskRunning);
+
+    if (webServer != nullptr)
+    {
+        webServer->close();
+        free(webServer);
+        webServer = nullptr;
+    }
+
+    if (settingsCSV != nullptr)
+    {
+        free(settingsCSV);
+        settingsCSV = nullptr;
+    }
+
+    if (incomingSettings != nullptr)
+    {
+        free(incomingSettings);
+        incomingSettings = nullptr;
+    }
+}
+
+//----------------------------------------
+//----------------------------------------
+void updateWebServerTask(void *e)
+{
+    // Start notification
+    task.updateWebServerTaskRunning = true;
+    if (settings.printTaskStartStop)
+        systemPrintln("Task updateWebServerTask started");
+
+    // Verify that the task is still running
+    task.updateWebServerTaskStopRequest = false;
+    while (task.updateWebServerTaskStopRequest == false)
+    {
+        // Display an alive message
+        if (PERIODIC_DISPLAY(PD_TASK_UPDATE_WEBSERVER))
+        {
+            PERIODIC_CLEAR(PD_TASK_UPDATE_WEBSERVER);
+            systemPrintln("updateWebServerTask running");
+        }
+
+        webServer->handleClient();
+
+        feedWdt();
+        taskYIELD();
+    }
+
+    // Stop notification
+    if (settings.printTaskStartStop)
+        systemPrintln("Task updateWebServerTask stopped");
+    task.updateWebServerTaskRunning = false;
+    vTaskDelete(updateWebServerTaskHandle);
+}
 
 //----------------------------------------
 // Create the web server and web sockets
@@ -558,38 +1145,23 @@ bool webServerAssignResources(int httpPort = 80)
 }
 
 //----------------------------------------
-// Start the Web Server state machine
+// Get the webconfig state name
 //----------------------------------------
-void webServerStart()
+const char *webServerGetStateName(uint8_t state, char *string)
 {
-    // Display the heap state
-    reportHeapNow(settings.debugWebServer);
-
-    systemPrintln("Web Server start");
-    webServerSetState(WEBSERVER_STATE_WAIT_FOR_NETWORK);
+    if (state < WEBSERVER_STATE_MAX)
+        return webServerStateNames[state];
+    sprintf(string, "Unknown state (%d)", state);
+    return string;
 }
 
 //----------------------------------------
-// Stop the web config state machine
 //----------------------------------------
-void webServerStop()
+bool webServerIsRunning()
 {
-    online.webServer = false;
-
-    if (settings.debugWebServer)
-        systemPrintln("webServerStop called");
-
-    if (webServerState != WEBSERVER_STATE_OFF)
-    {
-        webServerStopSockets();      // Release socket resources
-        webServerReleaseResources(); // Release web server resources
-
-        // Stop network
-        systemPrintln("Web Server releasing network request");
-
-        // Stop the machine
-        webServerSetState(WEBSERVER_STATE_OFF);
-    }
+    if (webServerState == WEBSERVER_STATE_RUNNING)
+        return (true);
+    return (false);
 }
 
 //----------------------------------------
@@ -600,6 +1172,38 @@ bool webServerNeedsNetwork()
     if (webServerState >= WEBSERVER_STATE_WAIT_FOR_NETWORK && webServerState <= WEBSERVER_STATE_RUNNING)
         return true;
     return false;
+}
+
+//----------------------------------------
+//----------------------------------------
+void webServerReleaseResources()
+{
+    if (task.updateWebServerTaskRunning)
+        task.updateWebServerTaskStopRequest = true;
+
+    // Wait for task to stop running
+    do
+        delay(10);
+    while (task.updateWebServerTaskRunning);
+
+    if (webServer != nullptr)
+    {
+        webServer->close();
+        free(webServer);
+        webServer = nullptr;
+    }
+
+    if (settingsCSV != nullptr)
+    {
+        free(settingsCSV);
+        settingsCSV = nullptr;
+    }
+
+    if (incomingSettings != nullptr)
+    {
+        free(incomingSettings);
+        incomingSettings = nullptr;
+    }
 }
 
 //----------------------------------------
@@ -670,119 +1274,37 @@ void webServerSetState(uint8_t newState)
 }
 
 //----------------------------------------
-// Get the webconfig state name
+// Start the Web Server state machine
 //----------------------------------------
-const char *webServerGetStateName(uint8_t state, char *string)
+void webServerStart()
 {
-    if (state < WEBSERVER_STATE_MAX)
-        return webServerStateNames[state];
-    sprintf(string, "Unknown state (%d)", state);
-    return string;
+    // Display the heap state
+    reportHeapNow(settings.debugWebServer);
+
+    systemPrintln("Web Server start");
+    webServerSetState(WEBSERVER_STATE_WAIT_FOR_NETWORK);
 }
 
 //----------------------------------------
+// Stop the web config state machine
 //----------------------------------------
-bool webServerIsRunning()
+void webServerStop()
 {
-    if (webServerState == WEBSERVER_STATE_RUNNING)
-        return (true);
-    return (false);
-}
+    online.webServer = false;
 
-//----------------------------------------
-//----------------------------------------
-void updateWebServerTask(void *e)
-{
-    // Start notification
-    task.updateWebServerTaskRunning = true;
-    if (settings.printTaskStartStop)
-        systemPrintln("Task updateWebServerTask started");
+    if (settings.debugWebServer)
+        systemPrintln("webServerStop called");
 
-    // Verify that the task is still running
-    task.updateWebServerTaskStopRequest = false;
-    while (task.updateWebServerTaskStopRequest == false)
+    if (webServerState != WEBSERVER_STATE_OFF)
     {
-        // Display an alive message
-        if (PERIODIC_DISPLAY(PD_TASK_UPDATE_WEBSERVER))
-        {
-            PERIODIC_CLEAR(PD_TASK_UPDATE_WEBSERVER);
-            systemPrintln("updateWebServerTask running");
-        }
+        webServerStopSockets();      // Release socket resources
+        webServerReleaseResources(); // Release web server resources
 
-        webServer->handleClient();
+        // Stop network
+        systemPrintln("Web Server releasing network request");
 
-        feedWdt();
-        taskYIELD();
-    }
-
-    // Stop notification
-    if (settings.printTaskStartStop)
-        systemPrintln("Task updateWebServerTask stopped");
-    task.updateWebServerTaskRunning = false;
-    vTaskDelete(updateWebServerTaskHandle);
-}
-
-//----------------------------------------
-//----------------------------------------
-void stopWebServer()
-{
-    if (task.updateWebServerTaskRunning)
-        task.updateWebServerTaskStopRequest = true;
-
-    // Wait for task to stop running
-    do
-        delay(10);
-    while (task.updateWebServerTaskRunning);
-
-    if (webServer != nullptr)
-    {
-        webServer->close();
-        free(webServer);
-        webServer = nullptr;
-    }
-
-    if (settingsCSV != nullptr)
-    {
-        free(settingsCSV);
-        settingsCSV = nullptr;
-    }
-
-    if (incomingSettings != nullptr)
-    {
-        free(incomingSettings);
-        incomingSettings = nullptr;
-    }
-}
-
-//----------------------------------------
-//----------------------------------------
-void webServerReleaseResources()
-{
-    if (task.updateWebServerTaskRunning)
-        task.updateWebServerTaskStopRequest = true;
-
-    // Wait for task to stop running
-    do
-        delay(10);
-    while (task.updateWebServerTaskRunning);
-
-    if (webServer != nullptr)
-    {
-        webServer->close();
-        free(webServer);
-        webServer = nullptr;
-    }
-
-    if (settingsCSV != nullptr)
-    {
-        free(settingsCSV);
-        settingsCSV = nullptr;
-    }
-
-    if (incomingSettings != nullptr)
-    {
-        free(incomingSettings);
-        incomingSettings = nullptr;
+        // Stop the machine
+        webServerSetState(WEBSERVER_STATE_OFF);
     }
 }
 
@@ -846,681 +1368,159 @@ void webServerUpdate()
 }
 
 //----------------------------------------
-//----------------------------------------
-void notFound()
-{
-    String logmessage = "notFound: Client:" + webServer->client().remoteIP().toString() + " " + webServer->uri();
-    systemPrintln(logmessage);
-    webServer->send(404, "text/plain", "Not found");
-}
-
-//----------------------------------------
-// Handler for firmware file downloads
-//----------------------------------------
-static void handleFileManager()
-{
-    // This section does not tolerate semaphore transactions
-    String logmessage =
-        "handleFileManager: Client:" + webServer->client().remoteIP().toString() + " " + webServer->uri();
-
-    if (webServer->hasArg("name") && webServer->hasArg("action"))
-    {
-        String fileName = webServer->arg("name");
-        String fileAction = webServer->arg("action");
-
-        logmessage = "Client:" + webServer->client().remoteIP().toString() + " " + webServer->uri() +
-                     "?name=" + fileName + "&action=" + fileAction;
-
-        char slashFileName[60];
-        snprintf(slashFileName, sizeof(slashFileName), "/%s", fileName.c_str());
-
-        bool fileExists = sd->exists(slashFileName);
-
-        if (fileExists == false)
-        {
-            logmessage += " ERROR: file ";
-            logmessage += slashFileName;
-            logmessage += " does not exist";
-            webServer->send(400, "text/plain", "ERROR: file does not exist");
-        }
-        else
-        {
-            logmessage += " file exists";
-
-            if (fileAction == "download")
-            {
-                logmessage += " downloaded";
-
-                // This would be SO much easier with webServer->streamFile
-                // except streamFile only works with File - not SdFile...
-                // TODO: if we ever upgrade to SD from SdFat, replace this with streamFile
-
-                if (managerFileOpen == false)
-                {
-                    // Allocate the managerTempFile
-                    if (!managerTempFile)
-                    {
-                        managerTempFile = new SdFile;
-                        if (!managerTempFile)
-                        {
-                            systemPrintln("Failed to allocate managerTempFile!");
-                            return;
-                        }
-                    }
-
-                    if (managerTempFile->open(slashFileName, O_READ) == true)
-                        managerFileOpen = true;
-                    else
-                        systemPrintln("Error: File Manager failed to open file");
-                }
-                else
-                {
-                    // File is already in use. Wait your turn.
-                    webServer->send(202, "text/plain", "ERROR: File already downloading");
-                }
-
-                const size_t maxLen = 8192;
-                uint8_t *buf = new uint8_t[maxLen];
-
-                size_t dataAvailable = managerTempFile->size();
-
-                bool firstSend = true;
-
-                while (dataAvailable > 0)
-                {
-                    size_t sending;
-
-                    if (dataAvailable > maxLen)
-                    {
-                        sending = managerTempFile->read(buf, maxLen);
-                    }
-                    else
-                    {
-                        sending = managerTempFile->read(buf, dataAvailable);
-                    }
-
-                    if (firstSend) // First send?
-                    {
-                        webServer->setContentLength(dataAvailable);
-                        webServer->sendHeader("Cache-Control", "no-cache");
-                        webServer->sendHeader("Content-Disposition", "attachment; filename=" + String(fileName));
-                        webServer->sendHeader("Access-Control-Allow-Origin", "*");
-                        webServer->send(200, "application/octet-stream", "");
-                        firstSend = false;
-                    }
-
-                    webServer->sendContent((const char *)buf, sending);
-
-                    if (sending < maxLen) // Last send?
-                    {
-                        managerTempFile->close();
-
-                        managerFileOpen = false;
-
-                        sendStringToWebsocket("fmNext,1,"); // Tell browser to send next file if needed
-                    }
-
-                    dataAvailable -= sending;
-                }
-
-                delete[] buf;
-            }
-            else if (fileAction == "delete")
-            {
-                logmessage += " deleted";
-                sd->remove(slashFileName);
-                webServer->send(200, "text/plain", "Deleted File: " + fileName);
-            }
-            else
-            {
-                logmessage += " ERROR: invalid action param supplied";
-                webServer->send(400, "text/plain", "ERROR: invalid action param supplied");
-            }
-        }
-        systemPrintln(logmessage);
-    }
-    else
-    {
-        webServer->send(400, "text/plain", "ERROR: name and action params required");
-    }
-}
-
-//----------------------------------------
-// Handler for firmware file upload
-//----------------------------------------
-static void handleFirmwareFileUpload()
-{
-    String fileName = "";
-
-    HTTPUpload &upload = webServer->upload();
-
-    if (upload.status == UPLOAD_FILE_START)
-    {
-        // Check file name against valid firmware names
-        const char *BIN_EXT = "bin";
-        const char *BIN_HEADER = "RTK_Everywhere_Firmware";
-
-        fileName = upload.filename;
-
-        int fnameLen = fileName.length();
-        char fname[fnameLen + 2] = {'/'}; // Filename must start with / or VERY bad things happen on SD_MMC
-        fileName.toCharArray(&fname[1], fnameLen + 1);
-        fname[fnameLen + 1] = '\0'; // Terminate array
-
-        // Check 'bin' extension
-        if (strcmp(BIN_EXT, &fname[strlen(fname) - strlen(BIN_EXT)]) == 0)
-        {
-            // Check for 'RTK_Everywhere_Firmware' start of file name
-            if (strncmp(fname, BIN_HEADER, strlen(BIN_HEADER)) == 0)
-            {
-                // Begin update process
-                if (!Update.begin(UPDATE_SIZE_UNKNOWN))
-                {
-                    Update.printError(Serial);
-                    webServer->send(400, "text/plain", "OTA could not begin");
-                    return;
-                }
-            }
-            else
-            {
-                systemPrintf("handleFirmwareFileUpload: Unknown: %s\r\n", fname);
-                webServer->send(400, "text/html", "<b>Error:</b> Unknown file type");
-                return;
-            }
-        }
-        else
-        {
-            systemPrintf("handleFirmwareFileUpload: Unknown: %s\r\n", fname);
-            webServer->send(400, "text/html", "<b>Error:</b> Unknown file type");
-            return;
-        }
-    }
-
-    // Write chunked data to the free sketch space
-    else if (upload.status == UPLOAD_FILE_WRITE)
-    {
-        if (Update.write(upload.buf, upload.currentSize) != upload.currentSize)
-        {
-            webServer->send(400, "text/plain", "OTA could not begin");
-            return;
-        }
-        else
-        {
-            binBytesSent = upload.currentSize;
-
-            // Send an update to browser every 100k
-            if (binBytesSent - binBytesLastUpdate > 100000)
-            {
-                binBytesLastUpdate = binBytesSent;
-
-                char bytesSentMsg[100];
-                snprintf(bytesSentMsg, sizeof(bytesSentMsg), "%'d bytes sent", binBytesSent);
-
-                char statusMsg[200] = {'\0'};
-                stringRecord(statusMsg, "firmwareUploadStatus",
-                             bytesSentMsg); // Convert to "firmwareUploadMsg,11214 bytes sent,"
-
-                systemPrintf("msg: %s\r\n", statusMsg);
-                sendStringToWebsocket(statusMsg);
-            }
-        }
-    }
-
-    else if (upload.status == UPLOAD_FILE_END)
-    {
-        if (!Update.end(true))
-        {
-            Update.printError(Serial);
-            webServer->send(400, "text/plain", "Could not end OTA");
-            return;
-        }
-        else
-        {
-            sendStringToWebsocket("firmwareUploadComplete,1,");
-            systemPrintln("Firmware update complete. Restarting");
-            delay(500);
-            ESP.restart();
-        }
-    }
-}
-
-//----------------------------------------
-// Report back to the web config page with a CSV that contains the either CURRENT or
-// the latest version as obtained by the OTA state machine
-//----------------------------------------
-void createFirmwareVersionString(char *settingsCSV)
-{
-    char newVersionCSV[100];
-
-    settingsCSV[0] = '\0'; // Erase current settings string
-
-    // Create a string of the unit's current firmware version
-    char currentVersion[21];
-    getFirmwareVersion(currentVersion, sizeof(currentVersion), enableRCFirmware);
-
-    // Compare the unit's version against the reported version from OTA
-    if (isReportedVersionNewer(otaReportedVersion, currentVersion) == true)
-    {
-        if (settings.debugWebServer == true)
-            systemPrintln("New version detected");
-        snprintf(newVersionCSV, sizeof(newVersionCSV), "%s,", otaReportedVersion);
-    }
-    else
-    {
-        if (settings.debugWebServer == true)
-            systemPrintln("No new firmware available");
-        snprintf(newVersionCSV, sizeof(newVersionCSV), "CURRENT,");
-    }
-
-    stringRecord(settingsCSV, "newFirmwareVersion", newVersionCSV);
-
-    strcat(settingsCSV, "\0");
-}
-
-//----------------------------------------
-// Create a csv string with the dynamic data to update (current coordinates, battery level, etc)
-//----------------------------------------
-void createDynamicDataString(char *settingsCSV)
-{
-    settingsCSV[0] = '\0'; // Erase current settings string
-
-    // Current coordinates come from HPPOSLLH call back
-    stringRecord(settingsCSV, "geodeticLat", gnss->getLatitude(), haeNumberOfDecimals);
-    stringRecord(settingsCSV, "geodeticLon", gnss->getLongitude(), haeNumberOfDecimals);
-    stringRecord(settingsCSV, "geodeticAlt", gnss->getAltitude(), 3);
-
-    double ecefX = 0;
-    double ecefY = 0;
-    double ecefZ = 0;
-
-    geodeticToEcef(gnss->getLatitude(), gnss->getLongitude(), gnss->getAltitude(), &ecefX, &ecefY, &ecefZ);
-
-    stringRecord(settingsCSV, "ecefX", ecefX, 3);
-    stringRecord(settingsCSV, "ecefY", ecefY, 3);
-    stringRecord(settingsCSV, "ecefZ", ecefZ, 3);
-
-    if (online.batteryFuelGauge == false) // Product has no battery
-    {
-        stringRecord(settingsCSV, "batteryIconFileName", (char *)"src/BatteryBlank.png");
-        stringRecord(settingsCSV, "batteryPercent", (char *)" ");
-    }
-    else
-    {
-        // Determine battery icon
-        int iconLevel = 0;
-        if (batteryLevelPercent < 25)
-            iconLevel = 0;
-        else if (batteryLevelPercent < 50)
-            iconLevel = 1;
-        else if (batteryLevelPercent < 75)
-            iconLevel = 2;
-        else // batt level > 75
-            iconLevel = 3;
-
-        char batteryIconFileName[sizeof("src/Battery2_Charging.png__")]; // sizeof() includes 1 for \0 termination
-
-        if (isCharging())
-            snprintf(batteryIconFileName, sizeof(batteryIconFileName), "src/Battery%d_Charging.png", iconLevel);
-        else
-            snprintf(batteryIconFileName, sizeof(batteryIconFileName), "src/Battery%d.png", iconLevel);
-
-        stringRecord(settingsCSV, "batteryIconFileName", batteryIconFileName);
-
-        // Limit batteryLevelPercent to sane levels
-        if (batteryLevelPercent > 100)
-            batteryLevelPercent = 100;
-
-        // Determine battery percent
-        char batteryPercent[sizeof("+100%__")];
-        if (isCharging())
-            snprintf(batteryPercent, sizeof(batteryPercent), "+%d%%", batteryLevelPercent);
-        else
-            snprintf(batteryPercent, sizeof(batteryPercent), "%d%%", batteryLevelPercent);
-        stringRecord(settingsCSV, "batteryPercent", batteryPercent);
-    }
-
-    strcat(settingsCSV, "\0");
-}
-
-//----------------------------------------
-// Break CSV into setting constituents
-// Can't use strtok because we may have two commas next to each other, ie
-// measurementRateHz,4.00,measurementRateSec,,dynamicModel,0,
-//----------------------------------------
-bool parseIncomingSettings()
-{
-    char settingName[100] = {'\0'};
-    char valueStr[150] = {'\0'}; // stationGeodetic1,ANameThatIsTooLongToBeDisplayed 40.09029479 -105.18505761 1560.089
-
-    char *commaPtr = incomingSettings;
-    char *headPtr = incomingSettings;
-
-    int counter = 0;
-    int maxAttempts = 500;
-    while (*headPtr) // Check if we've reached the end of the string
-    {
-        // Spin to first comma
-        commaPtr = strstr(headPtr, ",");
-        if (commaPtr != nullptr)
-        {
-            *commaPtr = '\0';
-            strcpy(settingName, headPtr);
-            headPtr = commaPtr + 1;
-        }
-
-        commaPtr = strstr(headPtr, ",");
-        if (commaPtr != nullptr)
-        {
-            *commaPtr = '\0';
-            strcpy(valueStr, headPtr);
-            headPtr = commaPtr + 1;
-        }
-
-        if (settings.debugWebServer == true)
-            systemPrintf("settingName: %s value: %s\r\n", settingName, valueStr);
-
-        updateSettingWithValue(false, settingName, valueStr);
-
-        // Avoid infinite loop if response is malformed
-        counter++;
-        if (counter == maxAttempts)
-        {
-            systemPrintln("Error: Incoming settings malformed.");
-            break;
-        }
-    }
-
-    if (counter < maxAttempts)
-    {
-        // Confirm receipt
-        if (settings.debugWebServer == true)
-            systemPrintln("Sending receipt confirmation of settings");
-        sendStringToWebsocket("confirmDataReceipt,1,");
-    }
-
-    return (true);
-}
-
-//----------------------------------------
-// When called, responds with the root folder list of files on SD card
-// Name and size are formatted in CSV, formatted to html by JS
-//----------------------------------------
-void getFileList(String &returnText)
-{
-    returnText = "";
-
-    // Update the SD Size and Free Space
-    String cardSize;
-    stringHumanReadableSize(cardSize, sdCardSize);
-    returnText += "sdSize," + cardSize + ",";
-    String freeSpace;
-    stringHumanReadableSize(freeSpace, sdFreeSpace);
-    returnText += "sdFreeSpace," + freeSpace + ",";
-
-    char fileName[50]; // Handle long file names
-
-    // Attempt to gain access to the SD card
-    if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
-    {
-        markSemaphore(FUNCTION_FILEMANAGER_UPLOAD1);
-
-        SdFile root;
-        root.open("/"); // Open root
-        SdFile file;
-        uint16_t fileCount = 0;
-
-        while (file.openNext(&root, O_READ))
-        {
-            if (file.isFile())
-            {
-                fileCount++;
-
-                file.getName(fileName, sizeof(fileName));
-
-                String fileSize;
-                stringHumanReadableSize(fileSize, file.fileSize());
-                returnText += "fmName," + String(fileName) + ",fmSize," + fileSize + ",";
-            }
-        }
-
-        root.close();
-        file.close();
-
-        xSemaphoreGive(sdCardSemaphore);
-    }
-    else
-    {
-        char semaphoreHolder[50];
-        getSemaphoreFunction(semaphoreHolder);
-
-        // This is an error because the current settings no longer match the settings
-        // on the microSD card, and will not be restored to the expected settings!
-        systemPrintf("sdCardSemaphore failed to yield, held by %s, Form.ino line %d\r\n", semaphoreHolder, __LINE__);
-    }
-
-    if (settings.debugWebServer == true)
-        systemPrintf("returnText (%d bytes): %s\r\n", returnText.length(), returnText.c_str());
-}
-
-//----------------------------------------
-// When called, responds with the messages supported on this platform
-// Message name and current rate are formatted in CSV, formatted to html by JS
-//----------------------------------------
-void createMessageList(String &returnText)
-{
-    returnText = "";
-
-    if (present.gnss_zedf9p)
-    {
-#ifdef COMPILE_ZED
-        for (int messageNumber = 0; messageNumber < MAX_UBX_MSG; messageNumber++)
-        {
-            if (messageSupported(messageNumber) == true)
-                returnText += "ubxMessageRate_" + String(ubxMessages[messageNumber].msgTextName) + "," +
-                              String(settings.ubxMessageRates[messageNumber]) + ",";
-        }
-#endif // COMPILE_ZED
-    }
-
-#ifdef COMPILE_UM980
-    else if (present.gnss_um980)
-    {
-        for (int messageNumber = 0; messageNumber < MAX_UM980_NMEA_MSG; messageNumber++)
-        {
-            returnText += "messageRateNMEA_" + String(umMessagesNMEA[messageNumber].msgTextName) + "," +
-                          String(settings.um980MessageRatesNMEA[messageNumber]) + ",";
-        }
-        for (int messageNumber = 0; messageNumber < MAX_UM980_RTCM_MSG; messageNumber++)
-        {
-            returnText += "messageRateRTCMRover_" + String(umMessagesRTCM[messageNumber].msgTextName) + "," +
-                          String(settings.um980MessageRatesRTCMRover[messageNumber]) + ",";
-        }
-    }
-#endif // COMPILE_UM980
-
-#ifdef COMPILE_MOSAICX5
-    else if (present.gnss_mosaicX5)
-    {
-        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_NMEA_MSG; messageNumber++)
-        {
-            returnText += "messageStreamNMEA_" + String(mosaicMessagesNMEA[messageNumber].msgTextName) + "," +
-                          String(settings.mosaicMessageStreamNMEA[messageNumber]) + ",";
-        }
-        for (int stream = 0; stream < MOSAIC_NUM_NMEA_STREAMS; stream++)
-        {
-            returnText +=
-                "streamIntervalNMEA_" + String(stream) + "," + String(settings.mosaicStreamIntervalsNMEA[stream]) + ",";
-        }
-        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_INTERVAL_GROUPS; messageNumber++)
-        {
-            returnText += "messageIntervalRTCMRover_" + String(mosaicRTCMv3MsgIntervalGroups[messageNumber].name) +
-                          "," + String(settings.mosaicMessageIntervalsRTCMv3Rover[messageNumber]) + ",";
-        }
-        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_MSG; messageNumber++)
-        {
-            returnText += "messageEnabledRTCMRover_" + String(mosaicMessagesRTCMv3[messageNumber].name) + "," +
-                          (settings.mosaicMessageEnabledRTCMv3Rover[messageNumber] ? "true" : "false") + ",";
-        }
-    }
-#endif // COMPILE_MOSAICX5
-
-    if (settings.debugWebServer == true)
-        systemPrintf("returnText (%d bytes): %s\r\n", returnText.length(), returnText.c_str());
-}
-
-//----------------------------------------
-// When called, responds with the RTCM/Base messages supported on this platform
-// Message name and current rate are formatted in CSV, formatted to html by JS
-//----------------------------------------
-void createMessageListBase(String &returnText)
-{
-    returnText = "";
-
-    if (present.gnss_zedf9p)
-    {
-#ifdef COMPILE_ZED
-        GNSS_ZED *zed = (GNSS_ZED *)gnss;
-        int firstRTCMRecord = zed->getMessageNumberByName("RTCM_1005");
-
-        for (int messageNumber = 0; messageNumber < MAX_UBX_MSG_RTCM; messageNumber++)
-        {
-            if (messageSupported(firstRTCMRecord + messageNumber) == true)
-                returnText += "ubxMessageRateBase_" + String(ubxMessages[messageNumber + firstRTCMRecord].msgTextName) +
-                              "," + String(settings.ubxMessageRatesBase[messageNumber]) + ","; // UBX_RTCM_1074Base,4,
-        }
-#endif // COMPILE_ZED
-    }
-
-#ifdef COMPILE_UM980
-    else if (present.gnss_um980)
-    {
-        for (int messageNumber = 0; messageNumber < MAX_UM980_RTCM_MSG; messageNumber++)
-        {
-            returnText += "messageRateRTCMBase_" + String(umMessagesRTCM[messageNumber].msgTextName) + "," +
-                          String(settings.um980MessageRatesRTCMBase[messageNumber]) + ",";
-        }
-    }
-#endif // COMPILE_UM980
-
-#ifdef COMPILE_MOSAICX5
-    else if (present.gnss_mosaicX5)
-    {
-        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_INTERVAL_GROUPS; messageNumber++)
-        {
-            returnText += "messageIntervalRTCMBase_" + String(mosaicRTCMv3MsgIntervalGroups[messageNumber].name) + "," +
-                          String(settings.mosaicMessageIntervalsRTCMv3Base[messageNumber]) + ",";
-        }
-        for (int messageNumber = 0; messageNumber < MAX_MOSAIC_RTCM_V3_MSG; messageNumber++)
-        {
-            returnText += "messageEnabledRTCMBase_" + String(mosaicMessagesRTCMv3[messageNumber].name) + "," +
-                          (settings.mosaicMessageEnabledRTCMv3Base[messageNumber] ? "true" : "false") + ",";
-        }
-    }
-#endif // COMPILE_MOSAICX5
-
-    if (settings.debugWebServer == true)
-        systemPrintf("returnText (%d bytes): %s\r\n", returnText.length(), returnText.c_str());
-}
-
-//----------------------------------------
-// Handles uploading of user files to SD
-// https://github.com/espressif/arduino-esp32/blob/master/libraries/WebServer/examples/FSBrowser/FSBrowser.ino
-//----------------------------------------
-void handleUpload()
-{
-    HTTPUpload &upload = webServer->upload();
-
-    if (upload.status == UPLOAD_FILE_START)
-    {
-        String filename = upload.filename;
-
-        String logmessage = "Upload Start: " + filename;
-
-        int fileNameLen = filename.length();
-        char tempFileName[fileNameLen + 2] = {'/'}; // Filename must start with / or VERY bad things happen on SD_MMC
-        filename.toCharArray(&tempFileName[1], fileNameLen + 1);
-        tempFileName[fileNameLen + 1] = '\0'; // Terminate array
-
-        // Allocate the managerTempFile
-        if (!managerTempFile)
-        {
-            managerTempFile = new SdFile;
-            if (!managerTempFile)
-            {
-                systemPrintln("Failed to allocate managerTempFile!");
-                return;
-            }
-        }
-
-        if (managerFileOpen == false)
-        {
-            // Attempt to gain access to the SD card
-            if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
-            {
-                markSemaphore(FUNCTION_FILEMANAGER_UPLOAD1);
-
-                if (managerTempFile->open(tempFileName, O_CREAT | O_APPEND | O_WRITE) == true)
-                    managerFileOpen = true;
-                else
-                    systemPrintln("Error: handleUpload failed to open file");
-
-                xSemaphoreGive(sdCardSemaphore);
-            }
-        }
-        else
-        {
-            // File is already in use. Wait your turn.
-            webServer->send(202, "text/plain", "ERROR: File already uploading");
-        }
-
-        systemPrintln(logmessage);
-    }
-
-    else if (upload.status == UPLOAD_FILE_WRITE)
-    {
-        // Attempt to gain access to the SD card
-        if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
-        {
-            markSemaphore(FUNCTION_FILEMANAGER_UPLOAD2);
-
-            managerTempFile->write(upload.buf, upload.currentSize); // stream the incoming chunk to the opened file
-
-            xSemaphoreGive(sdCardSemaphore);
-        }
-    }
-
-    else if (upload.status == UPLOAD_FILE_END)
-    {
-        String logmessage = "Upload Complete: " + String(upload.filename) + ", size: " + String(upload.totalSize);
-
-        // Attempt to gain access to the SD card
-        if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
-        {
-            markSemaphore(FUNCTION_FILEMANAGER_UPLOAD3);
-
-            sdUpdateFileCreateTimestamp(managerTempFile); // Update the file create time & date
-
-            managerTempFile->close();
-            managerFileOpen = false;
-
-            xSemaphoreGive(sdCardSemaphore);
-        }
-
-        systemPrintln(logmessage);
-
-        // Redirect to "/"
-        webServer->sendHeader("Location", "/");
-        webServer->send(302, "text/plain", "");
-    }
-}
-
-//----------------------------------------
 // Verify the web server tables
 //----------------------------------------
 void webServerVerifyTables()
 {
     if (webServerStateEntries != WEBSERVER_STATE_MAX)
         reportFatalError("Fix webServerStateNames to match WebServerState");
+}
+
+//----------------------------------------
+//----------------------------------------
+static esp_err_t ws_handler(httpd_req_t *req)
+{
+    // Log the req, so we can reuse it for httpd_ws_send_frame
+    // TODO: do we need to be cleverer about this?
+    // last_ws_req = req;
+
+    if (req->method == HTTP_GET)
+    {
+        // Log the fd, so we can reuse it for httpd_ws_send_frame_async
+        // TODO: do we need to be cleverer about this?
+        last_ws_fd = httpd_req_to_sockfd(req);
+
+        if (settings.debugWebServer == true)
+            systemPrintf("Handshake done, the new ws connection was opened with fd %d\r\n", last_ws_fd);
+
+        websocketConnected = true;
+        lastDynamicDataUpdate = millis();
+        sendStringToWebsocket(settingsCSV);
+
+        return ESP_OK;
+    }
+
+    httpd_ws_frame_t ws_pkt;
+    uint8_t *buf = NULL;
+    memset(&ws_pkt, 0, sizeof(httpd_ws_frame_t));
+    ws_pkt.type = HTTPD_WS_TYPE_TEXT;
+    /* Set max_len = 0 to get the frame len */
+    esp_err_t ret = httpd_ws_recv_frame(req, &ws_pkt, 0);
+    if (ret != ESP_OK)
+    {
+        systemPrintf("httpd_ws_recv_frame failed to get frame len with %d\r\n", ret);
+        return ret;
+    }
+    if (settings.debugWebServer == true)
+        systemPrintf("frame len is %d\r\n", ws_pkt.len);
+    if (ws_pkt.len)
+    {
+        /* ws_pkt.len + 1 is for NULL termination as we are expecting a string */
+        if (online.psram == true)
+            buf = (uint8_t *)ps_malloc(ws_pkt.len + 1);
+        else
+            buf = (uint8_t *)malloc(ws_pkt.len + 1);
+
+        if (buf == NULL)
+        {
+            systemPrintln("Failed to malloc memory for buf");
+            return ESP_ERR_NO_MEM;
+        }
+        ws_pkt.payload = buf;
+        /* Set max_len = ws_pkt.len to get the frame payload */
+        ret = httpd_ws_recv_frame(req, &ws_pkt, ws_pkt.len);
+        if (ret != ESP_OK)
+        {
+            systemPrintf("httpd_ws_recv_frame failed with %d\r\n", ret);
+            free(buf);
+            return ret;
+        }
+    }
+    if (settings.debugWebServer == true)
+        systemPrintf("Packet type: %d\r\n", ws_pkt.type);
+    // HTTPD_WS_TYPE_CONTINUE   = 0x0,
+    // HTTPD_WS_TYPE_TEXT       = 0x1,
+    // HTTPD_WS_TYPE_BINARY     = 0x2,
+    // HTTPD_WS_TYPE_CLOSE      = 0x8,
+    // HTTPD_WS_TYPE_PING       = 0x9,
+    // HTTPD_WS_TYPE_PONG       = 0xA
+
+    if (ws_pkt.type == HTTPD_WS_TYPE_TEXT)
+    {
+        if (settings.debugWebServer == true)
+        {
+            systemPrintf("Got packet with message: %s\r\n", ws_pkt.payload);
+            dumpBuffer(ws_pkt.payload, ws_pkt.len);
+        }
+
+        if (currentlyParsingData == false)
+        {
+            for (int i = 0; i < ws_pkt.len; i++)
+            {
+                incomingSettings[incomingSettingsSpot++] = ws_pkt.payload[i];
+                incomingSettingsSpot %= AP_CONFIG_SETTING_SIZE;
+            }
+            timeSinceLastIncomingSetting = millis();
+        }
+        else
+        {
+            if (settings.debugWebServer == true)
+                systemPrintln("Ignoring packet due to parsing block");
+        }
+    }
+    else if (ws_pkt.type == HTTPD_WS_TYPE_CLOSE)
+    {
+        if (settings.debugWebServer == true)
+            systemPrintln("Client closed or refreshed the web page");
+
+        createSettingsString(settingsCSV);
+        websocketConnected = false;
+    }
+
+    free(buf);
+    return ret;
+}
+
+//----------------------------------------
+//----------------------------------------
+static const httpd_uri_t ws = {.uri = "/ws",
+                               .method = HTTP_GET,
+                               .handler = ws_handler,
+                               .user_ctx = NULL,
+                               .is_websocket = true,
+                               .handle_ws_control_frames = true,
+                               .supported_subprotocol = NULL};
+
+//----------------------------------------
+//----------------------------------------
+bool websocketServerStart(void)
+{
+    httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+
+    // Use different ports for websocket and webServer - use port 81 for the websocket - also defined in main.js
+    config.server_port = 81;
+
+    // Increase the stack size from 4K to ~15K
+    config.stack_size = updateWebSocketStackSize;
+
+    // Start the httpd server
+    if (settings.debugWebServer == true)
+        systemPrintf("Starting wsserver on port: %d\r\n", config.server_port);
+
+    if (wsserver == nullptr)
+        wsserver = new httpd_handle_t;
+
+    if (httpd_start(wsserver, &config) == ESP_OK)
+    {
+        // Registering the ws handler
+        if (settings.debugWebServer == true)
+            systemPrintln("Registering URI handlers");
+        httpd_register_uri_handler(*wsserver, &ws);
+        return true;
+    }
+
+    systemPrintln("Error starting wsserver!");
+    return false;
 }
 
 #endif // COMPILE_AP

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -1257,7 +1257,7 @@ void webServerUpdate()
     case WEBSERVER_STATE_NETWORK_CONNECTED: {
         // Determine if the network has failed
         if (networkIsConnected(&webServerPriority) == false && wifiSoftApRunning == false)
-            webServerStop();
+            webServerSetState(WEBSERVER_STATE_WAIT_FOR_NETWORK);
         if (settings.debugWebServer)
             systemPrintln("Assigning web server resources");
 
@@ -1270,7 +1270,10 @@ void webServerUpdate()
     case WEBSERVER_STATE_RUNNING:
         // Determine if the network has failed
         if (networkIsConnected(&webServerPriority) == false && wifiSoftApRunning == false)
-            webServerStop();
+        {
+            webServerReleaseResources(); // Release web server resources
+            webServerSetState(WEBSERVER_STATE_WAIT_FOR_NETWORK);
+        }
 
         // This state is exited when webServerStop() is called
 

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -620,6 +620,17 @@ void wifiResetTimeout()
 }
 
 //*********************************************************************
+// Turn on and off WiFi soft AP mode
+// Inputs:
+//   on: True to start WiFi soft AP mode, false to stop WiFi soft AP mode
+// Returns:
+//   Returns the status of WiFi soft AP start or stop
+bool wifiSoftApOn(bool on)
+{
+    return wifi.enable(wifiEspNowRunning, on, wifiStationRunning);
+}
+
+//*********************************************************************
 // Start or stop the WiFi station
 // Returns true if successful and false upon failure
 bool wifiStationOn(bool on)

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -400,9 +400,6 @@ const int wifiStartNamesEntries = sizeof(wifiStartNames) / sizeof(wifiStartNames
 #define WIFI_MAX_TIMEOUT    (15 * 60 * 1000)    // Timeout in milliseconds
 #define WIFI_MIN_TIMEOUT    (15 * 1000)         // Timeout in milliseconds
 
-const char * wifiSoftApSsid = "RTK Config";
-const char * wifiSoftApPassword = nullptr;
-
 //****************************************
 // Locals
 //****************************************

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -2582,6 +2582,11 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
     if (restartWiFiStation)
         wifiReconnectRequest = true;
 
+    // Set the online flags
+    wifiEspNowOnline = espNowOnline();
+    wifiSoftApOnline = softApOnline();
+    wifiStationOnline = stationOnline();
+
     // Return the enable status
     bool enabled = ((_started & allOnline) == expected);
     if (!enabled)

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -1376,6 +1376,16 @@ bool RTK_WIFI::softApSetIpAddress(const char * ipAddress,
 }
 
 //*********************************************************************
+// Get the soft AP IP address
+// Returns the soft IP address
+IPAddress RTK_WIFI::softApIpAddress()
+{
+    if (softApOnline())
+        return _apIpAddress;
+    return IPAddress((uint32_t)0);
+}
+
+//*********************************************************************
 // Get the soft AP status
 bool RTK_WIFI::softApOnline()
 {
@@ -1648,6 +1658,16 @@ bool RTK_WIFI::stationHostName(const char * hostName)
 }
 
 //*********************************************************************
+// Get the WiFi station IP address
+// Returns the IP address of the WiFi station
+IPAddress RTK_WIFI::stationIpAddress()
+{
+    if (stationOnline())
+        return _staIpAddress;
+    return IPAddress((uint32_t)0);
+}
+
+//*********************************************************************
 // Get the station status
 bool RTK_WIFI::stationOnline()
 {
@@ -1787,6 +1807,16 @@ WIFI_CHANNEL_t RTK_WIFI::stationSelectAP(uint8_t apCount, bool list)
 
     // Return the channel number
     return apChannel;
+}
+
+//*********************************************************************
+// Get the SSID of the remote AP
+const char * RTK_WIFI::stationSsid()
+{
+    if (stationOnline())
+        return _staRemoteApSsid;
+    else
+        return "";
 }
 
 //*********************************************************************

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -881,7 +881,7 @@ bool RTK_WIFI::enable(bool enableESPNow, bool enableSoftAP, bool enableStation)
     if (enableSoftAP)
     {
         // Verify that the SSID is set
-        if (wifiSoftApSsid && strlen(wifiSoftApSsid) && wifiSoftApPassword)
+        if (wifiSoftApSsid && strlen(wifiSoftApSsid))
         {
             starting |= WIFI_START_SOFT_AP;
             wifiSoftApRunning = true;
@@ -1397,7 +1397,8 @@ bool RTK_WIFI::softApSetSsidPassword(const char * ssid, const char * password)
     if (!created)
         systemPrintf("ERROR: Failed to set soft AP SSID and Password!\r\n");
     else if (settings.debugWifiState)
-        systemPrintf("WiFi AP: SSID: %s, Password: %s\r\n", ssid, password);
+        systemPrintf("WiFi AP: SSID: %s%s%s\r\n", ssid,
+                     password ? ", Password: " : "", password ? password : "");
     return created;
 }
 
@@ -2343,10 +2344,11 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
             _started = _started | WIFI_AP_ONLINE;
 
             // Display the soft AP status
-            systemPrintf("WiFi: Soft AP online, SSID: %s (%s), Password: %s\r\n",
+            systemPrintf("WiFi: Soft AP online, SSID: %s (%s)%s%s\r\n",
                          wifiSoftApSsid,
                          _apIpAddress.toString().c_str(),
-                         wifiSoftApPassword);
+                         wifiSoftApPassword ? ", Password: " : "",
+                         wifiSoftApPassword ? wifiSoftApPassword : "");
         }
 
         //****************************************

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -2313,12 +2313,14 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         // Set the soft AP host name
         if (starting & WIFI_AP_SET_HOST_NAME)
         {
+            const char * hostName = &settings.mdnsHostName[0];
+
             // Display the host name
             if (settings.debugWifiState && _verbose)
-                systemPrintf("Host name: %s\r\n", &settings.mdnsHostName[0]);
+                systemPrintf("Host name: %s\r\n", hostName);
 
             // Set the host name
-            if (!softApSetHostName(&settings.mdnsHostName[0]))
+            if (!softApSetHostName(hostName))
                 break;
             _started = _started | WIFI_AP_SET_HOST_NAME;
         }
@@ -2360,12 +2362,14 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         // Set the host name
         if (starting & WIFI_STA_SET_HOST_NAME)
         {
+            const char * hostName = &settings.mdnsHostName[0];
+
             // Display the host name
             if (settings.debugWifiState && _verbose)
-                systemPrintf("Host name: %s\r\n", &settings.mdnsHostName[0]);
+                systemPrintf("Host name: %s\r\n", hostName);
 
             // Set the host name
-            if (!stationHostName(&settings.mdnsHostName[0]))
+            if (!stationHostName(hostName))
                 break;
             _started = _started | WIFI_STA_SET_HOST_NAME;
         }

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2175,6 +2175,10 @@ class RTK_WIFI
     //   display: Address of a Print object
     void softApConfigurationDisplay(Print * display);
 
+    // Get the soft AP IP address
+    // Returns the soft IP address
+    IPAddress softApIpAddress();
+
     // Get the soft AP status
     // Outputs:
     //   Returns true when the soft AP is ready for use
@@ -2189,10 +2193,17 @@ class RTK_WIFI
     //    otherwise
     bool startAp(bool forceAP);
 
+    // Get the WiFi station IP address
+    // Returns the IP address of the WiFi station
+    IPAddress stationIpAddress();
+
     // Get the station status
     // Outputs:
     //   Returns true when the WiFi station is online and ready for use
     bool stationOnline();
+
+    // Get the SSID of the remote AP
+    const char * stationSsid();
 
     // Stop and start WiFi components
     // Inputs:

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -381,9 +381,11 @@ typedef enum
     BLUETOOTH_RADIO_OFF,
 } BluetoothRadioType_e;
 
+#define SSID_LENGTH     50
+
 typedef struct WiFiNetwork
 {
-    char ssid[50];
+    char ssid[SSID_LENGTH];
     char password[50];
 } WiFiNetwork;
 


### PR DESCRIPTION
WebServer: Separate routines
WebServer: Alphabetize routines
GNSS: Move createMessageList and createMessageListBase into GNSS
WebServer: Update error messages
WebServer: Move online.webServer
WiFi: Make soft AP SSID and password global
WiFi: Support no password for soft AP
WiFi: Use local variable for hostName
WiFi: Expose wifi*Online variables
WiFi: Add routines to get soft AP IP addr and station SSID and IP addr
Network: Allow multiple calls to networkConsumerRemove
States: Don't force RTK CONFIG as soft AP SSID
WiFi: Add wifiSoftApOn routine to start/stop soft AP
WebServer: Start and stop the network
Display: Move globals into displayConfigViaWiFi
Display: Simplify display of WiFi config values
WiFi: Eliminate magic number for SSID_LENGTH
Network: Add more debug prints
WebServer: Move webServerStopSockets call into webServerReleaseResources
WebServer: Move online.webServer into webServer*Resources
WebServer: Don't call webServerStop, instead use STATE_WAIT_FOR_NETWORK
Ethernet: Always notify network layer of state change
Network: Add calls to networkDisplayStatus
Network: Don't start network if it is already starting or started
Network: Only stop interface when it is started
Display: Add displayEthernetIcon routine
Display: Merge *ConfigViaEthernet & *ConfigViaWiFi into displayWebConfig
