### PR TITLE
Update TCP server to better work as an NTRIP or base caster

### DIFF
--- a/Firmware/RTK_Everywhere/AP-Config/index.html
+++ b/Firmware/RTK_Everywhere/AP-Config/index.html
@@ -1637,6 +1637,17 @@
                             <span class="icon-info-circle text-primary ms-2"></span>
                         </span>
                     </div>
+                    <div id="tcpWiFiTypeDropdown" class="mt-3">
+                        <label for="tcpOverWiFiStation">TCP Server Connection: </label>
+                        <select name="tcpWiFiType" id="tcpOverWiFiStation" class="form-dropdown">
+                            <option value="1">WiFi</option>
+                            <option value="0">AP</option>
+                        </select>
+                        <span class="tt" data-bs-placement="right"
+                            title="In WiFi mode, the device will attempt to connect to local WiFi to broadcast TCP packets. In AP mode, the device will become an Access Point that devices can connect to over WiFi.">
+                            <span class="icon-info-circle text-primary ms-2"></span>
+                        </span>
+                    </div>
                 </div>
                 <div class="form-group row">
                     <p id="enableTcpServerError" class="inlineError"></p>
@@ -1676,18 +1687,6 @@
                 </div>
                 <div class="form-group row">
                     <p id="enableUdpServerError" class="inlineError"></p>
-                </div>
-
-                <div id="tcpWiFiTypeDropdown" class="mt-3">
-                    <label for="tcpOverWiFiStation">TCP Server Connection: </label>
-                    <select name="tcpWiFiType" id="tcpOverWiFiStation" class="form-dropdown">
-                        <option value="1">WiFi</option>
-                        <option value="0">AP</option>
-                    </select>
-                    <span class="tt" data-bs-placement="right"
-                        title="In WiFi mode, the device will attempt to connect to local WiFi to broadcast TCP/UDP packets. In AP mode, the device will become an Access Point that devices can connect to over WiFi.">
-                        <span class="icon-info-circle text-primary ms-2"></span>
-                    </span>
                 </div>
             </div>
         </div>

--- a/Firmware/RTK_Everywhere/AP-Config/index.html
+++ b/Firmware/RTK_Everywhere/AP-Config/index.html
@@ -1678,9 +1678,9 @@
                     <p id="enableUdpServerError" class="inlineError"></p>
                 </div>
 
-                <div id="tcpUdpWiFiTypeDropdown" class="mt-3">
-                    <label for="tcpUdpOverWiFiStation">TCP/UDP Server Connection: </label>
-                    <select name="tcpUdpWiFiType" id="tcpUdpOverWiFiStation" class="form-dropdown">
+                <div id="tcpWiFiTypeDropdown" class="mt-3">
+                    <label for="tcpOverWiFiStation">TCP Server Connection: </label>
+                    <select name="tcpWiFiType" id="tcpOverWiFiStation" class="form-dropdown">
                         <option value="1">WiFi</option>
                         <option value="0">AP</option>
                     </select>

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -171,6 +171,8 @@ bool webServerStart(int httpPort = 80)
 bool parseIncomingSettings() {return false;}
 void sendStringToWebsocket(const char* stringToSend) {}
 void stopWebServer() {}
+bool webServerSettingsCheckAndFree()    {return false;}
+void webServerSettingsClone()   {}
 void webServerStop() {}
 void webServerUpdate()  {}
 void webServerVerifyTables() {}

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -226,8 +226,8 @@ void menuTcpUdp()
         if (settings.mdnsEnable)
             systemPrintf("n) MDNS host name: %s\r\n", settings.mdnsHostName);
 
-        systemPrint("a) Broadcast TCP/UDP Server packets over local WiFi or act as Access Point: ");
-        systemPrintf("%s\r\n", settings.tcpUdpOverWiFiStation ? "WiFi" : "AP");
+        systemPrint("t) Broadcast TCP/UDP Server packets over local WiFi or act as Access Point: ");
+        systemPrintf("%s\r\n", settings.tcpOverWiFiStation ? "WiFi" : "AP");
 
         systemPrint("u) Broadcast UDP Server packets over local WiFi or act as Access Point: ");
         systemPrintf("%s\r\n", settings.udpOverWiFiStation ? "WiFi" : "AP");
@@ -326,9 +326,9 @@ void menuTcpUdp()
             getUserInputString((char *)&settings.mdnsHostName, sizeof(settings.mdnsHostName));
         }
 
