### PR TITLE
WiFi: Switch to new restart

### DIFF
--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -220,6 +220,7 @@ bool wifiSoftApOn(const char * fileName, uint32_t lineNumber) {return false;}
 bool wifiStationOff(const char * fileName, uint32_t lineNumber) {return true;}
 bool wifiStationOn(const char * fileName, uint32_t lineNumber) {return false;}
 void wifiStopAll()                              {}
+void wifiUpdateSettings()                       {}
 void wifiVerifyTables()                         {}
 
 #endif // COMPILE_WIFI

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -210,9 +210,7 @@ void wifiDisplaySoftApStatus()                  {}
 bool wifiEspNowOff(const char * fileName, uint32_t lineNumber) {return true;}
 bool wifiEspNowOn(const char * fileName, uint32_t lineNumber) {return false;}
 void wifiEspNowSetChannel(WIFI_CHANNEL_t channel) {}
-uint32_t wifiGetStartTimeout()                  {return 0;}
 int wifiNetworkCount()                          {return 0;}
-void wifiResetThrottleTimeout()                 {}
 void wifiResetTimeout()                         {}
 IPAddress wifiSoftApGetIpAddress()              {return IPAddress((uint32_t)0);}
 const char * wifiSoftApGetSsid()                {return "";}

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -219,6 +219,7 @@ bool wifiSoftApOff(const char * fileName, uint32_t lineNumber) {return true;}
 bool wifiSoftApOn(const char * fileName, uint32_t lineNumber) {return false;}
 bool wifiStationOff(const char * fileName, uint32_t lineNumber) {return true;}
 bool wifiStationOn(const char * fileName, uint32_t lineNumber) {return false;}
+void wifiStationUpdate()                        {}
 void wifiStopAll()                              {}
 void wifiUpdateSettings()                       {}
 void wifiVerifyTables()                         {}

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -220,6 +220,7 @@ bool wifiSoftApOn(const char * fileName, uint32_t lineNumber) {return false;}
 bool wifiStationOff(const char * fileName, uint32_t lineNumber) {return true;}
 bool wifiStationOn(const char * fileName, uint32_t lineNumber) {return false;}
 void wifiStopAll()                              {}
+void wifiVerifyTables()                         {}
 
 #endif // COMPILE_WIFI
 

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -214,6 +214,7 @@ uint32_t wifiGetStartTimeout()                  {return 0;}
 int wifiNetworkCount()                          {return 0;}
 void wifiResetThrottleTimeout()                 {}
 void wifiResetTimeout()                         {}
+IPAddress wifiSoftApGetIpAddress()              {return IPAddress((uint32_t)0);}
 const char * wifiSoftApGetSsid()                {return "";}
 bool wifiSoftApOff(const char * fileName, uint32_t lineNumber) {return true;}
 bool wifiSoftApOn(const char * fileName, uint32_t lineNumber) {return false;}

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -2462,6 +2462,26 @@ void networkUserAdd(NETCONSUMER_t consumer,
 }
 
 //----------------------------------------
+// Get the network user bit mask
+//----------------------------------------
+NETCONSUMER_MASK_t networkUserBits(NetIndex_t index)
+{
+    // Validate the index
+    networkValidateIndex(index);
+
+    // Return the consumer bits
+    return netIfUsers[index];
+}
+
+//----------------------------------------
+// Count the number of network users
+//----------------------------------------
+int networkUserCount(NetIndex_t index)
+{
+    return networkConsumerCountBits(networkUserBits(index));
+}
+
+//----------------------------------------
 // Display the network interface users
 //----------------------------------------
 void networkUserDisplay(NetIndex_t index)

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -2314,17 +2314,7 @@ void networkUpdate()
 
         // Handle the network lost internet event
         if (networkEventInternetLost[index])
-        {
             networkInterfaceInternetConnectionLost(index);
-
-            // Attempt to restart WiFi
-            if ((index == NETWORK_WIFI_STATION) && (networkIsHighestPriority(index)))
-            {
-                if (networkIsStarted(index))
-                    networkStop(index, settings.debugWifiState, __FILE__, __LINE__);
-                networkStart(index, settings.debugWifiState, __FILE__, __LINE__);
-            }
-        }
 
         // Handle the network stop event
         if (networkEventStop[index])
@@ -2359,6 +2349,9 @@ void networkUpdate()
                 pollRoutine(index, sequence->parameter, settings.debugNetworkLayer);
         }
     }
+
+    // Update the WiFi state
+    wifiStationUpdate();
 
     // Update the network services
     // Start or stop mDNS

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1366,7 +1366,7 @@ bool networkIsHighestPriority(NetIndex_t index)
     // Determine if the specified interface has higher priority
     higherPriority = (priority == NETWORK_OFFLINE);
     if (!higherPriority)
