### PR TITLE
Rename some routines and variables

### DIFF
--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1366,7 +1366,7 @@ bool networkIsHighestPriority(NetIndex_t index)
     // Determine if the specified interface has higher priority
     higherPriority = (priority == NETWORK_OFFLINE);
     if (!higherPriority)
-        higherPriority = (priority > networkPriorityTable[index]);
+        higherPriority = (priority >= networkPriorityTable[index]);
     return higherPriority;
 }
 

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -502,9 +502,17 @@ NETCONSUMER_MASK_t networkConsumerBits(NetIndex_t index)
 }
 
 //----------------------------------------
+// Count the number of network consumers
+//----------------------------------------
+int networkConsumerCount(NetIndex_t index)
+{
+    return networkConsumerCountBits(networkConsumerBits(index));
+}
+
+//----------------------------------------
 // Count the network consumer bits
 //----------------------------------------
-int networkConsumerCount(NETCONSUMER_MASK_t bits)
+int networkConsumerCountBits(NETCONSUMER_MASK_t bits)
 {
     int bitCount;
     NETCONSUMER_MASK_t bitMask;
@@ -543,7 +551,7 @@ void networkConsumerDisplay()
         bits |= netIfConsumers[index];
         users = netIfUsers[index];
     }
-    systemPrintf("Network Consumers: %d", networkConsumerCount(bits));
+    systemPrintf("Network Consumers: %d", networkConsumerCountBits(bits));
     networkConsumerPrint(bits, users, ", ");
     systemPrintln();
 
@@ -2025,7 +2033,7 @@ NETCONSUMER_MASK_t networkSoftApConsumerBits()
 //----------------------------------------
 void networkSoftApConsumerDisplay()
 {
-    systemPrintf("WiFi Soft AP Consumers: %d", networkConsumerCount(networkSoftApConsumer));
+    systemPrintf("WiFi Soft AP Consumers: %d", networkConsumerCountBits(networkSoftApConsumer));
     networkConsumerPrint(networkSoftApConsumer, 0, ", ");
     systemPrintln();
 }
@@ -2465,7 +2473,7 @@ void networkUserDisplay(NetIndex_t index)
 
     // Determine if there are any users
     bits = netIfUsers[index];
