### PR TITLE
PointPerfectRTCM - pcUpdates

### DIFF
--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -298,18 +298,6 @@ void lg290pReset()      {}
 
 #ifndef COMPILE_ZED
 
-// MON HW Antenna Status
-enum sfe_ublox_antenna_status_e
-{
-  SFE_UBLOX_ANTENNA_STATUS_INIT,
-  SFE_UBLOX_ANTENNA_STATUS_DONTKNOW,
-  SFE_UBLOX_ANTENNA_STATUS_OK,
-  SFE_UBLOX_ANTENNA_STATUS_SHORT,
-  SFE_UBLOX_ANTENNA_STATUS_OPEN
-};
-
-uint8_t aStatus = SFE_UBLOX_ANTENNA_STATUS_DONTKNOW;
-
 // void checkRXMCOR() {}
 // void pushRXMPMP() {}
 void convertGnssTimeToEpoch(uint32_t *epochSecs, uint32_t *epochMicros) {

--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -1575,7 +1575,7 @@ void displayBatteryVsEthernet(std::vector<iconPropertyBlinking> *iconList)
 
 void displaySivVsOpenShort(std::vector<iconPropertyBlinking> *iconList)
 {
-    if (present.antennaShortOpen == false)
+    if (gnss->supportsAntennaShortOpen() == false)
     {
         displayCoords textCoords = paintSIVIcon(iconList, nullptr, 0b11111111);
         paintSIVText(textCoords);
@@ -1584,11 +1584,11 @@ void displaySivVsOpenShort(std::vector<iconPropertyBlinking> *iconList)
     {
         displayCoords textCoords;
 
-        if (aStatus == SFE_UBLOX_ANTENNA_STATUS_SHORT)
+        if (gnss->isAntennaShorted())
         {
             textCoords = paintSIVIcon(iconList, &ShortIconProperties, 0b01010101);
         }
-        else if (aStatus == SFE_UBLOX_ANTENNA_STATUS_OPEN)
+        else if (gnss->isAntennaOpen())
         {
             textCoords = paintSIVIcon(iconList, &OpenIconProperties, 0b01010101);
         }
@@ -1846,7 +1846,7 @@ void paintBaseTempSurveyStarted(std::vector<iconPropertyBlinking> *iconList)
     xPos = SIVIconProperties.iconDisplay[present.display_type].xPos;
     yPos = SIVIconProperties.iconDisplay[present.display_type].yPos;
 
-    if (present.antennaShortOpen == false)
+    if (gnss->supportsAntennaShortOpen() == false)
     {
         oled->setCursor((uint8_t)((int)xPos + SIVTextStartXPosOffset[present.display_type]), yPos + 4); // x, y
         oled->setFont(QW_FONT_5X7);
@@ -1854,11 +1854,11 @@ void paintBaseTempSurveyStarted(std::vector<iconPropertyBlinking> *iconList)
     }
     else
     {
-        if (aStatus == SFE_UBLOX_ANTENNA_STATUS_SHORT)
+        if (gnss->isAntennaShorted())
         {
             paintSIVIcon(iconList, &ShortIconProperties, 0b01010101);
         }
-        else if (aStatus == SFE_UBLOX_ANTENNA_STATUS_OPEN)
+        else if (gnss->isAntennaOpen())
         {
             paintSIVIcon(iconList, &OpenIconProperties, 0b01010101);
         }
@@ -1914,7 +1914,7 @@ void paintRTCM(std::vector<iconPropertyBlinking> *iconList)
     xPos = SIVIconProperties.iconDisplay[present.display_type].xPos;
     yPos = SIVIconProperties.iconDisplay[present.display_type].yPos;
 
-    if (present.antennaShortOpen == false)
+    if (gnss->supportsAntennaShortOpen() == false)
     {
         oled->setCursor((uint8_t)((int)xPos + SIVTextStartXPosOffset[present.display_type]), yPos + 4); // x, y
         oled->setFont(QW_FONT_5X7);
@@ -1922,11 +1922,11 @@ void paintRTCM(std::vector<iconPropertyBlinking> *iconList)
     }
     else
     {
-        if (aStatus == SFE_UBLOX_ANTENNA_STATUS_SHORT)
+        if (gnss->isAntennaShorted())
         {
             paintSIVIcon(iconList, &ShortIconProperties, 0b01010101);
         }
-        else if (aStatus == SFE_UBLOX_ANTENNA_STATUS_OPEN)
+        else if (gnss->isAntennaOpen())
         {
             paintSIVIcon(iconList, &OpenIconProperties, 0b01010101);
         }

--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -3010,6 +3010,11 @@ void paintGettingKeys()
     displayMessage("Getting Keys", 2000);
 }
 
+void paintGettingCredentials()
+{
+    displayMessage("Getting Creds", 2000);
+}
+
 void paintEthernetConnected()
 {
     displayMessage("Ethernet Connected", 1000);

--- a/Firmware/RTK_Everywhere/GNSS.h
+++ b/Firmware/RTK_Everywhere/GNSS.h
@@ -238,6 +238,10 @@ class GNSS
     // Returns full year, ie 2023, not 23.
     virtual uint16_t getYear();
 
+    // Antenna Short / Open detection
+    virtual bool isAntennaShorted();
+    virtual bool isAntennaOpen();
+
     virtual bool isBlocking();
 
     // Date is confirmed once we have GNSS fix
@@ -373,6 +377,9 @@ class GNSS
     virtual bool softwareReset();
 
     virtual bool standby();
+
+    // Antenna Short / Open detection
+    virtual bool supportsAntennaShortOpen();
 
     // Reset the survey-in operation
     // Outputs:

--- a/Firmware/RTK_Everywhere/GNSS.ino
+++ b/Firmware/RTK_Everywhere/GNSS.ino
@@ -44,6 +44,16 @@ float GNSS::getSurveyInStartingAccuracy()
 }
 
 //----------------------------------------
+// Returns true if the antenna is shorted
+//----------------------------------------
+bool GNSS::isAntennaShorted() { return false; }
+
+//----------------------------------------
+// Returns true if the antenna is shorted
+//----------------------------------------
+bool GNSS::isAntennaOpen() { return false; }
+
+//----------------------------------------
 // Set the minimum satellite signal level for navigation.
 //----------------------------------------
 bool GNSS::setMinCno(uint8_t cnoValue)
@@ -53,6 +63,12 @@ bool GNSS::setMinCno(uint8_t cnoValue)
 
     // Pass the value to the GNSS receiver
     return gnss->setMinCnoRadio(cnoValue);
+}
+
+// Antenna Short / Open detection
+bool GNSS::supportsAntennaShortOpen()
+{
+    return false;
 }
 
 // Periodically push GGA sentence over NTRIP Client, to Caster, if enabled

--- a/Firmware/RTK_Everywhere/GNSS_ZED.h
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.h
@@ -11,8 +11,6 @@ GNSS_ZED.h
 
 #include <SparkFun_u-blox_GNSS_v3.h> //http://librarymanager/All#SparkFun_u-blox_GNSS_v3
 
-uint8_t aStatus = SFE_UBLOX_ANTENNA_STATUS_DONTKNOW;
-
 // Each constellation will have its config key, enable, and a visible name
 typedef struct
 {
@@ -385,6 +383,8 @@ class GNSS_ZED : GNSS
     {
     }
 
+    uint8_t aStatus = SFE_UBLOX_ANTENNA_STATUS_DONTKNOW;
+
     // If we have decryption keys, configure module
     // Note: don't check online.lband_neo here. We could be using ip corrections
     void applyPointPerfectKeys();
@@ -570,6 +570,10 @@ class GNSS_ZED : GNSS
     // Returns full year, ie 2023, not 23.
     uint16_t getYear();
 
+    // Antenna Short / Open detection
+    bool isAntennaShorted();
+    bool isAntennaOpen();
+
     bool isBlocking();
 
     // Date is confirmed once we have GNSS fix
@@ -735,6 +739,9 @@ class GNSS_ZED : GNSS
 
     // Callback to store MON-COMMS information
     void storeMONCOMMSdataRadio(UBX_MON_COMMS_data_t *ubxDataStruct);
+
+    // Antenna Short / Open detection
+    bool supportsAntennaShortOpen();
 
     // Reset the survey-in operation
     // Outputs:

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -1424,6 +1424,22 @@ uint16_t GNSS_ZED::getYear()
 }
 
 //----------------------------------------
+// Returns true if the antenna is shorted
+//----------------------------------------
+bool GNSS_ZED::isAntennaShorted()
+{
+    return (aStatus == SFE_UBLOX_ANTENNA_STATUS_SHORT);
+}
+
+//----------------------------------------
+// Returns true if the antenna is shorted
+//----------------------------------------
+bool GNSS_ZED::isAntennaOpen()
+{
+    return (aStatus == SFE_UBLOX_ANTENNA_STATUS_OPEN);
+}
+
+//----------------------------------------
 bool GNSS_ZED::isBlocking()
 {
     return (false);
@@ -2484,7 +2500,9 @@ void GNSS_ZED::storeHPdataRadio(UBX_NAV_HPPOSLLH_data_t *ubxDataStruct)
 //----------------------------------------
 void storeMONHWdata(UBX_MON_HW_data_t *ubxDataStruct)
 {
-    aStatus = ubxDataStruct->aStatus;
+    GNSS_ZED *zed = (GNSS_ZED *)gnss;
+
+    zed->aStatus = ubxDataStruct->aStatus;
 }
 
 //----------------------------------------
@@ -2625,6 +2643,12 @@ void storeTIMTPdata(UBX_TIM_TP_data_t *ubxDataStruct)
     timTpMicros = us;
     timTpArrivalMillis = millis();
     timTpUpdated = true;
+}
+
+// Antenna Short / Open detection
+bool GNSS_ZED::supportsAntennaShortOpen()
+{
+    return present.antennaShortOpen;
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/HTTP_Client.ino
+++ b/Firmware/RTK_Everywhere/HTTP_Client.ino
@@ -622,13 +622,15 @@ void httpClientUpdate()
                 else if (pointPerfectNtripNeeded() == true)
                 {
                     // We received a JSON blob containing NTRIP credentials
+                    // Note: this prints the userName and password, which should probably be kept secret?
+                    // TODO: comment this
                     systemPrintf("PointPerfect response: %s\r\n", response.c_str());
 
                     // Check if the JSON blob contains rtcmCredentials
                     // If this is the first time this device has connected to ThingStream, rtcmCredentials
-                    // will not be present and we need to retry
+                    // endpoint will not be present and we need to retry
                     // httpClientConnectLimitReached will prevent excessive retries
-                    if ((const char *)((*jsonZtp)["rtcmCredentials"]) == nullptr)
+                    if ((const char *)((*jsonZtp)["rtcmCredentials"]["endpoint"]) == nullptr)
                     {
                         systemPrintln("ERROR - rtcmCredentials not found!\r\n");
                         httpClientRestart(); // Try again - allow time for ThingStream to finish activating the device on plan

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -497,7 +497,7 @@ SFE_MAX1704X lipo(MAX1704X_MAX17048);
 
 #ifdef COMPILE_BQ40Z50
 #include "SparkFun_BQ40Z50_Battery_Manager_Arduino_Library.h" //Click here to get the library: http://librarymanager/All#SparkFun_BQ40Z50
-BQ40Z50 *bq40z50Battery;
+BQ40Z50 *bq40z50Battery = nullptr;
 #endif // COMPILE_BQ40Z50
 
 // RTK LED PWM (LEDC) properties
@@ -544,8 +544,8 @@ volatile bool forwardGnssDataToUsbSerial;
 
 #define platformPrefix platformPrefixTable[productVariant] // Sets the prefix for broadcast names
 
-HardwareSerial *serialGNSS;  // Don't instantiate until we know what gnssPlatform we're on
-HardwareSerial *serial2GNSS; // Don't instantiate until we know what gnssPlatform we're on
+HardwareSerial *serialGNSS = nullptr;  // Don't instantiate until we know what gnssPlatform we're on
+HardwareSerial *serial2GNSS = nullptr; // Don't instantiate until we know what gnssPlatform we're on
 
 #define SERIAL_SIZE_TX 512
 uint8_t wBuffer[SERIAL_SIZE_TX]; // Buffer for writing from incoming SPP to F9P
@@ -619,7 +619,7 @@ const int beepTaskUpdatesHz = 20; // Update Beep 20 times a second. Shortest dur
 // Buttons - Interrupt driven and debounce
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 #include <JC_Button.h> //http://librarymanager/All#JC_Button
-Button *userBtn;
+Button *userBtn = nullptr;
 
 const uint8_t buttonCheckTaskPriority = 1; // 3 being the highest, and 0 being the lowest
 const int buttonTaskStackSize = 2000;

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -648,9 +648,6 @@ unsigned long lastDynamicDataUpdate;
 #include <WebServer.h>       // Port 80
 #include <esp_http_server.h> // Needed for web sockets only - on port 81
 
-// https://github.com/espressif/arduino-esp32/blob/master/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
-DNSServer *dnsserver;
-
 bool websocketConnected = false;
 
 #endif // COMPILE_AP

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -834,8 +834,7 @@ bool webServerAssignResources(int httpPort = 80)
         }
         createSettingsString(settingsCSV);
 
-    //
-    https: // github.com/espressif/arduino-esp32/blob/master/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
+        /* https://github.com/espressif/arduino-esp32/blob/master/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino */
 
         webServer = new WebServer(httpPort);
         if (!webServer)

--- a/Firmware/RTK_Everywhere/menuPP.ino
+++ b/Firmware/RTK_Everywhere/menuPP.ino
@@ -1532,13 +1532,16 @@ void provisioningUpdate()
         else if (networkConsumerIsConnected(NETCONSUMER_POINTPERFECT_KEY_UPDATE))
         {
             if (settings.debugPpCertificate)
-                systemPrintln("PointPerfect key update connected to network");
+                systemPrintln("PointPerfect key/credentials update connected to network");
 
             // Go get latest keys
             ztpResponse = ZTP_NOT_STARTED;           // HTTP_Client will update this
             httpClientModeNeeded = true;             // This will start the HTTP_Client
             provisioningStartTime_millis = millis(); // Record the start time so we can timeout
-            paintGettingKeys();
+            if (pointPerfectServiceUsesKeys() == true)
+                paintGettingKeys();
+            else
+                paintGettingCredentials();
             networkUserAdd(NETCONSUMER_POINTPERFECT_KEY_UPDATE, __FILE__, __LINE__);
             provisioningSetState(PROVISIONING_STARTED);
         }


### PR DESCRIPTION
- Prevent crash from uninitialized class instance pointers
- Remove unused `dnsserver` (lower case s)
- Make HTTP_Client retry if ThingStream is still activating the Location Thing
- Prevent crash if PP JSON blob does not contain expected data
- Add `paintGettingCredentials`
- Add support for antenna short / open detection on mosaic-X5. Move antenna detection into the GNSS class