-        higherPriority = (priority > networkPriorityTable[index]);
+        higherPriority = (priority >= networkPriorityTable[index]);
     return higherPriority;
 }
 

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -502,9 +502,17 @@ NETCONSUMER_MASK_t networkConsumerBits(NetIndex_t index)
 }
 
 //----------------------------------------
+// Count the number of network consumers
+//----------------------------------------
+int networkConsumerCount(NetIndex_t index)
+{
+    return networkConsumerCountBits(networkConsumerBits(index));
+}
+
+//----------------------------------------
 // Count the network consumer bits
 //----------------------------------------
-int networkConsumerCount(NETCONSUMER_MASK_t bits)
+int networkConsumerCountBits(NETCONSUMER_MASK_t bits)
 {
     int bitCount;
     NETCONSUMER_MASK_t bitMask;
@@ -543,7 +551,7 @@ void networkConsumerDisplay()
         bits |= netIfConsumers[index];
         users = netIfUsers[index];
     }
-    systemPrintf("Network Consumers: %d", networkConsumerCount(bits));
+    systemPrintf("Network Consumers: %d", networkConsumerCountBits(bits));
     networkConsumerPrint(bits, users, ", ");
     systemPrintln();
 
@@ -2025,7 +2033,7 @@ NETCONSUMER_MASK_t networkSoftApConsumerBits()
 //----------------------------------------
 void networkSoftApConsumerDisplay()
 {
-    systemPrintf("WiFi Soft AP Consumers: %d", networkConsumerCount(networkSoftApConsumer));
+    systemPrintf("WiFi Soft AP Consumers: %d", networkConsumerCountBits(networkSoftApConsumer));
     networkConsumerPrint(networkSoftApConsumer, 0, ", ");
     systemPrintln();
 }
@@ -2465,7 +2473,7 @@ void networkUserDisplay(NetIndex_t index)
 
     // Determine if there are any users
     bits = netIfUsers[index];
