### PR TITLE
Display: Add displayHalt routine, call from reportFatalError

### DIFF
--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -99,6 +99,7 @@ static QwiicCustomOLED *oled = nullptr;
 // Fonts
 #include <res/qw_fnt_5x7.h>
 #include <res/qw_fnt_8x16.h>
+#include <res/qw_fnt_31x48.h>
 #include <res/qw_fnt_largenum.h>
 
 // Icons
@@ -2268,6 +2269,20 @@ void displayFirmwareUpdateProgress(int percentComplete)
 void displayEventMarked(uint16_t displayTime)
 {
     displayMessage("Event Marked", displayTime);
+}
+
+// Print the error message every 15 seconds
+void displayHalt()
+{
+    if (online.display)
+    {
+        oled->erase(); // Clear the display's internal buffer
+        int yPos = (oled->getHeight() - 16) / 2;
+        QwiicFont * font = (oled->getWidth() > 64) ? (QwiicFont *)&QW_FONT_31X48
+                                                   : (QwiicFont *)&QW_FONT_8X16;
+        printTextCenter("Halt", yPos, *font, 1, false); // text, y, font type, kerning, inverted
+        oled->display(); // Push internal buffer to display
+    }
 }
 
 void displayNoLogging(uint16_t displayTime)

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -1073,9 +1073,6 @@ void setup()
     systemPrintln();
     systemPrintln();
 
-    DMW_b("verifyTables");
-    verifyTables(); // Verify the consistency of the internal tables
-
     DMW_b("findSpiffsPartition");
     if (!findSpiffsPartition())
     {
@@ -1129,6 +1126,9 @@ void setup()
 
     DMW_b("beginDisplay");
     beginDisplay(i2cDisplay); // Start display to be able to display any errors
+
+    DMW_b("verifyTables");
+    verifyTables(); // Verify the consistency of the internal tables
 
     beginVersion(); // Assemble platform name. Requires settings/LFS.
 

--- a/Firmware/RTK_Everywhere/System.ino
+++ b/Firmware/RTK_Everywhere/System.ino
@@ -765,6 +765,7 @@ const char *coordinatePrintableInputType(CoordinateInputType coordinateInputType
 // Print the error message every 15 seconds
 void reportFatalError(const char *errorMsg)
 {
+    displayHalt();
     while (1)
     {
         systemPrint("HALTED: ");


### PR DESCRIPTION
Move verifyTables to later in the boot sequence to enable HALT display