### PR TITLE
OTA: Support WiFi setup and firmware update as one change

### DIFF
--- a/Firmware/RTK_Everywhere/AP-Config/index.html
+++ b/Firmware/RTK_Everywhere/AP-Config/index.html
@@ -1982,13 +1982,13 @@
                     </div>
                     <br>
 
-                    <div align="center" id="divGetNewFirmware" style="display:none">
+                    <div align="center" id="divGetNewFirmware">
                         <button type="button" id="btnGetNewFirmware" class="btn btn-primary box-margin20"
-                            onClick="getNewFirmware()">Update to v3.14.15</button>
+                            onClick="getNewFirmware()">Update to lastest firmware</button>
 
-                        <center><progress id="firmwareUpdateProgressBar" value="12" max="100"
+                        <center><progress id="firmwareUpdateProgressBar" value="0" max="100"
                                 style="width:300px;"></progress>
-                            <p id="firmwareUpdateProgressMsg" class="inlineSuccess">37%</p>
+                            <p id="firmwareUpdateProgressMsg" class="inlineSuccess">0%</p>
                         </center>
                     </div>
                 </div>

--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -210,7 +210,7 @@ void wifiDisplayNetworkData()                   {}
 void wifiDisplaySoftApStatus()                  {}
 bool wifiEspNowOff(const char * fileName, uint32_t lineNumber) {return true;}
 bool wifiEspNowOn(const char * fileName, uint32_t lineNumber) {return false;}
-void wifiEspNowSetChannel(WIFI_CHANNEL_t channel) {}
+void wifiEspNowChannelSet(WIFI_CHANNEL_t channel) {}
 int wifiNetworkCount()                          {return 0;}
 void wifiResetTimeout()                         {}
 IPAddress wifiSoftApGetIpAddress()              {return IPAddress((uint32_t)0);}