-    systemPrintf("%s Users: %d", networkInterfaceTable[index].name, networkConsumerCount(bits));
+    systemPrintf("%s Users: %d", networkInterfaceTable[index].name, networkConsumerCountBits(bits));
     networkConsumerPrint(bits, 0, ", ");
     systemPrintln();
 }

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1528,7 +1528,7 @@ void networkPrintStatus(uint8_t priority)
 {
     NetMask_t bitMask;
     NETCONSUMER_MASK_t consumerMask;
-    NETCONSUMER_t consumers;
+    NETCONSUMER_MASK_t consumers;
     bool highestPriority;
     int index;
     const char *name;

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -2301,10 +2301,7 @@ void networkStartDelayed(NetIndex_t index, uintptr_t parameter, bool debug)
 //----------------------------------------
 void networkUpdate()
 {
-    bool displayIpAddress;
     NetIndex_t index;
-    IPAddress ipAddress;
-    bool ipAddressDisplayed;
     uint8_t networkType;
     NETWORK_POLL_ROUTINE pollRoutine;
     uint8_t priority;
@@ -2389,44 +2386,62 @@ void networkUpdate()
     webServerUpdate(); // Start webServer for web config as needed
 
     // Periodically display the network interface state
-    displayIpAddress = PERIODIC_DISPLAY(PD_IP_ADDRESS);
-    for (int index = 0; index < NETWORK_OFFLINE; index++)
-    {
-        // Display the current state
-        ipAddressDisplayed = displayIpAddress && (index == networkPriority);
-        if (PERIODIC_DISPLAY(networkInterfaceTable[index].pdState) || PERIODIC_DISPLAY(PD_NETWORK_STATE) ||
-            ipAddressDisplayed)
-        {
-            PERIODIC_CLEAR(networkInterfaceTable[index].pdState);
-            if (networkInterfaceTable[index].netif->hasIP())
-            {
-                ipAddress = networkInterfaceTable[index].netif->localIP();
-                systemPrintf("%s: %s%s\r\n", networkInterfaceTable[index].name, ipAddress.toString().c_str(),
-                             networkInterfaceTable[index].netif->isDefault() ? " (default)" : "");
-            }
-            else if (networkInterfaceTable[index].netif->linkUp())
-                systemPrintf("%s: Link Up\r\n", networkInterfaceTable[index].name);
-            else if (networkInterfaceTable[index].netif->started())
-                systemPrintf("%s: Started\r\n", networkInterfaceTable[index].name);
-
-            else if (index == NETWORK_WIFI_STATION && (WiFi.getMode() == WIFI_AP || WiFi.getMode() == WIFI_AP_STA))
-            {
-                // NETIF doesn't capture the IP address of a soft AP
-                ipAddress = WiFi.softAPIP();
-                systemPrintf("%s: %s%s\r\n", networkInterfaceTable[index].name, ipAddress.toString().c_str(),
-                             networkInterfaceTable[index].netif->isDefault() ? " (default)" : "");
-            }
-            else
-                systemPrintf("%s: Stopped\r\n", networkInterfaceTable[index].name);
-        }
-    }
     if (PERIODIC_DISPLAY(PD_NETWORK_STATE))
-        PERIODIC_CLEAR(PD_NETWORK_STATE);
-    if (displayIpAddress)
     {
-        if (!ipAddressDisplayed)
-            systemPrintln("Network: Offline");
+        PERIODIC_CLEAR(PD_NETWORK_STATE);
         PERIODIC_CLEAR(PD_IP_ADDRESS);
+        for (int index = 0; index < NETWORK_OFFLINE; index++)
+            PERIODIC_CLEAR(networkInterfaceTable[index].pdState);
+
+        // Display the network state
+        networkDisplayStatus();
+    }
+
+    // Periodically display the IP address
+    else if (PERIODIC_DISPLAY(PD_IP_ADDRESS))
+    {
+        int index;
+        IPAddress ipAddress;
+
+        PERIODIC_CLEAR(PD_IP_ADDRESS);
+
+        // Display the IP address of the highest priority network
+        index = networkPriorityTable[networkPriority];
+        if ((index < NETWORK_OFFLINE)
+            && networkInterfaceHasInternet(index)
+            && networkInterfaceTable[index].netif->hasIP())
+        {
+            ipAddress = networkInterfaceTable[index].netif->localIP();
+            systemPrintf("%s: %s%s\r\n",
+                         networkInterfaceTable[index].name,
+                         ipAddress.toString().c_str(),
+                         networkInterfaceTable[index].netif->isDefault() ? " (default)" : "");
+        }
+        else
+            systemPrintf("Network: Offline\r\n");
+
+        // Display the soft AP IP address
+        if (wifiSoftApOnline)
+        {
+            ipAddress = wifiSoftApGetIpAddress();
+            systemPrintf("WiFi Soft AP: %s\r\n", ipAddress.toString().c_str());
+        }
+        else
+            systemPrintf("WiFi Soft AP: Offline\r\n");
+    }
+
+    // Periodically display an interface state
+    else
+    {
+        for (int index = 0; index < NETWORK_OFFLINE; index++)
+            if (PERIODIC_DISPLAY(networkInterfaceTable[index].pdState))
+            {
+                PERIODIC_CLEAR(networkInterfaceTable[index].pdState);
+
+                // Display the state for an interface
+                networkPrintStatus(index);
+                networkDisplayInterface(index);
+            }
     }
 }
 

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1355,7 +1355,7 @@ void networkInterfaceInternetConnectionLost(NetIndex_t index)
 bool networkIsHighestPriority(NetIndex_t index)
 {
     NetPriority_t priority;
-    bool higherPriority;
+    bool highestPriority;
 
     // Validate the index
     networkValidateIndex(index);
@@ -1364,10 +1364,10 @@ bool networkIsHighestPriority(NetIndex_t index)
     priority = networkPriority;
 
     // Determine if the specified interface has higher priority
-    higherPriority = (priority == NETWORK_OFFLINE);
-    if (!higherPriority)
-        higherPriority = (priority >= networkPriorityTable[index]);
-    return higherPriority;
+    highestPriority = (priority == NETWORK_OFFLINE);
+    if (highestPriority == false)
+        highestPriority = (priority >= networkPriorityTable[index]);
+    return highestPriority;
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -878,7 +878,7 @@ unsigned long loraLastIncomingSerial; // Last time a user sent a serial command.
 
 // Display boot times
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-#define MAX_BOOT_TIME_ENTRIES 41
+#define MAX_BOOT_TIME_ENTRIES 42
 uint8_t bootTimeIndex;
 uint32_t bootTime[MAX_BOOT_TIME_ENTRIES];
 const char *bootTimeString[MAX_BOOT_TIME_ENTRIES];
@@ -1257,6 +1257,9 @@ void setup()
 
     DMW_b("beginIdleTasks");
     beginIdleTasks(); // Requires settings. Enable processor load calculations
+
+    DMW_b("wifiUpdateSettings");
+    wifiUpdateSettings();
 
     DMW_b("networkBegin");
     networkBegin();

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -961,6 +961,14 @@ void wifiWaitNoUsers(NetIndex_t index, uintptr_t parameter, bool debug)
 }
 
 //*********************************************************************
+// Verify the WiFi tables
+void wifiVerifyTables()
+{
+    // Verify the RTK_WIFI tables
+    wifi.verifyTables();
+}
+
+//*********************************************************************
 // Constructor
 // Inputs:
 //   verbose: Set to true to display additional WiFi debug data

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -1468,7 +1468,7 @@ bool RTK_WIFI::enable(bool enableESPNow,
     if (enableSoftAP)
     {
         // Verify that the SSID is set
-        if (wifiSoftApSsid && strlen(wifiSoftApSsid))
+        if (wifiSoftApSsidSet)
         {
             // Allocate the soft AP SSID
             if (!_apSsid)
@@ -1498,10 +1498,7 @@ bool RTK_WIFI::enable(bool enableESPNow,
     if (enableStation)
     {
         // Verify that at least one SSID is set
-        for (authIndex = 0; authIndex < MAX_WIFI_NETWORKS; authIndex++)
-            if (strlen(settings.wifiNetworks[authIndex].ssid))
-                break;
-        if (authIndex >= MAX_WIFI_NETWORKS)
+        if (wifiStationSsidSet == false)
         {
             systemPrintf("ERROR: No valid SSID in settings\r\n");
             displayNoSSIDs(2000);

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -378,24 +378,16 @@ const int wifiStartNamesEntries = sizeof(wifiStartNames) / sizeof(wifiStartNames
 // DNS server for Captive Portal
 static DNSServer dnsServer;
 
-static int wifiFailedConnectionAttempts = 0; // Count the number of connection attempts between restarts
-static bool wifiReconnectRequest; // Set true to request WiFi reconnection
-
 const char * wifiSoftApName = "Soft AP";
 bool wifiSoftApSsidSet; // Set when the WiFi soft AP SSID string exists
 bool wifiStationRestart; // Restart Wifi station
 bool wifiStationSsidSet; // Set when one or more SSID strings exist
-
-// Start timeout
-static uint32_t wifiStartTimeout;
 
 //*********************************************************************
 // Set WiFi credentials
 // Enable TCP connections
 void menuWiFi()
 {
-    bool wifiRestartRequested;      // Restart WiFi if user changes anything
-
     while (1)
     {
         networkDisplayInterface(NETWORK_WIFI_STATION);
@@ -437,14 +429,11 @@ void menuWiFi()
             }
 
             // If we are modifying the SSID table, force restart of WiFi
-            wifiRestartRequested = true;
-            wifiFailedConnectionAttempts = 0;
             wifiUpdateSettings();
         }
         else if (incoming == 'a')
         {
             settings.wifiConfigOverAP ^= 1;
-            wifiRestartRequested = true;
             wifiUpdateSettings();
         }
         else if (incoming == 'c')
@@ -466,13 +455,6 @@ void menuWiFi()
     {
         if (strlen(settings.wifiNetworks[x].ssid) == 0)
             strcpy(settings.wifiNetworks[x].password, "");
-    }
-
-    if (wifiRestartRequested)
-    {
-        // Fake the loss of the IP address
-        networkInterfaceEventInternetLost(NETWORK_WIFI_STATION, __FILE__, __LINE__);
-        wifiReconnectRequest = true;
     }
 
     clearBuffer(); // Empty buffer of any newline chars
@@ -625,13 +607,6 @@ bool wifiEspNowOn(const char * fileName, uint32_t lineNumber)
 }
 
 //*********************************************************************
-// Return the start timeout in milliseconds
-uint32_t wifiGetStartTimeout()
-{
-    return (wifiStartTimeout);
-}
-
-//*********************************************************************
 // Counts the number of entered SSIDs
 int wifiNetworkCount()
 {
@@ -687,25 +662,6 @@ void wifiPromiscuousRxHandler(void *buf, wifi_promiscuous_pkt_type_t type)
 
     ppkt = (wifi_promiscuous_pkt_t *)buf;
     packetRSSI = ppkt->rx_ctrl.rssi;
-}
-
-//*********************************************************************
-// Reset the last WiFi start attempt
-// Useful when WiFi settings have changed
-void wifiResetThrottleTimeout()
-{
-    wifiReconnectionTimer = millis() - WIFI_MAX_TIMEOUT;
-}
-
-//*********************************************************************
-// Set WiFi timeout back to zero
-// Useful if other things (such as a successful ethernet connection) need
-// to reset wifi timeout
-void wifiResetTimeout()
-{
-    wifiStartTimeout = 0;
-    if (settings.debugWifiState == true)
-        systemPrintln("WiFi: Start timeout reset to zero");
 }
 
 //*********************************************************************
@@ -770,31 +726,6 @@ bool wifiSoftApOn(const char * fileName, uint32_t lineNumber)
                        true,
                        wifiStationRunning,
                        __FILE__, __LINE__);
-}
-
-//*********************************************************************
-// Start WiFi with throttling, used by wifiStopSequence
-void wifiStartThrottled(NetIndex_t index, uintptr_t parameter, bool debug)
-{
-    // Check for network shutdown
-    if (networkConsumerCount == 0)
-    {
-        // Stop the connection attempts
-        wifiResetThrottleTimeout();
-        wifiResetTimeout();
-        networkSequenceExit(NETWORK_WIFI_STATION, debug, __FILE__, __LINE__);
-        return;
-    }
-
-    if (wifiReconnectRequest)
-    {
-        wifiReconnectRequest = false;
-        if (settings.debugWifiState)
-            systemPrintf("WiFi: Attempting WiFi restart\r\n");
-    }
-
-    if (wifiStationReconnectionRequest())
-        networkSequenceNextEntry(NETWORK_WIFI_STATION, debug);
 }
 
 //*********************************************************************
@@ -933,103 +864,6 @@ void wifiStationSetState(uint8_t newState)
 
     // Set the new state
     wifiStationState = newState;
-}
-
-//*********************************************************************
-// Handle WiFi station reconnection requests
-bool wifiStationReconnectionRequest()
-{
-    bool connected;
-    int minutes;
-    int seconds;
-
-    // Restart delay
-    connected = false;
-    if ((millis() - wifiReconnectionTimer) < wifiStartTimeout)
-        return connected;
-    wifiReconnectionTimer = millis();
-
-    // Attempt to start WiFi station
-    if (wifiStationOn(__FILE__, __LINE__))
-    {
-        // Successfully connected to a remote AP
-        connected = true;
-        if (settings.debugWifiState)
-            systemPrintf("WiFi: WiFi station successfully started\r\n");
-        networkSequenceNextEntry(NETWORK_WIFI_STATION, settings.debugNetworkLayer);
-        wifiFailedConnectionAttempts = 0;
-    }
-    else
-    {
-        // Failed to connect to a remote AP
-        if (settings.debugWifiState)
-            systemPrintf("WiFi: WiFi station failed to start!\r\n");
-
-        // Account for this connection attempt
-        wifiFailedConnectionAttempts++;
-
-        // Start the next network interface if necessary
-        if (wifiFailedConnectionAttempts >= 2)
-            networkStartNextInterface(NETWORK_WIFI_STATION);
-
-        // Increase the timeout
-        wifiStartTimeout <<= 1;
-        if (!wifiStartTimeout)
-            wifiStartTimeout = WIFI_MIN_TIMEOUT;
-        else if (wifiStartTimeout > WIFI_MAX_TIMEOUT)
-            wifiStartTimeout = WIFI_MAX_TIMEOUT;
-
-        // Display the delay
-        seconds = wifiStartTimeout / MILLISECONDS_IN_A_SECOND;
-        minutes = seconds / SECONDS_IN_A_MINUTE;
-        seconds -= minutes * SECONDS_IN_A_MINUTE;
-        if (settings.debugWifiState)
-            systemPrintf("WiFi: Delaying %2d:%02d before restarting WiFi\r\n", minutes, seconds);
-    }
-    return connected;
-}
-
-//*********************************************************************
-// Start WiFi with throttling, used by wifiStopSequence
-void wifiStationRestartOld(NetIndex_t index, uintptr_t parameter, bool debug)
-{
-    // Check for network shutdown
-    if (networkConsumerCount == 0)
-    {
-        // Stop the connection attempts
-        wifiResetThrottleTimeout();
-        wifiResetTimeout();
-        networkSequenceExit(NETWORK_WIFI_STATION, debug, __FILE__, __LINE__);
-        return;
-    }
-
-    // Check for a reconnection request
-    if (wifiReconnectRequest)
-    {
-        // Fake a WiFi failure
-        networkConsumerReconnect(NETWORK_WIFI_STATION);
-        networkInterfaceEventInternetLost(NETWORK_WIFI_STATION, __FILE__, __LINE__);
-
-        // Clear the bits to perform the restart operation
-        wifi.clearStarted(WIFI_STA_RECONNECT);
-    }
-    wifi.clearStarted(WIFI_STA_ONLINE);
-    wifiStationOnline = false;
-
-    // Continue the stop sequence
-    networkSequenceNextEntry(NETWORK_WIFI_STATION, debug);
-}
-
-//*********************************************************************
-// Stop WiFi, used by wifiStopSequence
-void wifiStop(NetIndex_t index, uintptr_t parameter, bool debug)
-{
-    networkInterfaceInternetConnectionLost(NETWORK_WIFI_STATION);
-
-    // Stop WiFi station
-    wifi.enable(wifiEspNowRunning, wifiSoftApRunning, false, __FILE__, __LINE__);
-
-    networkSequenceNextEntry(NETWORK_WIFI_STATION, settings.debugNetworkLayer);
 }
 
 //*********************************************************************
@@ -1226,45 +1060,6 @@ void wifiStopAll()
 }
 
 //*********************************************************************
-// Wait for WiFi users to release their connections
-void wifiWaitNoUsers(NetIndex_t index, uintptr_t parameter, bool debug)
-{
-    static uint32_t lastMsec;
-
-    // Check for network shutdown
-    if (networkConsumerCount == 0)
-    {
-        // Stop the connection attempts
-        wifiResetThrottleTimeout();
-        wifiResetTimeout();
-        networkSequenceExit(NETWORK_WIFI_STATION, debug, __FILE__, __LINE__);
-        return;
-    }
-
-    // Check for WiFi station users
-    if (networkUsersActive(NETWORK_WIFI_STATION) == 0)
-    {
-        // None, continue the start sequence
-        if (settings.debugWifiState)
-            systemPrintf("WiFi: No users\r\n");
-
-        // Continue the stop sequence
-        networkSequenceNextEntry(NETWORK_WIFI_STATION, debug);
-    }
-    else
-    {
-        // Display the network users
-        uint32_t currentMsec = millis();
-        if (settings.debugWifiState && ((currentMsec - lastMsec) > (2 * 1000)))
-        {
-            lastMsec = currentMsec;
-            systemPrintf("WiFi: Waiting for WiFi users to shutdown\r\n");
-            networkUserDisplay(NETWORK_WIFI_STATION);
-        }
-    }
-}
-
-//*********************************************************************
 // Determine if any of the WiFi station SSID values are set
 void wifiUpdateSettings()
 {
@@ -1324,8 +1119,6 @@ RTK_WIFI::RTK_WIFI(bool verbose)
     wifiChannel = 0;
     wifiEspNowOnline = false;
     wifiEspNowRunning = false;
-    wifiFailedConnectionAttempts = 0;
-    wifiReconnectionTimer = 0;
     wifiSoftApOnline = false;
     wifiSoftApRunning = false;
     wifiStationOnline = false;
@@ -1335,10 +1128,6 @@ RTK_WIFI::RTK_WIFI(bool verbose)
     _apSsid = (char *)rtkMalloc(SSID_LENGTH, "SSID string (_apSsid)");
     if (_apSsid)
         _apSsid[0] = 0;
-
-    // Prepare to start WiFi immediately
-    wifiResetThrottleTimeout();
-    wifiResetTimeout();
 }
 
 //*********************************************************************
@@ -2074,8 +1863,6 @@ bool RTK_WIFI::stationConnectAP()
                          wifiChannel,
                          (_staAuthType < WIFI_AUTH_MAX) ? wifiAuthorizationName[_staAuthType] : "Unknown");
 
-        // Don't delay the next WiFi start request
-        wifiResetTimeout();
     } while (0);
     return connected;
 }
