### PR TITLE
Add some routines to Network and WiFi

### DIFF
--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -220,6 +220,7 @@ bool wifiSoftApOn(const char * fileName, uint32_t lineNumber) {return false;}
 bool wifiStationOff(const char * fileName, uint32_t lineNumber) {return true;}
 bool wifiStationOn(const char * fileName, uint32_t lineNumber) {return false;}
 void wifiStopAll()                              {}
+void wifiUpdateSettings()                       {}
 void wifiVerifyTables()                         {}
 
 #endif // COMPILE_WIFI

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -219,6 +219,7 @@ bool wifiSoftApOff(const char * fileName, uint32_t lineNumber) {return true;}
 bool wifiSoftApOn(const char * fileName, uint32_t lineNumber) {return false;}
 bool wifiStationOff(const char * fileName, uint32_t lineNumber) {return true;}
 bool wifiStationOn(const char * fileName, uint32_t lineNumber) {return false;}
+void wifiStationUpdate()                        {}
 void wifiStopAll()                              {}
 void wifiUpdateSettings()                       {}
 void wifiVerifyTables()                         {}

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -220,6 +220,7 @@ bool wifiSoftApOn(const char * fileName, uint32_t lineNumber) {return false;}
 bool wifiStationOff(const char * fileName, uint32_t lineNumber) {return true;}
 bool wifiStationOn(const char * fileName, uint32_t lineNumber) {return false;}
 void wifiStopAll()                              {}
+void wifiVerifyTables()                         {}
 
 #endif // COMPILE_WIFI
 

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -2462,6 +2462,26 @@ void networkUserAdd(NETCONSUMER_t consumer,
 }
 
 //----------------------------------------
+// Get the network user bit mask
+//----------------------------------------
+NETCONSUMER_MASK_t networkUserBits(NetIndex_t index)
+{
+    // Validate the index
+    networkValidateIndex(index);
+
+    // Return the consumer bits
+    return netIfUsers[index];
+}
+
+//----------------------------------------
+// Count the number of network users
+//----------------------------------------
+int networkUserCount(NetIndex_t index)
+{
+    return networkConsumerCountBits(networkUserBits(index));
+}
+
+//----------------------------------------
 // Display the network interface users
 //----------------------------------------
 void networkUserDisplay(NetIndex_t index)

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -878,7 +878,7 @@ unsigned long loraLastIncomingSerial; // Last time a user sent a serial command.
 
 // Display boot times
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-#define MAX_BOOT_TIME_ENTRIES 41
+#define MAX_BOOT_TIME_ENTRIES 42
 uint8_t bootTimeIndex;
 uint32_t bootTime[MAX_BOOT_TIME_ENTRIES];
 const char *bootTimeString[MAX_BOOT_TIME_ENTRIES];
@@ -1257,6 +1257,9 @@ void setup()
 
     DMW_b("beginIdleTasks");
     beginIdleTasks(); // Requires settings. Enable processor load calculations
+
+    DMW_b("wifiUpdateSettings");
+    wifiUpdateSettings();
 
     DMW_b("networkBegin");
     networkBegin();

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -961,6 +961,14 @@ void wifiWaitNoUsers(NetIndex_t index, uintptr_t parameter, bool debug)
 }
 
 //*********************************************************************
+// Verify the WiFi tables
+void wifiVerifyTables()
+{
+    // Verify the RTK_WIFI tables
+    wifi.verifyTables();
+}
+
+//*********************************************************************
 // Constructor
 // Inputs:
 //   verbose: Set to true to display additional WiFi debug data

--- a/Firmware/RTK_Everywhere/support.ino
+++ b/Firmware/RTK_Everywhere/support.ino
@@ -723,9 +723,7 @@ void verifyTables()
     mosaicVerifyTables();
     correctionVerifyTables();
     webServerVerifyTables();
-#ifdef COMPILE_WIFI
-    wifi.verifyTables();
-#endif  // COMPILE_WIFI
+    wifiVerifyTables();
 
     if (CORR_NUM >= (int)('x' - 'a'))
         reportFatalError("Too many correction sources");


### PR DESCRIPTION
Rebase on #654 

Changes:
* WiFi: Add wifiVerifyTables
* Network: Add networkUserBits and networkUserCount
* WiFi: Add *GetStateName, *SetState and WiFi station restart states
* WiFi: Add wifiStationEnabled and wifiUpdateSettings
    The routines setup and menuWiFi call wifiUpdateSettings to determine if
    the SSIDs are available for WiFi station and soft AP and trigger a WiFi
    station restart.
    
    The wifiStationEnabled determines if the WiFi station state machine
    should start.
* WiFi: Add wifiStationUpdate
    Use WIFI_CONNECTION_STABLE_MSEC to determine when it is time to reset
    the connectionAttempts and startTimeout.