--- a/Firmware/RTK_Everywhere/HTTP_Client.ino
+++ b/Firmware/RTK_Everywhere/HTTP_Client.ino
@@ -356,6 +356,7 @@ void httpClientUpdate()
     // Connect to the HTTP server
     case HTTP_CLIENT_CONNECTING_2_SERVER: {
         // Allocate the httpSecureClient structure
+        networkUseDefaultInterface();
         httpSecureClient = new NetworkClientSecure();
         if (!httpSecureClient)
         {

--- a/Firmware/RTK_Everywhere/HTTP_Client.ino
+++ b/Firmware/RTK_Everywhere/HTTP_Client.ino
@@ -372,6 +372,17 @@ void httpClientUpdate()
         if (!httpSecureClient->connect(THINGSTREAM_SERVER, HTTPS_PORT))
         {
             // Failed to connect to the server
+            int length = 1024;
+            char * errMessage = (char *)rtkMalloc(length, "HTTP error message");
+            if (errMessage)
+            {
+                memset(errMessage, 0, length);
+                httpSecureClient->lastError(errMessage, length - 1);
+                systemPrintf("Get %s failed, %s\r\n", THINGSTREAM_SERVER, errMessage);
+                rtkFree(errMessage, "HTTP error message");
+            }
+            else
+                systemPrintf("Get %s failed!\r\n", THINGSTREAM_SERVER);
             systemPrintln("ERROR: Failed to connect to the Thingstream server!");
             httpClientRestart(); // I _think_ we want to restart here - i.e. retry after the timeout?
             break;

--- a/Firmware/RTK_Everywhere/MQTT_Client.ino
+++ b/Firmware/RTK_Everywhere/MQTT_Client.ino
@@ -952,6 +952,16 @@ void mqttClientUpdate()
         // Attempt connection to the MQTT broker
         if (!mqttClient->connect(settings.pointPerfectBrokerHost, 8883))
         {
+            // Failed to connect to the server
+            int length = 1024;
+            char * errMessage = (char *)rtkMalloc(length, "HTTP error message");
+            if (errMessage)
+            {
+                memset(errMessage, 0, length);
+                mqttSecureClient->lastError(errMessage, length - 1);
+                systemPrintf("MQTT Error: %s\r\n", errMessage);
+                rtkFree(errMessage, "HTTP error message");
+            }
             systemPrintf("Failed to connect to MQTT broker %s\r\n", settings.pointPerfectBrokerHost);
             mqttClientRestart();
             break;

--- a/Firmware/RTK_Everywhere/MQTT_Client.ino
+++ b/Firmware/RTK_Everywhere/MQTT_Client.ino
@@ -876,6 +876,7 @@ void mqttClientUpdate()
     // Connect to the MQTT broker
     case MQTT_CLIENT_CONNECTING_2_BROKER: {
         // Allocate the mqttSecureClient structure
+        networkUseDefaultInterface();
         mqttSecureClient = new NetworkClientSecure();
         if (!mqttSecureClient)
         {

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -1269,6 +1269,37 @@ void networkInterfaceInternetConnectionAvailable(NetIndex_t index)
         networkMulticastDNSStart(previousIndex);
 }
 
+/*
+    Network Loss Handling:
+
+                     Arduino IP lost event
+                               |
+                               |
+                               V
+                networkInterfaceEventInternetLost
+                               |
+                               | Set internet lost event flag
+                               V
+                         networkUpdate
+                               |
+                               | Clear internet lost event flag
+                               V
+                               +<------- Fake connection loss
+                               |
+                               V
+              networkInterfaceInternetConnectionLost
+                               |
+                               | Notify Interface of connection loss
+                               V
+              .----------------+----------------.
+              |                                 |
+              |                                 |
+              V                                 V
+    networkInterfaceRunning          Interface stop sequence
+      called by xxxUpdate
+         or xxxEnabled
+*/
+
 //----------------------------------------
 // Mark network interface as having NO access to the internet
 //----------------------------------------
@@ -1375,6 +1406,35 @@ void networkInterfaceInternetConnectionLost(NetIndex_t index)
             networkDisplayStatus();
         }
     }
+}
+
+//----------------------------------------
+// Get the interface priority
+//----------------------------------------
+NetPriority_t networkInterfacePriority(NetIndex_t index)
+{
+    NetPriority_t priority;
+
+    // Validate the index
+    networkValidateIndex(index);
+
+    // Get the interface priority
+    priority = networkIndexTable[index];
+    return priority;
+}
+
+//----------------------------------------
+// Determine if the interface should be running
+//----------------------------------------
+NetPriority_t networkInterfaceRunning(NetIndex_t index)
+{
+    NetPriority_t priority;
+
+    // Get the interface priority
+    priority = networkInterfacePriority(index);
+
+    // Return the running status
+    return (networkPriority >= priority);
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -2435,6 +2435,25 @@ void networkUpdate()
 }
 
 //----------------------------------------
+// Set the default network interface
+//----------------------------------------
+void networkUseDefaultInterface()
+{
+    NetIndex_t index;
+    bool isDefault;
+
+    // Get the network index
+    index = networkGetCurrentInterfaceIndex();
+    if (index < NETWORK_OFFLINE)
+    {
+        // Get the default network interface
+        isDefault = networkInterfaceTable[index].netif->isDefault();
+        if (!isDefault)
+            networkInterfaceTable[index].netif->setDefault();
+    }
+}
+
+//----------------------------------------
 // Add a network user
 //----------------------------------------
 void networkUserAdd(NETCONSUMER_t consumer, const char *fileName, uint32_t lineNumber)

--- a/Firmware/RTK_Everywhere/NtripClient.ino
+++ b/Firmware/RTK_Everywhere/NtripClient.ino
@@ -656,6 +656,7 @@ void ntripClientUpdate()
         if (connected)
         {
             // Allocate the ntripClient structure
+            networkUseDefaultInterface();
             ntripClient = new NetworkClient();
             if (!ntripClient)
             {

--- a/Firmware/RTK_Everywhere/TcpClient.ino
+++ b/Firmware/RTK_Everywhere/TcpClient.ino
@@ -306,6 +306,7 @@ bool tcpClientStart()
     NetworkClient *client;
 
     // Allocate the TCP client
+    networkUseDefaultInterface();
     client = new NetworkClient();
     if (client)
     {

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -765,6 +765,7 @@ bool wifiStationEnabled(const char **reason)
         // Is WiFi the highest priority
         if (networkIsHighestPriority(NETWORK_WIFI_STATION) == false)
         {
+            // Another network has higher priority
             // Allocate the reason buffer once
             if (reasonBuffer == nullptr)
                 reasonBuffer = (char *)rtkMalloc(64, "WiFi reasonBuffer");
@@ -784,7 +785,7 @@ bool wifiStationEnabled(const char **reason)
 
         // WiFi should start and continue running
         enabled = true;
-        *reason = ", is enabled";
+        *reason = "";
     } while (0);
     return enabled;
 }

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -979,19 +979,6 @@ void wifiStationUpdate()
     // Update the WiFi station state
     switch (wifiStationState)
     {
-    // There are no WiFi station consumers
-    case WIFI_STATION_STATE_OFF:
-        if (enabled)
-        {
-            connectionAttempts = 0;
-            timer = millis();
-            startTimeout = 0;
-
-            // Start WiFi station
-            wifiStationSetState(WIFI_STATION_STATE_RESTART_DELAY);
-        }
-        break;
-
     // Wait for WiFi station users to release resources before shutting
     // down WiFi station
     case WIFI_STATION_STATE_WAIT_NO_USERS:
@@ -1050,6 +1037,27 @@ void wifiStationUpdate()
             }
         }
         break;
+
+    // There are no WiFi station consumers
+    case WIFI_STATION_STATE_OFF:
+        // Check for disabled
+        if (!enabled)
+            break;
+
+        // Reset the restart timeout when off
+        if (wifiStationState == WIFI_STATION_STATE_OFF)
+        {
+            connectionAttempts = 0;
+            timer = millis();
+            startTimeout = 0;
+        }
+
+        // Wait for the delay to complete
+        wifiStationSetState(WIFI_STATION_STATE_RESTART_DELAY);
+
+        //          |
+        //          | Fall through
+        //          V
 
     // Perform the restart delay
     case WIFI_STATION_STATE_RESTART_DELAY:

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -762,8 +762,8 @@ bool wifiStationEnabled(const char **reason)
             break;
         }
 
-        // Is WiFi the highest priority
-        if (networkIsHighestPriority(NETWORK_WIFI_STATION) == false)
+        // Determine if WiFi should be running (is the highest priority)
+        if (networkInterfaceRunning(NETWORK_WIFI_STATION) == false)
         {
             // Another network has higher priority
             // Allocate the reason buffer once

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -536,10 +536,17 @@ void wifiDisplayState()
 }
 
 //*********************************************************************
-// Set the ESP-NOW channel
-void wifiEspNowSetChannel(WIFI_CHANNEL_t channel)
+// Get the ESP-NOW channel
+WIFI_CHANNEL_t wifiEspNowChannelGet()
 {
-    wifi.espNowSetChannel(channel);
+    return wifi.espNowChannelGet();
+}
+
+//*********************************************************************
+// Set the ESP-NOW channel
+void wifiEspNowChannelSet(WIFI_CHANNEL_t channel)
+{
+    wifi.espNowChannelSet(channel);
 }
 
 //*********************************************************************
@@ -636,6 +643,20 @@ void wifiPromiscuousRxHandler(void *buf, wifi_promiscuous_pkt_type_t type)
 
     ppkt = (wifi_promiscuous_pkt_t *)buf;
     packetRSSI = ppkt->rx_ctrl.rssi;
+}
+
+//*********************************************************************
+// Get the soft AP channel
+WIFI_CHANNEL_t wifiSoftApChannelGet()
+{
+    return wifi.softApChannelGet();
+}
+
+//*********************************************************************
+// Set the soft AP channel
+void wifiSoftApChannelSet(WIFI_CHANNEL_t channel)
+{
+    wifi.softApChannelSet(channel);
 }
 
 //*********************************************************************
@@ -1303,21 +1324,30 @@ bool RTK_WIFI::enable(bool enableESPNow, bool enableSoftAP, bool enableStation, 
 }
 
 //*********************************************************************
-// Get the ESP-NOW status
+// Get the ESP-NOW channel
 // Outputs:
-//   Returns true when ESP-NOW is online and ready for use
-bool RTK_WIFI::espNowOnline()
+//   Returns the requested ESP-NOW channel
+WIFI_CHANNEL_t RTK_WIFI::espNowChannelGet()
 {
-    return (_started & WIFI_EN_ESP_NOW_ONLINE) ? true : false;
+    return _espNowChannel;
 }
 
 //*********************************************************************
 // Set the ESP-NOW channel
 // Inputs:
 //   channel: New ESP-NOW channel number
-void RTK_WIFI::espNowSetChannel(WIFI_CHANNEL_t channel)
+void RTK_WIFI::espNowChannelSet(WIFI_CHANNEL_t channel)
 {
     _espNowChannel = channel;
+}
+
+//*********************************************************************
+// Get the ESP-NOW status
+// Outputs:
+//   Returns true when ESP-NOW is online and ready for use
+bool RTK_WIFI::espNowOnline()
+{
+    return (_started & WIFI_EN_ESP_NOW_ONLINE) ? true : false;
 }
 
 //*********************************************************************
@@ -1549,6 +1579,24 @@ bool RTK_WIFI::setWiFiProtocols(wifi_interface_t interface, bool enableWiFiProto
 
     // Return the final status
     return started;
+}
+
+//*********************************************************************
+// Get the soft AP channel
+// Outputs:
+//   Returns the requested soft AP channel
+WIFI_CHANNEL_t RTK_WIFI::softApChannelGet()
+{
+    return _apChannel;
+}
+
+//*********************************************************************
+// Set the soft AP channel
+// Inputs:
+//   channel: Request the channel for WiFi soft AP
+void RTK_WIFI::softApChannelSet(WIFI_CHANNEL_t channel)
+{
+    _apChannel = channel;
 }
 
 //*********************************************************************
@@ -1785,6 +1833,20 @@ bool RTK_WIFI::softApSetSsidPassword(const char *ssid, const char *password)
 bool RTK_WIFI::startAp(bool forceAP)
 {
     return enable(wifiEspNowRunning, forceAP | settings.wifiConfigOverAP, wifiStationRunning, __FILE__, __LINE__);
+}
+
+//*********************************************************************
+// Get the station channel
+WIFI_CHANNEL_t RTK_WIFI::stationChannelGet()
+{
+    return _stationChannel;
+}
+
+//*********************************************************************
+// Set the station channel
+void RTK_WIFI::stationChannelSet(WIFI_CHANNEL_t channel)
+{
+    _stationChannel = channel;
 }
 
 //*********************************************************************

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -24,7 +24,7 @@ enum WIFI_STATION_STATES
 {
     WIFI_STATION_STATE_OFF,
     WIFI_STATION_STATE_WAIT_NO_USERS,
-    WIFI_STATION_STATE_RESTART,
+    WIFI_STATION_STATE_RESTART_DELAY,
     WIFI_STATION_STATE_STARTING,
     WIFI_STATION_STATE_ONLINE,
     WIFI_STATION_STATE_STABLE,
@@ -33,9 +33,14 @@ enum WIFI_STATION_STATES
 };
 uint8_t wifiStationState;
 
-const char *wifiStationStateName[] = {
-    "WIFI_STATION_STATE_OFF",      "WIFI_STATION_STATE_WAIT_NO_USERS", "WIFI_STATION_STATE_RESTART",
-    "WIFI_STATION_STATE_STARTING", "WIFI_STATION_STATE_ONLINE",        "WIFI_STATION_STATE_STABLE",
+const char * wifiStationStateName[] =
+{
+    "WIFI_STATION_STATE_OFF",
+    "WIFI_STATION_STATE_WAIT_NO_USERS",
+    "WIFI_STATION_STATE_RESTART_DELAY",
+    "WIFI_STATION_STATE_STARTING",
+    "WIFI_STATION_STATE_ONLINE",
+    "WIFI_STATION_STATE_STABLE",
 };
 const int wifiStationStateNameEntries = sizeof(wifiStationStateName) / sizeof(wifiStationStateName[0]);
 
@@ -884,33 +889,36 @@ void wifiStationUpdate()
 /*
         WiFi Station States:
 
-                WIFI_STATION_STATE_WAIT_NO_USERS <------.
-                               |                        |
-                               | No Users               |
-                enabled        V                        |
-             .-----------------+                        |
-             |                 |                        |
-             V                 |                        |
-    WIFI_STATION_STATE_RESTART |                        |
-             |                 |                        |
-     Display |                 | !enabled               |
-      delay  |                 V                        |
-             |       WIFI_STATION_STATE_OFF             |
-             |                 |                        |
-             |                 | enabled                |
-             |                 V                        |
-             '---------------->+                        |
-                               |                        |
-                               V               !enabled |
-                  WIFI_STATION_STATE_STARTING --------->+
-                               |                        ^
-                               |                        |
-                               V               !enabled |
-                   WIFI_STATION_STATE_ONLINE ---------->+
-                               |                        ^
-                               |                        |
-                               V               !enabled |
-                   WIFI_STATION_STATE_STABLE -----------'
+                     WIFI_STATION_STATE_OFF <--------------+<---.
+                               |                           ^    |
+                               | enabled                   |    |
+                               |                           |    |
+                               V                  !enabled |    |
+                WIFI_STATION_STATE_RESTART_DELAY ----------'    |
+                               |                                |
+                               | Timeout                        |
+                               | Complete                       |
+                               V                  !enabled      |
+                  WIFI_STATION_STATE_STARTING -------------.    |
+                               |                           |    |
+                               | WiFi connected            |    |
+                               V                  !enabled |    |
+                   WIFI_STATION_STATE_ONLINE ------------->+    |
+                               |                           ^    |
+                               | Long delay                |    |
+                               V                           |    |
+                   WIFI_STATION_STATE_STABLE               |    |
+                               |                           |    |
+                               | !enabled                  |    |
+                               V                           |    |
+                               +<--------------------------'    |
+                               |                                |
+                               V                                |
+                WIFI_STATION_STATE_WAIT_NO_USERS                |
+                               |                                |
+                               | No Users                       |
+                               |                                |
+                               '--------------------------------'
 
     Network Loss Handling:
 
@@ -979,13 +987,8 @@ void wifiStationUpdate()
             timer = millis();
             startTimeout = 0;
 
-            // Display the major state transition
-            if (settings.debugWifiState)
-                systemPrintf("--------------- %s Starting ---------------\r\n",
-                             networkInterfaceTable[NETWORK_WIFI_STATION].name);
-
             // Start WiFi station
-            wifiStationSetState(WIFI_STATION_STATE_STARTING);
+            wifiStationSetState(WIFI_STATION_STATE_RESTART_DELAY);
         }
         break;
 
@@ -1022,6 +1025,8 @@ void wifiStationUpdate()
                                      networkInterfaceTable[NETWORK_WIFI_STATION].name);
                     wifiStationOff(__FILE__, __LINE__);
                 }
+
+                // Reset the start timeout
                 wifiStationSetState(WIFI_STATION_STATE_OFF);
             }
 
@@ -1030,62 +1035,58 @@ void wifiStationUpdate()
             {
                 // Clear the bits to perform the restart operation
                 wifi.clearStarted(WIFI_STA_RECONNECT);
-                wifiStationSetState(WIFI_STATION_STATE_RESTART);
+
+                // Display the restart delay and then start WiFi station
+                if (startTimeout && settings.debugWifiState)
+                {
+                    // Display the delay
+                    uint32_t seconds = startTimeout / MILLISECONDS_IN_A_SECOND;
+                    uint32_t minutes = seconds / SECONDS_IN_A_MINUTE;
+                    seconds -= minutes * SECONDS_IN_A_MINUTE;
+                    systemPrintf("WiFi: Delaying %2d:%02d before restarting WiFi\r\n", minutes, seconds);
+                }
+                timer = millis();
+                wifiStationSetState(WIFI_STATION_STATE_STARTING);
             }
         }
         break;
 
-    // Display the restart delay and then start WiFi station
-    case WIFI_STATION_STATE_RESTART:
-        if (startTimeout && settings.debugWifiState)
+    // Perform the restart delay
+    case WIFI_STATION_STATE_RESTART_DELAY:
+        // Stop WiFi station if necessary
+        if (enabled == false)
         {
-            // Display the delay
-            uint32_t seconds = startTimeout / MILLISECONDS_IN_A_SECOND;
-            uint32_t minutes = seconds / SECONDS_IN_A_MINUTE;
-            seconds -= minutes * SECONDS_IN_A_MINUTE;
-            systemPrintf("WiFi: Delaying %2d:%02d before restarting WiFi\r\n", minutes, seconds);
+            wifiStationSetState(WIFI_STATION_STATE_OFF);
+            break;
         }
-        timer = millis();
+
+        // Delay before starting WiFi
+        if ((millis() - timer) < startTimeout)
+            break;
+
+        // Display the major state transition
+        if (settings.debugWifiState)
+            systemPrintf("--------------- %s Starting ---------------\r\n",
+                         networkInterfaceTable[NETWORK_WIFI_STATION].name);
+
+        // Timeout complete
         wifiStationSetState(WIFI_STATION_STATE_STARTING);
-        break;
+
+        //          |
+        //          | Fall through
+        //          V
 
     // At least one consumer is requesting a network
     case WIFI_STATION_STATE_STARTING:
-        // Delay before starting WiFi
-        if ((millis() - timer) >= startTimeout)
-        {
-            timer = millis();
+        // Increase the timeout
+        startTimeout <<= 1;
+        if (!startTimeout)
+            startTimeout = WIFI_MIN_TIMEOUT;
+        else if (startTimeout > WIFI_MAX_TIMEOUT)
+            startTimeout = WIFI_MAX_TIMEOUT;
 
-            // Increase the timeout
-            startTimeout <<= 1;
-            if (!startTimeout)
-                startTimeout = WIFI_MIN_TIMEOUT;
-            else if (startTimeout > WIFI_MAX_TIMEOUT)
-                startTimeout = WIFI_MAX_TIMEOUT;
-
-            // Account for this connection attempt
-            connectionAttempts++;
-
-            // Attempt to start WiFi station
-            if (wifiStationOn(__FILE__, __LINE__))
-            {
-                // Successfully connected to a remote AP
-                if (settings.debugWifiState)
-                    systemPrintf("WiFi: WiFi station successfully started\r\n");
-
-                // WiFi station is now available
-                wifiStationSetState(WIFI_STATION_STATE_ONLINE);
-            }
-            else
-            {
-                // Failed to connect to a remote AP
-                if (settings.debugWifiState)
-                    systemPrintf("WiFi: WiFi station failed to start!\r\n");
-
-                // Restart WiFi after delay
-                // Clear the bits to perform the restart operation
-                wifi.clearStarted(WIFI_STA_RECONNECT);
-                wifiStationSetState(WIFI_STATION_STATE_RESTART);
+        // Account for this connection attempt
+        connectionAttempts++;
 
                 // Start the next network interface if necessary
                 if (connectionAttempts >= 2)

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -1001,28 +1001,23 @@ void wifiStationUpdate()
         // No more network users
         else
         {
+            // Display the major state transition
+            if (wifiStationRunning)
+            {
+                if (settings.debugWifiState)
+                    systemPrintf("--------------- %s Stopping ---------------\r\n",
+                                 networkInterfaceTable[NETWORK_WIFI_STATION].name);
+                wifiStationOff(__FILE__, __LINE__);
+            }
+
             // Stop WiFi station if necessary
             if (enabled == false)
-            {
-                // Display the major state transition
-                if (wifiStationRunning)
-                {
-                    if (settings.debugWifiState)
-                        systemPrintf("--------------- %s Stopping ---------------\r\n",
-                                     networkInterfaceTable[NETWORK_WIFI_STATION].name);
-                    wifiStationOff(__FILE__, __LINE__);
-                }
-
                 // Reset the start timeout
                 wifiStationSetState(WIFI_STATION_STATE_OFF);
-            }
 
             // Restart WiFi after delay
             else
             {
-                // Clear the bits to perform the restart operation
-                wifi.clearStarted(WIFI_STA_RECONNECT);
-
                 // Display the restart delay and then start WiFi station
                 if (startTimeout && settings.debugWifiState)
                 {
@@ -1033,7 +1028,7 @@ void wifiStationUpdate()
                     systemPrintf("WiFi: Delaying %2d:%02d before restarting WiFi\r\n", minutes, seconds);
                 }
                 timer = millis();
-                wifiStationSetState(WIFI_STATION_STATE_STARTING);
+                wifiStationSetState(WIFI_STATION_STATE_RESTART_DELAY);
             }
         }
         break;
@@ -1108,6 +1103,7 @@ void wifiStationUpdate()
         // Wait until the WiFi link is stable
         if ((millis() - timer) >= WIFI_CONNECTION_STABLE_MSEC)
         {
+            // Reset restart timeout and the connection attempts
             connectionAttempts = 0;
             startTimeout = 0;
             wifiStationSetState(WIFI_STATION_STATE_STABLE);

--- a/Firmware/RTK_Everywhere/menuFirmware.ino
+++ b/Firmware/RTK_Everywhere/menuFirmware.ino
@@ -630,15 +630,11 @@ void otaMenuDisplay(char *currentVersion)
         systemPrintf("s) Change Firmware JSON URL: %s\r\n", otaFirmwareJsonUrl);
     }
 
-    if (firmwareVersionIsReportedNewer(otaReportedVersion, &currentVersion[1]) == true ||
-        settings.debugFirmwareUpdate == true)
-    {
-        systemPrintf("u) Update to new firmware: v%s - ", otaReportedVersion);
-        if (otaRequestFirmwareUpdate == true)
-            systemPrintln("Requested");
-        else
-            systemPrintln("Not requested");
-    }
+    systemPrintf("u) Update to new firmware: v%s - ", otaReportedVersion);
+    if (otaRequestFirmwareUpdate == true)
+        systemPrintln("Requested");
+    else
+        systemPrintln("Not requested");
 }
 
 //----------------------------------------
@@ -675,7 +671,7 @@ bool otaMenuProcessInput(byte incoming)
         getUserInputString(otaFirmwareJsonUrl, sizeof(otaFirmwareJsonUrl) - 1);
     }
 
-    else if ((incoming == 'u') && (newOTAFirmwareAvailable || settings.debugFirmwareUpdate == true))
+    else if (incoming == 'u')
         otaRequestFirmwareUpdate ^= 1; // Tell network we need access, and otaUpdate() that we want to update
 
     // Input not associated with OTA menu items

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -689,7 +689,7 @@ void menuRadio()
             if (getNewSetting("Enter the WiFi channel to use for ESP-NOW communication", 1, 14,
                               &settings.wifiChannel) == INPUT_RESPONSE_VALID)
             {
-                wifiEspNowSetChannel(settings.wifiChannel);
+                wifiEspNowChannelSet(settings.wifiChannel);
                 if (settings.wifiChannel)
                 {
                     if (settings.wifiChannel == wifiChannel)

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2185,15 +2185,20 @@ class RTK_WIFI
                 const char * fileName,
                 int lineNumber);
 
-    // Get the ESP-NOW status
+    // Get the ESP-NOW channel
     // Outputs:
-    //   Returns true when ESP-NOW is online and ready for use
-    bool espNowOnline();
+    //   Returns the requested ESP-NOW channel
+    WIFI_CHANNEL_t espNowChannelGet();
 
     // Set the ESP-NOW channel
     // Inputs:
     //   channel: New ESP-NOW channel number
-    void espNowSetChannel(WIFI_CHANNEL_t channel);
+    void espNowChannelSet(WIFI_CHANNEL_t channel);
+
+    // Get the ESP-NOW status
+    // Outputs:
+    //   Returns true when ESP-NOW is online and ready for use
+    bool espNowOnline();
 
     // Handle the WiFi event
     // Inputs:
@@ -2207,6 +2212,16 @@ class RTK_WIFI
     // Outputs:
     //   Returns the current WiFi channel number
     WIFI_CHANNEL_t getChannel();
+
+    // Get the soft AP channel
+    // Outputs:
+    //   Returns the requested soft AP channel
+    WIFI_CHANNEL_t softApChannelGet();
+
+    // Set the soft AP channel
+    // Inputs:
+    //   channel: Request the channel for WiFi soft AP
+    void softApChannelSet(WIFI_CHANNEL_t channel);
 
     // Configure the soft AP
     // Inputs:
@@ -2245,6 +2260,16 @@ class RTK_WIFI
     //    Returns true if the soft AP was started successfully and false
     //    otherwise
     bool startAp(bool forceAP);
+
+    // Get the station channel
+    // Outputs:
+    //   Returns the requested station channel
+    WIFI_CHANNEL_t stationChannelGet();
+
+    // Set the station channel
+    // Inputs:
+    //   channel: Request the channel for WiFi station
+    void stationChannelSet(WIFI_CHANNEL_t channel);
 
     // Get the WiFi station IP address
     // Returns the IP address of the WiFi station


### PR DESCRIPTION
Always display the update button and menu item, remove the requirement check for new firmware qualification.  When the settings are written back to to the GNSS device the system is able to establish the connection to the remote access point using the newly specified WIFI SSID and password and then perform the OTA firmware update.
    
Note: Due to the WiFi restart the connection is broken between the browser and the GNSS device.  As a result, the browser does not receive the status update message for the progress bar and reset.
    
Prior to this change the user would need to check for new firmware before performing the firmware update:
    
1. Use a browser to connect to 192.168.4.1
2. Click on the "WiFi Configuration" button
3. Specify the WiFi SSID and Password
4. Click on the "Save Configuration" button
5. Reconnect the browser to 192.168.4.1
6. Click on the "System Configuration" button
7. Click on the "Check for New Firmware" button
8. If new firmware is available, click on the "Update to vXX.YY" button
    
While it is possible to change the WiFi SSID and password and then hit the "Check for New Firmware" button the response gets lost because of the WiFi restart.  When the browser is reconnected the "Update to vXX.YY" button is still disabled because the page got reloaded and the browser does not have the new firmware version.  As such, the "Check for New Firmware" button needs to be pressed again to get the new firmware version and enable the "Update to vXX.YY" button.