@@ -2168,10 +1955,7 @@ void RTK_WIFI::stationEventHandler(arduino_event_id_t event, arduino_event_info_
     case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
         // Start the reconnection timer
         if (event == ARDUINO_EVENT_WIFI_STA_DISCONNECTED)
-        {
             networkInterfaceEventInternetLost(NETWORK_WIFI_STATION, __FILE__, __LINE__);
-            wifiReconnectRequest = true;
-        }
 
         // Fall through
         //      |
@@ -2193,10 +1977,7 @@ void RTK_WIFI::stationEventHandler(arduino_event_id_t event, arduino_event_info_
 
     case ARDUINO_EVENT_WIFI_STA_LOST_IP:
         if (event == ARDUINO_EVENT_WIFI_STA_LOST_IP)
-        {
             networkInterfaceEventInternetLost(NETWORK_WIFI_STATION, __FILE__, __LINE__);
-            wifiReconnectRequest = true;
-        }
 
         // Mark the WiFi station offline
         if (_started & WIFI_STA_ONLINE)
@@ -2458,7 +2239,6 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
     WIFI_ACTION_t notStarted;
     uint8_t primaryChannel;
     WIFI_ACTION_t restarting;
-    bool restartWiFiStation;
     wifi_second_chan_t secondaryChannel;
     WIFI_ACTION_t startingNow;
     esp_err_t status;
@@ -2466,7 +2246,6 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
 
     // Determine the next actions
     notStarted = 0;
-    restartWiFiStation = false;
 
     // Display the parameters
     if (settings.debugWifiState && _verbose)
@@ -3020,8 +2799,6 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         // Start the WiFi station components
         //****************************************
 
-        restartWiFiStation = true;
-
         // Set the host name
         if (starting & WIFI_STA_SET_HOST_NAME)
         {
@@ -3088,7 +2865,6 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         // Mark the station online
         if (starting & WIFI_STA_ONLINE)
         {
-            restartWiFiStation = false;
             _started = _started | WIFI_STA_ONLINE;
             systemPrintf("WiFi: Station online (%s: %s)\r\n",
                          _staRemoteApSsid, _staIpAddress.toString().c_str());
@@ -3240,10 +3016,6 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
 
     if (settings.debugWifiState && _verbose && _started)
         displayComponents("Started items", _started);
-
-    // Restart WiFi if necessary
-    if (restartWiFiStation)
-        wifiReconnectRequest = true;
 
     // Set the online flags
     wifiEspNowOnline = espNowOnline();
@@ -3401,23 +3173,5 @@ void RTK_WIFI::verifyTables()
         reportFatalError("Fix wifiStartNames list to match list of defines!!");
     }
 }
-
-//****************************************
-// WiFi start sequence
-NETWORK_POLL_SEQUENCE wifiStartSequence[] = {
-    //  State           Parameter   Description
-    {wifiStartThrottled,    0,      "Initialize WiFi"},
-    {nullptr,               0,      "Termination"},
-};
-
-//****************************************
-// WiFi stop sequence
-NETWORK_POLL_SEQUENCE wifiStopSequence[] = {
-    //  State           Parameter   Description
-    {wifiStationRestartOld, 0,      "Restart WiFi"},
-    {wifiWaitNoUsers,       0,      "Wait for no WiFi users"},
-    {wifiStop,              0,      "Shutdown WiFi"},
-    {nullptr,               0,      "Termination"},
-};
 
 #endif  // COMPILE_WIFI

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -863,7 +863,7 @@ bool wifiStationReconnectionRequest()
 
 //*********************************************************************
 // Start WiFi with throttling, used by wifiStopSequence
-void wifiStationRestart(NetIndex_t index, uintptr_t parameter, bool debug)
+void wifiStationRestartOld(NetIndex_t index, uintptr_t parameter, bool debug)
 {
     // Check for network shutdown
     if (networkConsumerCount == 0)
@@ -3075,7 +3075,7 @@ NETWORK_POLL_SEQUENCE wifiStartSequence[] = {
 // WiFi stop sequence
 NETWORK_POLL_SEQUENCE wifiStopSequence[] = {
     //  State           Parameter   Description
-    {wifiStationRestart,    0,      "Restart WiFi"},
+    {wifiStationRestartOld, 0,      "Restart WiFi"},
     {wifiWaitNoUsers,       0,      "Wait for no WiFi users"},
     {wifiStop,              0,      "Shutdown WiFi"},
     {nullptr,               0,      "Termination"},

--- a/Firmware/RTK_Everywhere/makefile
+++ b/Firmware/RTK_Everywhere/makefile
@@ -24,9 +24,9 @@ DELETE=del /s
 DIR_LISTING=dir
 TERMINAL_APP=
 TERMINAL_PORT=
-TERMINAL_PARAMS=
+TERMINAL_PORT_LG209P=
 TERMINAL_PORT_TORCH=
-TERMINAL_PARAMS_TORCH=
+TERMINAL_PARAMS=
 
 # Windows NT generic paths
 USER_DIRECTORY_PATH=C:\Users\$(USERNAME)
@@ -59,9 +59,9 @@ DELETE=rm -Rf
 DIR_LISTING=ls
 TERMINAL_APP=minicom
 TERMINAL_PORT=/dev/ttyUSB0
-TERMINAL_PARAMS=-b 115200 -8 -D $(TERMINAL_PORT) < /dev/tty
+TERMINAL_PORT_LG290P=/dev/ttyACM0
 TERMINAL_PORT_TORCH=/dev/ttyACM1
-TERMINAL_PARAMS_TORCH=-b 115200 -8 -D $(TERMINAL_PORT_TORCH) < /dev/tty
+TERMINAL_PARAMS=-b 115200 -8 < /dev/tty
 
 # Linux generic paths
 USER_DIRECTORY_PATH=~
@@ -222,7 +222,27 @@ upload:	$(RTK_BIN_PATH)
          0x8000   $(BOOT_LOADER_PATH)RTK_Surveyor_Partitions_16MB.bin \
          0xe000   $(BOOT_LOADER_PATH)boot_app0.bin \
         0x10000   $<
-	$(TERMINAL_APP) $(TERMINAL_PARAMS)
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT)   $(TERMINAL_PARAMS)
+
+.PHONY: upload_lg290p
+
+upload_lg290p:	$(RTK_BIN_PATH)
+	python3 $(ESPTOOL_PATH)esptool.py \
+        --chip   esp32 \
+        --port   $(TERMINAL_PORT_LG290P) \
+        --baud   460800 \
+        --before   default_reset \
+        --after   hard_reset \
+        write_flash \
+        --flash_mode dio \
+        --flash_freq 80m \
+        --flash_size detect \
+        --compress \
+         0x1000   $(BOOT_LOADER_PATH)RTK_Surveyor.ino.bootloader.bin \
+         0x8000   $(BOOT_LOADER_PATH)RTK_Everywhere_Partitions_8MB.bin \
+         0xe000   $(BOOT_LOADER_PATH)boot_app0.bin \
+        0x10000   $<
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT_LG290P)   $(TERMINAL_PARAMS)
 
 .PHONY: upload_torch
 
@@ -242,17 +262,22 @@ upload_torch:	$(RTK_BIN_PATH)
          0x8000   $(BOOT_LOADER_PATH)RTK_Surveyor_Partitions_16MB.bin \
          0xe000   $(BOOT_LOADER_PATH)boot_app0.bin \
         0x10000   $<
-	$(TERMINAL_APP) $(TERMINAL_PARAMS_TORCH)
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT_TORCH)   $(TERMINAL_PARAMS)
 
 .PHONY:	terminal
 
 terminal:
-	$(TERMINAL_APP) $(TERMINAL_PARAMS)
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT)   $(TERMINAL_PARAMS)
+
+.PHONY:	terminal_lg290p
+
+terminal_lg290p:
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT_LG290P)   $(TERMINAL_PARAMS)
 
 .PHONY:	terminal_torch
 
 terminal_torch:
