### PR TITLE
NTP: Use common client organization

### DIFF
--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -34,6 +34,9 @@ void ntpServerStop() {}
 
 void menuTcpUdp() {systemPrint("**Network not compiled**");}
 void networkBegin() {}
+void networkConsumerAdd(NETCONSUMER_t consumer, NetIndex_t network, const char * fileName, uint32_t lineNumber) {}
+bool networkConsumerIsConnected(NETCONSUMER_t consumer) {return false;}
+void networkConsumerRemove(NETCONSUMER_t consumer, NetIndex_t network, const char * fileName, uint32_t lineNumber) {}
 IPAddress networkGetIpAddress() {return("0.0.0.0");}
 const uint8_t * networkGetMacAddress()
 {
@@ -48,7 +51,6 @@ NetPriority_t networkGetPriority() {return 0;}
 bool networkHasInternet() {return false;}
 bool networkHasInternet(NetIndex_t index) {return false;}
 bool networkInterfaceHasInternet(NetIndex_t index) {return false;}
-bool networkIsConnected(NetPriority_t * priority) {return false;}
 bool networkIsInterfaceStarted(NetIndex_t index) {return false;}
 void networkMarkOffline(NetIndex_t index) {}
 void networkMarkHasInternet(NetIndex_t index) {}

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -43,7 +43,8 @@ const uint8_t * networkGetMacAddress()
         return btMACAddress;
 #endif
     return zero;
-  }
+}
+NetPriority_t networkGetPriority() {return 0;}
 bool networkHasInternet() {return false;}
 bool networkHasInternet(NetIndex_t index) {return false;}
 bool networkInterfaceHasInternet(NetIndex_t index) {return false;}

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -206,6 +206,7 @@ uint32_t wifiGetStartTimeout()                  {return 0;}
 int wifiNetworkCount()                          {return 0;}
 void wifiResetThrottleTimeout()                 {}
 void wifiResetTimeout()                         {}
+const char * wifiSoftApGetSsid()                {return "";}
 bool wifiSoftApOn(bool on, const char * fileName, uint32_t lineNumber)                      {return !on;}
 bool wifiStationOn(bool on, const char * fileName, uint32_t lineNumber)                     {return !on;}
 void wifiStopAll()                              {}

--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -3090,7 +3090,7 @@ void displayWebConfig(std::vector<iconPropertyBlinking> &iconPropertyList)
     if (wifi.softApOnline())
     {
         setWiFiIcon(&iconPropertyList); // Blink WiFi in center
-        snprintf(mySSID, sizeof(mySSID), "%s", wifiSoftApSsid);
+        snprintf(mySSID, sizeof(mySSID), "%s", wifiSoftApGetSsid());
         strcpy(myIP, wifi.softApIpAddress().toString().c_str());
     }
     else if (networkInterfaceHasInternet(NETWORK_WIFI_STATION))

--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -1956,7 +1956,7 @@ void paintIPAddress()
 void displayFullIPAddress(std::vector<iconPropertyBlinking> *iconList) // Bottom left - 128x64 only
 {
     static IPAddress ipAddress;
-    static NetPriority_t priority;
+    NetPriority_t priority;
     static NetPriority_t previousPriority;
 
     // Max width: 15*6 = 90 pixels (6 pixels per character, nnn.nnn.nnn.nnn)
@@ -1965,21 +1965,24 @@ void displayFullIPAddress(std::vector<iconPropertyBlinking> *iconList) // Bottom
         char myAddress[16];
 
         // Reduce calls to networkGetIpAddress
-        networkIsConnected(&priority);
-        if (priority != previousPriority)
+        if (networkHasInternet())
         {
-            previousPriority = priority;
-            ipAddress = networkGetIpAddress();
-        }
+            priority = networkGetPriority();
+            if (priority != previousPriority)
+            {
+                previousPriority = priority;
+                ipAddress = networkGetIpAddress();
+            }
 
-        // Display the IP address when it is available
-        if (ipAddress != IPAddress((uint32_t)0))
-        {
-            snprintf(myAddress, sizeof(myAddress), "%s", ipAddress.toString());
+            // Display the IP address when it is available
+            if (ipAddress != IPAddress((uint32_t)0))
+            {
+                snprintf(myAddress, sizeof(myAddress), "%s", ipAddress.toString());
 
-            oled->setFont(QW_FONT_5X7); // Set font to smallest
-            oled->setCursor(0, 55);
-            oled->print(ipAddress);
+                oled->setFont(QW_FONT_5X7); // Set font to smallest
+                oled->setCursor(0, 55);
+                oled->print(ipAddress);
+            }
         }
     }
 }