-    systemPrintf("%s Users: %d", networkInterfaceTable[index].name, networkConsumerCount(bits));
+    systemPrintf("%s Users: %d", networkInterfaceTable[index].name, networkConsumerCountBits(bits));
     networkConsumerPrint(bits, 0, ", ");
     systemPrintln();
 }

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1528,7 +1528,7 @@ void networkPrintStatus(uint8_t priority)
 {
     NetMask_t bitMask;
     NETCONSUMER_MASK_t consumerMask;
-    NETCONSUMER_t consumers;
+    NETCONSUMER_MASK_t consumers;
     bool highestPriority;
     int index;
     const char *name;

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1355,7 +1355,7 @@ void networkInterfaceInternetConnectionLost(NetIndex_t index)
 bool networkIsHighestPriority(NetIndex_t index)
 {
     NetPriority_t priority;
-    bool higherPriority;
+    bool highestPriority;
 
     // Validate the index
     networkValidateIndex(index);
@@ -1364,10 +1364,10 @@ bool networkIsHighestPriority(NetIndex_t index)
     priority = networkPriority;
 
     // Determine if the specified interface has higher priority
-    higherPriority = (priority == NETWORK_OFFLINE);
-    if (!higherPriority)
-        higherPriority = (priority >= networkPriorityTable[index]);
-    return higherPriority;
+    highestPriority = (priority == NETWORK_OFFLINE);
+    if (highestPriority == false)
+        highestPriority = (priority >= networkPriorityTable[index]);
+    return highestPriority;
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -863,7 +863,7 @@ bool wifiStationReconnectionRequest()
 
 //*********************************************************************
 // Start WiFi with throttling, used by wifiStopSequence
-void wifiStationRestart(NetIndex_t index, uintptr_t parameter, bool debug)
+void wifiStationRestartOld(NetIndex_t index, uintptr_t parameter, bool debug)
 {
     // Check for network shutdown
     if (networkConsumerCount == 0)
@@ -3075,7 +3075,7 @@ NETWORK_POLL_SEQUENCE wifiStartSequence[] = {
 // WiFi stop sequence
 NETWORK_POLL_SEQUENCE wifiStopSequence[] = {
     //  State           Parameter   Description
-    {wifiStationRestart,    0,      "Restart WiFi"},
+    {wifiStationRestartOld, 0,      "Restart WiFi"},
     {wifiWaitNoUsers,       0,      "Wait for no WiFi users"},
     {wifiStop,              0,      "Shutdown WiFi"},
     {nullptr,               0,      "Termination"},

--- a/Firmware/RTK_Everywhere/makefile
+++ b/Firmware/RTK_Everywhere/makefile
@@ -24,9 +24,9 @@ DELETE=del /s
 DIR_LISTING=dir
 TERMINAL_APP=
 TERMINAL_PORT=
-TERMINAL_PARAMS=
+TERMINAL_PORT_LG209P=
 TERMINAL_PORT_TORCH=
-TERMINAL_PARAMS_TORCH=
+TERMINAL_PARAMS=
 
 # Windows NT generic paths
 USER_DIRECTORY_PATH=C:\Users\$(USERNAME)
@@ -59,9 +59,9 @@ DELETE=rm -Rf
 DIR_LISTING=ls
 TERMINAL_APP=minicom
 TERMINAL_PORT=/dev/ttyUSB0
-TERMINAL_PARAMS=-b 115200 -8 -D $(TERMINAL_PORT) < /dev/tty
+TERMINAL_PORT_LG290P=/dev/ttyACM0
 TERMINAL_PORT_TORCH=/dev/ttyACM1
-TERMINAL_PARAMS_TORCH=-b 115200 -8 -D $(TERMINAL_PORT_TORCH) < /dev/tty
+TERMINAL_PARAMS=-b 115200 -8 < /dev/tty
 
 # Linux generic paths
 USER_DIRECTORY_PATH=~
@@ -222,7 +222,27 @@ upload:	$(RTK_BIN_PATH)
          0x8000   $(BOOT_LOADER_PATH)RTK_Surveyor_Partitions_16MB.bin \
          0xe000   $(BOOT_LOADER_PATH)boot_app0.bin \
         0x10000   $<
-	$(TERMINAL_APP) $(TERMINAL_PARAMS)
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT)   $(TERMINAL_PARAMS)
+
+.PHONY: upload_lg290p
+
+upload_lg290p:	$(RTK_BIN_PATH)
+	python3 $(ESPTOOL_PATH)esptool.py \
+        --chip   esp32 \
+        --port   $(TERMINAL_PORT_LG290P) \
+        --baud   460800 \
+        --before   default_reset \
+        --after   hard_reset \
+        write_flash \
+        --flash_mode dio \
+        --flash_freq 80m \
+        --flash_size detect \
+        --compress \
+         0x1000   $(BOOT_LOADER_PATH)RTK_Surveyor.ino.bootloader.bin \
+         0x8000   $(BOOT_LOADER_PATH)RTK_Everywhere_Partitions_8MB.bin \
+         0xe000   $(BOOT_LOADER_PATH)boot_app0.bin \
+        0x10000   $<
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT_LG290P)   $(TERMINAL_PARAMS)
 
 .PHONY: upload_torch
 
@@ -242,17 +262,22 @@ upload_torch:	$(RTK_BIN_PATH)
          0x8000   $(BOOT_LOADER_PATH)RTK_Surveyor_Partitions_16MB.bin \
          0xe000   $(BOOT_LOADER_PATH)boot_app0.bin \
         0x10000   $<
-	$(TERMINAL_APP) $(TERMINAL_PARAMS_TORCH)
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT_TORCH)   $(TERMINAL_PARAMS)
 
 .PHONY:	terminal
 
 terminal:
-	$(TERMINAL_APP) $(TERMINAL_PARAMS)
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT)   $(TERMINAL_PARAMS)
+
+.PHONY:	terminal_lg290p
+
+terminal_lg290p:
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT_LG290P)   $(TERMINAL_PARAMS)
 
 .PHONY:	terminal_torch
 
 terminal_torch:
-	$(TERMINAL_APP) $(TERMINAL_PARAMS_TORCH)
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT_TORCH)   $(TERMINAL_PARAMS)
 
 ########
 # Clean the build directory

--- a/Firmware/RTK_Everywhere/makefile
+++ b/Firmware/RTK_Everywhere/makefile
@@ -135,7 +135,7 @@ lib-update:	core-update
 		"SparkFun Extensible Message Parser"@1.0.2 \
 		"SparkFun I2C Expander Arduino Library"@1.0.1 \
 		"SparkFun IM19 IMU Arduino Library"@1.0.1 \
-		"SparkFun LG290P Quadband RTK GNSS Arduino Library"@1.0.2
+		"SparkFun LG290P Quadband RTK GNSS Arduino Library"@1.0.5
 		"SparkFun LIS2DH12 Arduino Library"@1.0.3 \
 		"SparkFun MAX1704x Fuel Gauge Arduino Library"@1.0.4 \
 		"SparkFun Qwiic OLED Arduino Library"@1.0.13 \

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -8,13 +8,6 @@ void terminalUpdate()
     static bool passRtcmToGnss;
     static uint32_t rtcmTimer;
 
-    // Determine which items are periodically displayed
-    if ((millis() - lastPeriodicDisplay) >= settings.periodicDisplayInterval)
-    {
-        lastPeriodicDisplay = millis();
-        periodicDisplay = settings.periodicDisplay;
-    }
-
     // Check for USB serial input
     if (systemAvailable())
     {


### PR DESCRIPTION
Rebase on #653 

Changes:
* Network: Rename higherPriority to highestPriority
* Network: Rename *ConsumerCount to *ConsumerCountBits, add *ConsumerCount
* WiFi: Rename wifiStationRestart to wifiStationRestartOld