-	$(TERMINAL_APP) $(TERMINAL_PARAMS_TORCH)
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT_TORCH)   $(TERMINAL_PARAMS)
 
 ########
 # Clean the build directory

--- a/Firmware/RTK_Everywhere/makefile
+++ b/Firmware/RTK_Everywhere/makefile
@@ -135,7 +135,7 @@ lib-update:	core-update
 		"SparkFun Extensible Message Parser"@1.0.2 \
 		"SparkFun I2C Expander Arduino Library"@1.0.1 \
 		"SparkFun IM19 IMU Arduino Library"@1.0.1 \
-		"SparkFun LG290P Quadband RTK GNSS Arduino Library"@1.0.2
+		"SparkFun LG290P Quadband RTK GNSS Arduino Library"@1.0.5
 		"SparkFun LIS2DH12 Arduino Library"@1.0.3 \
 		"SparkFun MAX1704x Fuel Gauge Arduino Library"@1.0.4 \
 		"SparkFun Qwiic OLED Arduino Library"@1.0.13 \

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -8,13 +8,6 @@ void terminalUpdate()
     static bool passRtcmToGnss;
     static uint32_t rtcmTimer;
 
-    // Determine which items are periodically displayed
-    if ((millis() - lastPeriodicDisplay) >= settings.periodicDisplayInterval)
-    {
-        lastPeriodicDisplay = millis();
-        periodicDisplay = settings.periodicDisplay;
-    }
-
     // Check for USB serial input
     if (systemAvailable())
     {

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1886,7 +1886,7 @@ const NETWORK_TABLE_ENTRY networkInterfaceTable[] =
     #endif  // COMPILE_ETHERNET
 
     #ifdef COMPILE_WIFI
-        {&WiFi.STA, true,   NETWORK_WIFI_STATION,   PD_WIFI_STATE,      nullptr,                wifiStartSequence,  wifiStopSequence,   "WiFi",                 nullptr},
+        {&WiFi.STA, true,   NETWORK_WIFI_STATION,   PD_WIFI_STATE,      nullptr,                nullptr,            nullptr,            "WiFi Station",         nullptr},
     #else
         {nullptr,   false,  NETWORK_WIFI_STATION,   PD_WIFI_STATE,      nullptr,                nullptr,            nullptr,            "WiFi-NotCompiled",     nullptr},
     #endif  // COMPILE_WIFI

--- a/Firmware/RTK_Everywhere/support.ino
+++ b/Firmware/RTK_Everywhere/support.ino
@@ -723,9 +723,7 @@ void verifyTables()
     mosaicVerifyTables();
     correctionVerifyTables();
     webServerVerifyTables();
-#ifdef COMPILE_WIFI
-    wifi.verifyTables();
-#endif  // COMPILE_WIFI
+    wifiVerifyTables();
 
     if (CORR_NUM >= (int)('x' - 'a'))
         reportFatalError("Too many correction sources");


### PR DESCRIPTION
Rebase on #655 

Changes:
* WiFi: Change "WiFi" to "WiFi Station" in networkInterfaceTable
* Network: Update periodically display to show more data
* WiFi: Switch to using *SsidSet variables set in wifiUpdateSettings
* WiFi: Use new restart based upon wifiStationUpdate