--- a/Firmware/RTK_Everywhere/HTTP_Client.ino
+++ b/Firmware/RTK_Everywhere/HTTP_Client.ino
@@ -285,11 +285,13 @@ void httpClientStop(bool shutdown)
 void httpClientUpdate()
 {
     bool connected;
+    bool enabled;
 
     // Shutdown the HTTP client when the mode or setting changes
     DMW_st(httpClientSetState, httpClientState);
     connected = networkConsumerIsConnected(NETCONSUMER_HTTP_CLIENT);
-    if ((!httpClientEnabled()) && (httpClientState > HTTP_CLIENT_OFF))
+    enabled = httpClientEnabled();
+    if ((enabled == false) && (httpClientState > HTTP_CLIENT_OFF))
         httpClientShutdown();
 
     // Enable the network and the HTTP client if requested
@@ -297,7 +299,7 @@ void httpClientUpdate()
     {
     default:
     case HTTP_CLIENT_OFF: {
-        if (httpClientEnabled())
+        if (enabled)
         {
             networkConsumerAdd(NETCONSUMER_HTTP_CLIENT, NETWORK_ANY, __FILE__, __LINE__);
             httpClientStart();

--- a/Firmware/RTK_Everywhere/HTTP_Client.ino
+++ b/Firmware/RTK_Everywhere/HTTP_Client.ino
@@ -294,6 +294,10 @@ void httpClientUpdate()
     if ((enabled == false) && (httpClientState > HTTP_CLIENT_OFF))
         httpClientShutdown();
 
+    // Determine if the network has failed
+    else if ((httpClientState > HTTP_CLIENT_NETWORK_STARTED) && !connected)
+        httpClientRestart();
+
     // Enable the network and the HTTP client if requested
     switch (httpClientState)
     {
@@ -326,14 +330,6 @@ void httpClientUpdate()
 
     // Connect to the HTTP server
     case HTTP_CLIENT_CONNECTING_2_SERVER: {
-        // Determine if the network has failed
-        if (!connected)
-        {
-            // Failed to connect to the network, attempt to restart the network
-            httpClientRestart();
-            break;
-        }
-
         // Allocate the httpSecureClient structure
         httpSecureClient = new NetworkClientSecure();
         if (!httpSecureClient)
@@ -383,14 +379,6 @@ void httpClientUpdate()
     }
 
     case HTTP_CLIENT_CONNECTED: {
-        // Determine if the network has failed
-        if (!connected)
-        {
-            // Failed to connect to the network, attempt to restart the network
-            httpClientRestart();
-            break;
-        }
-
         String ztpRequest;
         createZtpRequest(ztpRequest);
 
@@ -583,13 +571,8 @@ void httpClientUpdate()
 
     // The ZTP HTTP POST is complete. We either can not or do not want to continue.
     // Hang here until httpClientModeNeeded is set to false by updateProvisioning
-    case HTTP_CLIENT_COMPLETE: {
-        // Determine if the network has failed
-        if (!connected)
-            // Failed to connect to the network, attempt to restart the network
-            httpClientRestart();
+    case HTTP_CLIENT_COMPLETE:
         break;
-    }
     }
 
     // Periodically display the HTTP client state

--- a/Firmware/RTK_Everywhere/MQTT_Client.ino
+++ b/Firmware/RTK_Everywhere/MQTT_Client.ino
@@ -760,12 +760,13 @@ void mqttClientStop(bool shutdown)
 void mqttClientUpdate()
 {
     bool connected;
+    bool enabled;
 
     // Shutdown the MQTT client when the mode or setting changes
     DMW_st(mqttClientSetState, mqttClientState);
     connected = networkConsumerIsConnected(NETCONSUMER_PPL_MQTT_CLIENT);
-
-    if ((!mqttClientEnabled()) && (mqttClientState > MQTT_CLIENT_OFF))
+    enabled = mqttClientEnabled();
+    if ((enabled == false) && (mqttClientState > MQTT_CLIENT_OFF))
     {
         if (settings.debugMqttClientState)
             systemPrintln("MQTT Client stopping");
@@ -777,7 +778,7 @@ void mqttClientUpdate()
     {
     default:
     case MQTT_CLIENT_OFF: {
-        if (mqttClientEnabled())
+        if (enabled)
         {
             // Start the MQTT client
             if (settings.debugMqttClientState)

--- a/Firmware/RTK_Everywhere/NTP.ino
+++ b/Firmware/RTK_Everywhere/NTP.ino
@@ -719,7 +719,7 @@ bool ntpProcessOneRequest(bool process, const timeval *recTv, const timeval *syn
 //----------------------------------------
 // Configure specific aspects of the receiver for NTP mode
 //----------------------------------------
-bool configureUbloxModuleNTP()
+bool ntpConfigureUbloxModule()
 {
     if (present.timePulseInterrupt == false)
         return (false);

--- a/Firmware/RTK_Everywhere/NTP.ino
+++ b/Firmware/RTK_Everywhere/NTP.ino
@@ -805,6 +805,7 @@ void ntpServerStop()
 //----------------------------------------
 void ntpServerUpdate()
 {
+    bool enabled;
     bool connected;
     char ntpDiag[768]; // Char array to hold diagnostic messages
 
@@ -813,7 +814,8 @@ void ntpServerUpdate()
 
     // Shutdown the NTP server when the mode changes or network fails
     connected = networkConsumerIsConnected(NETCONSUMER_NTP_SERVER);
-    if (NEQ_RTK_MODE(ntpServerMode) && (ntpServerState > NTP_STATE_OFF))
+    enabled = EQ_RTK_MODE(ntpServerMode);
+    if ((enabled == false) && (ntpServerState > NTP_STATE_OFF))
         ntpServerStop();
     else if ((ntpServerState > NTP_STATE_WAIT_NETWORK) && !connected)
         ntpServerStop();
@@ -827,7 +829,7 @@ void ntpServerUpdate()
 
     case NTP_STATE_OFF:
         // Determine if the NTP server is enabled
-        if (EQ_RTK_MODE(ntpServerMode))
+        if (enabled)
         {
             // The NTP server only works over Ethernet
             networkConsumerAdd(NETCONSUMER_NTP_SERVER, NETWORK_ETHERNET, __FILE__, __LINE__);

--- a/Firmware/RTK_Everywhere/NTP.ino
+++ b/Firmware/RTK_Everywhere/NTP.ino
@@ -778,7 +778,6 @@ void ntpServerUpdate()
     {
         if (ntpServerState > NTP_STATE_OFF)
             ntpServerStop();
-        return;
     }
 
     // Process the NTP state

--- a/Firmware/RTK_Everywhere/NTP.ino
+++ b/Firmware/RTK_Everywhere/NTP.ino
@@ -509,8 +509,8 @@ bool ntpProcessOneRequest(bool process, const timeval *recTv, const timeval *syn
 
         if (ntpDiag != nullptr) // Add the packet size and remote IP/Port to the diagnostics
         {
-            snprintf(ntpDiag, ntpDiagSize, "NTP request from:  Remote IP: %s  Remote Port: %d\r\n", remoteIP.toString(),
-                     remotePort);
+            snprintf(ntpDiag, ntpDiagSize, "NTP request from:  Remote IP: %s  Remote Port: %d\r\n",
+                     remoteIP.toString().c_str(), remotePort);
         }
 
         if (packetDataSize >= NTPpacket::NTPpacketSize)

--- a/Firmware/RTK_Everywhere/NTP.ino
+++ b/Firmware/RTK_Everywhere/NTP.ino
@@ -89,7 +89,6 @@ static uint32_t lastLoggedNTPRequest;
 //----------------------------------------
 // Menu to get the NTP settings
 //----------------------------------------
-
 void menuNTP()
 {
     if (!present.ethernet_ws5500 == true)
@@ -200,7 +199,7 @@ void menuNTP()
 }
 
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-// NTP Packet storage and utilities
+// NTP Packet storage class and utilities
 
 struct NTPpacket
 {
@@ -343,6 +342,8 @@ struct NTPpacket
         uint8_t unsigned8;
     } unsignedSigned8;
 
+    //----------------------------------------
+    //----------------------------------------
     uint32_t extractUnsigned32(uint8_t *ptr)
     {
         uint32_t val = 0;
@@ -353,6 +354,8 @@ struct NTPpacket
         return val;
     }
 
+    //----------------------------------------
+    //----------------------------------------
     void insertUnsigned32(uint8_t *ptr, uint32_t val)
     {
         *ptr++ = val >> 24; // NTP data is Big-Endian
@@ -361,7 +364,9 @@ struct NTPpacket
         *ptr++ = val & 0xFF;
     }
 
+    //----------------------------------------
     // Extract the data from an NTP packet into the correct fields
+    //----------------------------------------
     void extract()
     {
         uint8_t *ptr = packet;
@@ -401,7 +406,9 @@ struct NTPpacket
         ptr += 4;
     }
 
+    //----------------------------------------
     // Insert the data from the fields into an NTP packet
+    //----------------------------------------
     void insert()
     {
         uint8_t *ptr = packet;
@@ -442,6 +449,8 @@ struct NTPpacket
         ptr += 4;
     }
 
+    //----------------------------------------
+    //----------------------------------------
     uint32_t convertMicrosToSecsAndFraction(uint32_t val) // 16-bit fraction used by root delay and dispersion
     {
         double secs = val;
@@ -458,6 +467,8 @@ struct NTPpacket
         return (result);
     }
 
+    //----------------------------------------
+    //----------------------------------------
     uint32_t convertMicrosToFraction(uint32_t val) // 32-bit fraction used by the timestamps
     {
         val %= 1000000;      // Just in case
@@ -467,6 +478,8 @@ struct NTPpacket
         return (uint32_t)v;
     }
 
+    //----------------------------------------
+    //----------------------------------------
     uint32_t convertFractionToMicros(uint32_t val) // 32-bit fraction used by the timestamps
     {
         double v = val;      // Convert fraction to double
@@ -477,22 +490,27 @@ struct NTPpacket
         return ret;
     }
 
+    //----------------------------------------
+    //----------------------------------------
     uint32_t convertNTPsecondsToUnix(uint32_t val)
     {
         return (val - NTPtoUnixOffset);
     }
 
+    //----------------------------------------
+    //----------------------------------------
     uint32_t convertUnixSecondsToNTP(uint32_t val)
     {
         return (val + NTPtoUnixOffset);
     }
 };
 
-// =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+//----------------------------------------
 // NTP process one request
 // recTv contains the timeval the NTP packet was received
 // syncTv contains the timeval when the RTC was last sync'd
 // ntpDiag will contain useful diagnostics
+//----------------------------------------
 bool ntpProcessOneRequest(bool process, const timeval *recTv, const timeval *syncTv, char *ntpDiag = nullptr,
                           size_t ntpDiagSize = 0); // Header
 bool ntpProcessOneRequest(bool process, const timeval *recTv, const timeval *syncTv, char *ntpDiag, size_t ntpDiagSize)
@@ -698,7 +716,9 @@ bool ntpProcessOneRequest(bool process, const timeval *recTv, const timeval *syn
     return processed;
 }
 
+//----------------------------------------
 // Configure specific aspects of the receiver for NTP mode
+//----------------------------------------
 bool configureUbloxModuleNTP()
 {
     if (present.timePulseInterrupt == false)
@@ -725,7 +745,9 @@ bool configureUbloxModuleNTP()
 // NTP Server routines
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
+//----------------------------------------
 // Update the state of the NTP server state machine
+//----------------------------------------
 void ntpServerSetState(uint8_t newState)
 {
     if ((settings.debugNtp || PERIODIC_DISPLAY(PD_NTP_SERVER_STATE)) && (!inMainMenu))
@@ -749,7 +771,9 @@ void ntpServerSetState(uint8_t newState)
     }
 }
 
+//----------------------------------------
 // Stop the NTP server
+//----------------------------------------
 void ntpServerStop()
 {
     // Mark the NTP server as off
@@ -776,7 +800,9 @@ void ntpServerStop()
         ntpServerSetState(NTP_STATE_WAIT_NETWORK);
 }
 
+//----------------------------------------
 // Update the NTP server state
+//----------------------------------------
 void ntpServerUpdate()
 {
     bool connected;
@@ -938,7 +964,9 @@ void ntpServerUpdate()
         ntpServerSetState(ntpServerState);
 }
 
+//----------------------------------------
 // Verify the NTP tables
+//----------------------------------------
 void ntpValidateTables()
 {
     if (ntpServerStateNameEntries != NTP_STATE_MAX)

--- a/Firmware/RTK_Everywhere/NTP.ino
+++ b/Firmware/RTK_Everywhere/NTP.ino
@@ -769,6 +769,7 @@ void ntpServerStop()
     networkConsumerOffline(NETCONSUMER_NTP_SERVER);
     if (NEQ_RTK_MODE(ntpServerMode))
     {
+        networkConsumerRemove(NETCONSUMER_NTP_SERVER, NETWORK_ETHERNET, __FILE__, __LINE__);
         ntpServerSetState(NTP_STATE_OFF);
     }
     else
@@ -802,6 +803,8 @@ void ntpServerUpdate()
         // Determine if the NTP server is enabled
         if (EQ_RTK_MODE(ntpServerMode))
         {
+            // The NTP server only works over Ethernet
+            networkConsumerAdd(NETCONSUMER_NTP_SERVER, NETWORK_ETHERNET, __FILE__, __LINE__);
             ntpServerSetState(NTP_STATE_WAIT_NETWORK);
         }
         break;

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -862,6 +862,14 @@ const char *networkGetNameByPriority(NetPriority_t priority)
 }
 
 //----------------------------------------
+// Get the current network priority
+//----------------------------------------
+NetPriority_t networkGetPriority()
+{
+    return networkPriority;
+}
+
+//----------------------------------------
 // Determine if any network interface has access to the internet
 //----------------------------------------
 bool networkHasInternet()

--- a/Firmware/RTK_Everywhere/States.ino
+++ b/Firmware/RTK_Everywhere/States.ino
@@ -571,7 +571,7 @@ void stateUpdate()
             displayNtpStart(500); // Show 'NTP'
 
             // Start UART connected to the GNSS receiver for NMEA and UBX data (enables logging)
-            if (tasksStartGnssUart() && configureUbloxModuleNTP())
+            if (tasksStartGnssUart() && ntpConfigureUbloxModule())
             {
                 settings.updateGNSSSettings = false; // On the next boot, no need to update the GNSS on this profile
                 settings.lastState = STATE_NTPSERVER_NOT_STARTED; // Record this state for next POR

--- a/Firmware/RTK_Everywhere/States.ino
+++ b/Firmware/RTK_Everywhere/States.ino
@@ -210,18 +210,7 @@ void stateUpdate()
         case (STATE_BASE_CASTER_NOT_STARTED): {
             baseCasterEnableOverride();
 
-#ifdef COMPILE_WIFI
-            // If the AP is already running, check that the name is correct
-            if ((WiFi.getMode() == WIFI_AP) || (WiFi.getMode() == WIFI_AP_STA))
-            {
-                if (strcmp(WiFi.softAPSSID().c_str(), "RTK Caster") != 0)
-                {
-                    // The AP name cannot be changed while it is running. WiFi must be restarted.
-                    wifiRestartRequested = true; // Tell network layer to restart WiFi
-                }
-            }
-#endif // COMPILE_WIFI
-
+            wifiSoftApSsid = "RTK Caster";
             changeState(STATE_BASE_NOT_STARTED);
         }
         break;
@@ -444,6 +433,7 @@ void stateUpdate()
             for (int serverIndex = 0; serverIndex < NTRIP_SERVER_MAX; serverIndex++)
                 ntripServerStop(serverIndex, true); // Do not allocate new wifiClient
 
+            wifiSoftApSsid = "RTK Config";
             webServerStart(); // Start the webserver state machine for web config
 
             RTK_MODE(RTK_MODE_WEB_CONFIG);

--- a/Firmware/RTK_Everywhere/TcpServer.ino
+++ b/Firmware/RTK_Everywhere/TcpServer.ino
@@ -100,7 +100,6 @@ static volatile uint8_t tcpServerClientWriteError;
 static NetworkClient *tcpServerClient[TCP_SERVER_MAX_CLIENTS];
 static IPAddress tcpServerClientIpAddress[TCP_SERVER_MAX_CLIENTS];
 static volatile RING_BUFFER_OFFSET tcpServerClientTails[TCP_SERVER_MAX_CLIENTS];
-static NetPriority_t tcpServerPriority = NETWORK_OFFLINE;
 
 //----------------------------------------
 // TCP Server handleGnssDataTask Support Routines
@@ -392,6 +391,7 @@ void tcpServerStopClient(int index)
 void tcpServerUpdate()
 {
     bool clientConnected;
+    bool connected;
     bool dataSent;
     bool enabled;
     int index;
@@ -399,6 +399,7 @@ void tcpServerUpdate()
 
     // Shutdown the TCP server when the mode or setting changes
     DMW_st(tcpServerSetState, tcpServerState);
+    connected = networkConsumerIsConnected(NETCONSUMER_TCP_SERVER);
     enabled = tcpServerEnabled();
     if ((tcpServerState > TCP_SERVER_STATE_OFF) && !enabled)
         tcpServerStop();
@@ -440,7 +441,6 @@ void tcpServerUpdate()
                 networkConsumerAdd(NETCONSUMER_TCP_SERVER, NETWORK_ANY, __FILE__, __LINE__);
             else
                 networkSoftApConsumerAdd(NETCONSUMER_TCP_SERVER, __FILE__, __LINE__);
-            tcpServerPriority = NETWORK_OFFLINE;
             tcpServerSetState(TCP_SERVER_STATE_WAIT_FOR_NETWORK);
         }
         break;
@@ -448,7 +448,7 @@ void tcpServerUpdate()
     // Wait until the network is connected
     case TCP_SERVER_STATE_WAIT_FOR_NETWORK:
         // Wait until the network is connected to the media
-        if (networkIsConnected(&tcpServerPriority))
+        if (connected)
         {
             // Delay before starting the TCP server
             if ((millis() - tcpServerTimer) >= (1 * 1000))
@@ -466,7 +466,7 @@ void tcpServerUpdate()
     // Handle client connections and link failures
     case TCP_SERVER_STATE_RUNNING:
         // Determine if the network has failed
-        if ((networkIsConnected(&tcpServerPriority) == false && wifiSoftApRunning == false) || (!settings.enableTcpServer && !settings.baseCasterOverride))
+        if ((connected == false && wifiSoftApRunning == false) || (!settings.enableTcpServer && !settings.baseCasterOverride))
         {
             if ((settings.debugTcpServer || PERIODIC_DISPLAY(PD_TCP_SERVER_DATA)) && (!inMainMenu))
             {

--- a/Firmware/RTK_Everywhere/TcpServer.ino
+++ b/Firmware/RTK_Everywhere/TcpServer.ino
@@ -391,7 +391,7 @@ void tcpServerStopClient(int index)
 //----------------------------------------
 void tcpServerUpdate()
 {
-    bool connected;
+    bool clientConnected;
     bool dataSent;
     bool enabled;
     int index;
@@ -487,10 +487,10 @@ void tcpServerUpdate()
             {
                 // Data structure in use
                 // Check for a working TCP server client connection
-                connected = tcpServerClient[index]->connected();
+                clientConnected = tcpServerClient[index]->connected();
                 dataSent = ((millis() - tcpServerTimer) < TCP_SERVER_CLIENT_DATA_TIMEOUT) ||
                            (tcpServerClientDataSent & (1 << index));
-                if (connected && dataSent)
+                if (clientConnected && dataSent)
                 {
                     // Display this client connection
                     if (PERIODIC_DISPLAY(PD_TCP_SERVER_DATA) && (!inMainMenu))

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2101,6 +2101,7 @@ class RTK_WIFI
     void wifiEvent(arduino_event_id_t event, arduino_event_info_t info);
 
   public:
+    char * _apSsid; // SSID for the soft AP
 
     // Constructor
     // Inputs:

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -564,6 +564,7 @@ const int numRegionalAreas = sizeof(Regional_Information_Table) / sizeof(Regiona
 enum
 {
     NETCONSUMER_HTTP_CLIENT = 0,
+    NETCONSUMER_NTP_SERVER,
     NETCONSUMER_NTRIP_CLIENT,
     NETCONSUMER_NTRIP_SERVER,
     NETCONSUMER_OTA_CLIENT,


### PR DESCRIPTION
NTP: Move network check to top of ntpServerUpdate routine
NTP: Always periodically display the NTP state
NTP: Fix display of remote IP address
NTP: Add the NTP_STATE_WAIT_NETWORK state
NTP: Add the NTP network consumer
NTP: Separate the routines
NTP: Rename configureUbloxModuleNTP to ntpConfigureUbloxModule
NTP: Perform the enabled check once