-        else if (incoming == 'a')
+        else if (incoming == 't')
         {
-            settings.tcpUdpOverWiFiStation ^= 1;
+            settings.tcpOverWiFiStation ^= 1;
             wifiUpdateSettings();
         }
 

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -439,6 +439,7 @@ bool otaRequestFirmwareUpdate = false;
 
 bool enableRCFirmware;     // Goes true from AP config page
 bool currentlyParsingData; // Goes true when we hit 750ms timeout with new data
+bool tcpServerInCasterMode;// True when TCP server is running in caster mode
 
 // Give up connecting after this number of attempts
 // Connection attempts are throttled to increase the time between attempts

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -343,11 +343,6 @@ const TickType_t ringBuffer_longWait_ms = 300 / portTICK_PERIOD_MS;
 SemaphoreHandle_t ringBufferSemaphore = NULL;
 const char *ringBufferSemaphoreHolder = "None";
 
-// tcpServer semaphore - prevent tcpServerClientSendData (handleGnssDataTask) and tcpServerUpdate
-// from gatecrashing each other. See #695 for why this is needed.
-SemaphoreHandle_t tcpServerSemaphore = NULL;
-const char *tcpServerSemaphoreHolder = "None";
-
 // Display used/free space in menu and config page
 uint64_t sdCardSize;
 uint64_t sdFreeSpace;

--- a/Firmware/RTK_Everywhere/Tasks.ino
+++ b/Firmware/RTK_Everywhere/Tasks.ino
@@ -754,7 +754,7 @@ void processUart1Message(SEMP_PARSE_STATE *parse, uint16_t type)
     // If BaseCasterOverride is enabled, remove everything but RTCM from the circular buffer
     // to avoid saturating the downstream radio link that is consuming over a TCP (NTRIP Caster) connection
     // Remove NMEA, etc after passing to the GNSS receiver library so that we still have SIV and other stats available
-    if (settings.baseCasterOverride == true)
+    if (tcpServerInCasterMode)
     {
         if (type != RTK_RTCM_PARSER_INDEX)
         {

--- a/Firmware/RTK_Everywhere/TcpServer.ino
+++ b/Firmware/RTK_Everywhere/TcpServer.ino
@@ -698,7 +698,7 @@ void tcpServerUpdate()
         {
             if (settings.debugTcpServer && (!inMainMenu))
                 systemPrintf("%s start/r/n", tcpServerName);
-            if (settings.tcpUdpOverWiFiStation == true)
+            if (settings.tcpOverWiFiStation == true)
                 networkConsumerAdd(NETCONSUMER_TCP_SERVER, NETWORK_ANY, __FILE__, __LINE__);
             else
                 networkSoftApConsumerAdd(NETCONSUMER_TCP_SERVER, __FILE__, __LINE__);

--- a/Firmware/RTK_Everywhere/TcpServer.ino
+++ b/Firmware/RTK_Everywhere/TcpServer.ino
@@ -146,11 +146,8 @@ int32_t tcpServerClientSendData(int index, uint8_t *data, uint16_t length)
             if (length > 0)
                 tcpServerClientDataSent = tcpServerClientDataSent | (1 << index);
             if ((settings.debugTcpServer || PERIODIC_DISPLAY(PD_TCP_SERVER_CLIENT_DATA)) && (!inMainMenu))
-            {
-                PERIODIC_CLEAR(PD_TCP_SERVER_CLIENT_DATA);
                 systemPrintf("TCP server wrote %d bytes to %s\r\n", length,
                              tcpServerClientIpAddress[index].toString().c_str());
-            }
         }
 
         // Failed to write the data
@@ -240,6 +237,8 @@ int32_t tcpServerSendData(uint16_t dataHead)
         }
         tcpServerClientTails[index] = tail;
     }
+    if (PERIODIC_DISPLAY(PD_TCP_SERVER_CLIENT_DATA))
+        PERIODIC_CLEAR(PD_TCP_SERVER_CLIENT_DATA);
 
     // Return the amount of space that TCP server client is using in the buffer
     return usedSpace;

--- a/Firmware/RTK_Everywhere/TcpServer.ino
+++ b/Firmware/RTK_Everywhere/TcpServer.ino
@@ -346,12 +346,9 @@ void tcpServerClientUpdate(uint8_t index)
 
         // Periodically display this client connection
         if (PERIODIC_DISPLAY(PD_TCP_SERVER_DATA) && (!inMainMenu))
-        {
-            PERIODIC_CLEAR(PD_TCP_SERVER_DATA);
             systemPrintf("%s client %d connected to %s\r\n",
                          tcpServerName, index,
                          tcpServerClientIpAddress[index].toString().c_str());
-        }
         break;
     }
 
@@ -371,14 +368,10 @@ void tcpServerClientUpdate(uint8_t index)
             // TCP server client found
             // Start processing the new TCP server client connection
             tcpServerClientIpAddress[index] = tcpServerClient[index]->remoteIP();
-
             if ((settings.debugTcpServer || PERIODIC_DISPLAY(PD_TCP_SERVER_DATA)) && (!inMainMenu))
-            {
-                PERIODIC_CLEAR(PD_TCP_SERVER_DATA);
                 systemPrintf("%s client %d connected to %s\r\n",
                              tcpServerName, index,
                              tcpServerClientIpAddress[index].toString().c_str());
-            }
 
             // If we are acting as an NTRIP Caster, intercept the initial communication from the client
             //  and respond accordingly
@@ -550,8 +543,6 @@ void tcpServerStopClient(int index)
         // Done with this client connection
         if ((settings.debugTcpServer || PERIODIC_DISPLAY(PD_TCP_SERVER_DATA)) && (!inMainMenu))
         {
-            PERIODIC_CLEAR(PD_TCP_SERVER_DATA);
-
             // Determine the shutdown reason
             connected = tcpServerClient[index]->connected()
                       && (!(tcpServerClientWriteError & (1 << index)));
@@ -664,21 +655,19 @@ void tcpServerUpdate()
         if (connected == false)
         {
             if ((settings.debugTcpServer || PERIODIC_DISPLAY(PD_TCP_SERVER_DATA)) && (!inMainMenu))
-            {
-                PERIODIC_CLEAR(PD_TCP_SERVER_DATA);
                 systemPrintf("%s initiating shutdown\r\n", tcpServerName);
-            }
 
             // Network connection failed, attempt to restart the network
             tcpServerStop();
+            if (PERIODIC_DISPLAY(PD_TCP_SERVER_DATA))
+                PERIODIC_CLEAR(PD_TCP_SERVER_DATA);
             break;
         }
 
         // Walk the list of TCP server clients
         for (index = 0; index < TCP_SERVER_MAX_CLIENTS; index++)
-        {
             tcpServerClientUpdate(index);
-        }
+        PERIODIC_CLEAR(PD_TCP_SERVER_DATA);
 
         // Check for data moving across the connections
         if ((millis() - tcpServerTimer) >= TCP_SERVER_CLIENT_DATA_TIMEOUT)

--- a/Firmware/RTK_Everywhere/TcpServer.ino
+++ b/Firmware/RTK_Everywhere/TcpServer.ino
@@ -229,7 +229,7 @@ bool tcpServerEnabled(const char ** line)
             casterMode = true;
 
             // Select the base caster WiFi mode and port number
-            if (settings.baseCasterOverride)
+            if (settings.baseCasterOverride || (settings.tcpOverWiFiStation == false))
             {
                 // Using soft AP
                 name = "Base Caster";
@@ -698,10 +698,10 @@ void tcpServerUpdate()
         {
             if (settings.debugTcpServer && (!inMainMenu))
                 systemPrintf("%s start/r/n", tcpServerName);
-            if (settings.tcpOverWiFiStation == true)
-                networkConsumerAdd(NETCONSUMER_TCP_SERVER, NETWORK_ANY, __FILE__, __LINE__);
-            else
+            if (tcpServerWiFiSoftAp)
                 networkSoftApConsumerAdd(NETCONSUMER_TCP_SERVER, __FILE__, __LINE__);
+            else
+                networkConsumerAdd(NETCONSUMER_TCP_SERVER, NETWORK_ANY, __FILE__, __LINE__);
             tcpServerSetState(TCP_SERVER_STATE_WAIT_FOR_NETWORK);
         }
         break;

--- a/Firmware/RTK_Everywhere/TcpServer.ino
+++ b/Firmware/RTK_Everywhere/TcpServer.ino
@@ -452,18 +452,29 @@ void tcpServerClientUpdate(uint8_t index)
     {
         // Data structure not in use
         if(tcpServerClient[index] == nullptr)
+        {
             tcpServerClient[index] = new NetworkClient;
 
-        // Check for another TCP server client
+            // Check for allocation failure
+            if(tcpServerClient[index] == nullptr)
+            {
+                if (settings.debugTcpServer)
+                    Serial.printf("ERROR: Failed to allocate %s client!\r\n", tcpServerName);
+                break;
+            }
+        }
+
+        // Check for another incoming TCP server client connection request
         *tcpServerClient[index] = tcpServer->accept();
 
         // Exit if no TCP server client found
         if (!*tcpServerClient[index])
             break;
 
-        // TCP server client found
-        // Start processing the new TCP server client connection
+        // Get the remote IP address
         tcpServerClientIpAddress[index] = tcpServerClient[index]->remoteIP();
+
+        // Display the connection
         if ((settings.debugTcpServer || PERIODIC_DISPLAY(PD_TCP_SERVER_DATA)) && (!inMainMenu))
             systemPrintf("%s client %d connected to %s\r\n",
                          tcpServerName, index,

--- a/Firmware/RTK_Everywhere/menuCommands.ino
+++ b/Firmware/RTK_Everywhere/menuCommands.ino
@@ -1968,10 +1968,10 @@ void createSettingsString(char *newSettings)
     else
         stringRecord(newSettings, "wifiConfigOverAP", 0); // 1 = AP mode, 0 = WiFi
 
-    if (settings.tcpUdpOverWiFiStation == true)
-        stringRecord(newSettings, "tcpUdpOverWiFiStation", 1); // 1 = WiFi mode, 0 = AP
+    if (settings.tcpOverWiFiStation == true)
+        stringRecord(newSettings, "tcpOverWiFiStation", 1); // 1 = WiFi mode, 0 = AP
     else
-        stringRecord(newSettings, "tcpUdpOverWiFiStation", 0); // 1 = WiFi mode, 0 = AP
+        stringRecord(newSettings, "tcpOverWiFiStation", 0); // 1 = WiFi mode, 0 = AP
 
     if (settings.udpOverWiFiStation == true)
         stringRecord(newSettings, "udpOverWiFiStation", 1); // 1 = WiFi mode, 0 = AP

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -938,7 +938,7 @@ struct Settings
     bool debugTcpServer = false;
     bool enableTcpServer = false;
     uint16_t tcpServerPort = 2948; // TCP server port, 2948 is GPS Daemon: http://tcp-udp-ports.com/port-2948.htm
-    bool tcpUdpOverWiFiStation = true; // Controls if TCP/UDP settings should use Station or AP
+    bool tcpOverWiFiStation = true; // Should TCP server use Station (true) or AP (false)
     bool udpOverWiFiStation = true; // Should UDP server use Station (true) or AP (false)
 
     // Time Zone - Default to UTC
@@ -1586,7 +1586,7 @@ const RTK_Settings_Entry rtkSettingsEntries[] =
     { 0, 0, 0, 1, 1, 1, 1, 1, 1, _bool,     0, & settings.debugTcpServer, "debugTcpServer",  },
     { 1, 1, 0, 1, 1, 1, 1, 1, 1, _bool,     0, & settings.enableTcpServer, "enableTcpServer",  },
     { 1, 1, 0, 1, 1, 1, 1, 1, 1, _uint16_t, 0, & settings.tcpServerPort, "tcpServerPort",  },
-    { 1, 1, 0, 1, 1, 1, 1, 1, 1, _bool,     0, & settings.tcpUdpOverWiFiStation, "tcpUdpOverWiFiStation",  },
+    { 1, 1, 0, 1, 1, 1, 1, 1, 1, _bool,     0, & settings.tcpOverWiFiStation, "tcpOverWiFiStation",  },
 
     // Time Zone
     { 0, 1, 0, 1, 1, 1, 1, 1, 1, _int8_t,   0, & settings.timeZoneHours, "timeZoneHours",  },


### PR DESCRIPTION
Remember to enable some RTCM messages, link fails when no RTCM data is being sent!

Changes:
* TcpServer: Periodically display data sent messages for all clients
* TcpServer: Output TCP Server, NTRIP Caster or Base Caster messages
* TcpServer: Make port selection in tcpServerEnabled
* TcpServer: Determine operating mode in tcpServerEnabled
* TcpServer: Select WiFi mode in tcpServerEnabled
* TcpServer: Move the client handling into tcpServerClientUpdate
* TcpServer: Rework the client connection logic
* TcpServer: Periodically display all of the client connections
* TcpServer: Separate the tcpServerTimer from the tcpServerClientTimers
* TcpServer: Use client states to wait for and process caster request
* TcpServer: Handle client allocation failures
* TcpServer: Don't send data until the client enters *_CLIENT_SENDING_DATA
