### PR TITLE
Enable Captive Portal

### DIFF
--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -104,9 +104,20 @@ Network.ino
 //----------------------------------------
 
 static const char *networkConsumerTable[] = {
-    "HTTP_CLIENT",    "NTP_SERVER",     "NTRIP_CLIENT", "NTRIP_SERVER_0", "NTRIP_SERVER_1",
-    "NTRIP_SERVER_2", "NTRIP_SERVER_3", "OTA_CLIENT",   "POINTPERFECT_KEY_UPDATE", "POINTPERFECT_MQTT_CLIENT",
-    "TCP_CLIENT",     "TCP_SERVER",     "UDP_SERVER",   "WEB_CONFIG",
+    "HTTP_CLIENT",
+    "NTP_SERVER",
+    "NTRIP_CLIENT",
+    "NTRIP_SERVER_0",
+    "NTRIP_SERVER_1",
+    "NTRIP_SERVER_2",
+    "NTRIP_SERVER_3",
+    "OTA_CLIENT",
+    "POINTPERFECT_KEY_UPDATE",
+    "POINTPERFECT_MQTT_CLIENT",
+    "TCP_CLIENT",
+    "TCP_SERVER",
+    "UDP_SERVER",
+    "WEB_CONFIG",
 };
 
 static const int networkConsumerTableEntries = sizeof(networkConsumerTable) / sizeof(networkConsumerTable[0]);
@@ -203,7 +214,8 @@ void menuTcpUdp()
         if (settings.enableTcpServer)
         {
             systemPrintf("8) Enable NTRIP Caster: %s\r\n", settings.enableNtripCaster ? "Enabled" : "Disabled");
-            systemPrintf("9) Enable base Caster override: %s\r\n", settings.baseCasterOverride ? "Enabled" : "Disabled");
+            systemPrintf("9) Enable base Caster override: %s\r\n",
+                         settings.baseCasterOverride ? "Enabled" : "Disabled");
         }
 
         //------------------------------

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -947,6 +947,13 @@ void networkEvent(arduino_event_id_t event, arduino_event_info_t info)
     case ARDUINO_EVENT_WIFI_STA_GOT_IP:
     case ARDUINO_EVENT_WIFI_STA_GOT_IP6:
     case ARDUINO_EVENT_WIFI_STA_LOST_IP:
+    case ARDUINO_EVENT_WIFI_AP_START:
+    case ARDUINO_EVENT_WIFI_AP_STOP:
+    case ARDUINO_EVENT_WIFI_AP_STACONNECTED:
+    case ARDUINO_EVENT_WIFI_AP_STADISCONNECTED:
+    case ARDUINO_EVENT_WIFI_AP_STAIPASSIGNED:
+    case ARDUINO_EVENT_WIFI_AP_PROBEREQRECVED:
+    case ARDUINO_EVENT_WIFI_AP_GOT_IP6:
         wifi.eventHandler(event, info);
         break;
 #endif // COMPILE_WIFI

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -898,6 +898,9 @@ void networkEvent(arduino_event_id_t event, arduino_event_info_t info)
 {
     int index;
 
+    if (settings.debugNetworkLayer)
+        systemPrintf("event: %d (%s)\r\n", event, Network.eventName(event));
+
     // Get the index into the networkInterfaceTable for the default interface
     index = networkPriority;
     if (index < NETWORK_OFFLINE)

--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -2532,7 +2532,19 @@ void networkUseDefaultInterface()
         isDefault = networkInterfaceTable[index].netif->isDefault();
         if (!isDefault)
             networkInterfaceTable[index].netif->setDefault();
+
+        if (settings.debugNetworkLayer)
+            networkPrintDefaultInterface();
     }
+}
+
+//----------------------------------------
+// Print the default network interface specs
+//----------------------------------------
+void networkPrintDefaultInterface()
+{
+    NetworkInterface *irfc = Network.getDefaultInterface();
+    systemPrintln(irfc->printTo(Serial));
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -146,7 +146,7 @@
 #include <NetworkUdp.h>
 #endif // COMPILE_NETWORK
 
-#define RTK_MAX_CONNECTION_MSEC     (15 * MILLISECONDS_IN_A_MINUTE)
+#define RTK_MAX_CONNECTION_MSEC (15 * MILLISECONDS_IN_A_MINUTE)
 
 bool RTK_CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC =
     false; // Flag used by the special build of libmbedtls (libmbedcrypto) to select external memory
@@ -172,16 +172,16 @@ const uint16_t HTTPS_PORT = 443;                                                
 #include <PPP.h>
 #endif // COMPILE_CELLULAR
 
-#include <esp_mac.h>    // MAC address support
 #include "settings.h"
+#include <esp_mac.h> // MAC address support
 
 #define MAX_CPU_CORES 2
 #define IDLE_COUNT_PER_SECOND 515400 // Found by empirical sketch
 #define IDLE_TIME_DISPLAY_SECONDS 5
 #define MAX_IDLE_TIME_COUNT (IDLE_TIME_DISPLAY_SECONDS * IDLE_COUNT_PER_SECOND)
 
-#define HOURS_IN_A_DAY      24L
-#define MINUTES_IN_AN_HOUR  60L
+#define HOURS_IN_A_DAY 24L
+#define MINUTES_IN_AN_HOUR 60L
 #define SECONDS_IN_A_MINUTE 60L
 #define MILLISECONDS_IN_A_SECOND 1000L
 #define MILLISECONDS_IN_A_MINUTE (SECONDS_IN_A_MINUTE * MILLISECONDS_IN_A_SECOND)
@@ -377,8 +377,8 @@ bool wifiSoftApRunning;         // False: stopped, True: starting, running, stop
 bool wifiStationOnline;         // WiFi station started successfully
 bool wifiStationRunning;        // False: stopped, True: starting, running, stopping
 
-const char * wifiSoftApSsid = "RTK Config";
-const char * wifiSoftApPassword = nullptr;
+const char *wifiSoftApSsid = "RTK Config";
+const char *wifiSoftApPassword = nullptr;
 
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
@@ -996,7 +996,7 @@ volatile bool deadManWalking;
                                                                                                                        \
         /* Turn on nearly all the debug prints */                                                                      \
         settings.debugCorrections = true;                                                                              \
-        settings.debugGnss = false;                                                                                     \
+        settings.debugGnss = false;                                                                                    \
         settings.debugHttpClientData = true;                                                                           \
         settings.debugHttpClientState = true;                                                                          \
         settings.debugLora = true;                                                                                     \
@@ -1041,7 +1041,7 @@ volatile bool deadManWalking;
                                                                                                                        \
         /* Turn on nearly all the debug prints */                                                                      \
         settings.debugCorrections = true;                                                                              \
-        settings.debugGnss = false;                                                                                     \
+        settings.debugGnss = false;                                                                                    \
         settings.debugHttpClientData = false;                                                                          \
         settings.debugHttpClientState = true;                                                                          \
         settings.debugLora = false;                                                                                    \
@@ -1240,8 +1240,8 @@ void setup()
     DMW_b("loadSettings");
     loadSettings(); // Attempt to load settings after SD is started so we can read the settings file if available
 
-    //DEBUG_NEARLY_EVERYTHING // Debug nearly all the things
-    //DEBUG_THE_ESSENTIALS // Debug the essentials - handy for measuring the boot time after a factory reset
+    // DEBUG_NEARLY_EVERYTHING // Debug nearly all the things
+    // DEBUG_THE_ESSENTIALS // Debug the essentials - handy for measuring the boot time after a factory reset
 
     DMW_b("checkArrayDefaults");
     checkArrayDefaults(); // Check for uninitialized arrays that won't be initialized by gnssConfigure

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -591,14 +591,14 @@ void notFound()
     if (settings.enableCaptivePortal == true && knownCaptiveUrl(webServer->uri()) == true)
     {
         String logmessage = "Known captive URI: " + webServer->client().remoteIP().toString() + " " + webServer->uri();
-        Serial.println(logmessage);
-        webServer->sendHeader("Location", "/portal");
-        webServer->send(302, "text/plain", "Redirect to captive portal");
+        systemPrintln(logmessage);
+        webServer->sendHeader("Location", "/");
+        webServer->send(302, "text/plain", "Redirect to Web Config");
         return;
     }
 
     String logmessage = "notFound: " + webServer->client().remoteIP().toString() + " " + webServer->uri();
-    Serial.println(logmessage);
+    systemPrintln(logmessage);
     webServer->send(404, "text/plain", "Not found");
 }
 
@@ -619,22 +619,6 @@ bool knownCaptiveUrl(String uri)
             return true;
     }
     return false;
-}
-
-void respondWithPortal()
-{
-    Serial.println("\r\n Send portal page");
-
-    String response = "<!DOCTYPE html><html><head><title>RTK Config</title></head><body>";
-    response += "<div class='container'>";
-    response += "<div align='center' class='col-sm-12'><img src='http://";
-    response += WiFi.softAPIP().toString();
-    response += "/src/rtk-setup.png' alt='SparkFun RTK WiFi Setup'></div>";
-    response += "<div align='center'><h3>Configure your RTK receiver <a href='http://";
-    response += WiFi.softAPIP().toString();
-    response += "/'>here</a></h3></div>";
-    response += "</div></body></html>";
-    webServer->send(200, "text/html", response);
 }
 
 //----------------------------------------
@@ -893,13 +877,6 @@ bool webServerAssignResources(int httpPort = 80)
         GET_PAGE("/src/fonts/icomoon.svg", "text/plain", icomoon_svg);
         GET_PAGE("/src/fonts/icomoon.ttf", "text/plain", icomoon_ttf);
         GET_PAGE("/src/fonts/icomoon.woof", "text/plain", icomoon_woof);
-
-        // Handler for captive portal page
-        if (settings.enableCaptivePortal == true)
-        {
-            Serial.println("\r\n Setting portal");
-            webServer->on("/portal", []() { respondWithPortal(); });
-        }
 
         // Handler for the /uploadFile form POST
         webServer->on(

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -63,8 +63,8 @@ static int last_ws_fd;
 
 static TaskHandle_t updateWebServerTaskHandle;
 static const uint8_t updateWebServerTaskPriority = 0; // 3 being the highest, and 0 being the lowest
-static const int webServerTaskStackSize = 4096;       // Needs to be large enough to hold the file manager file list
-static const int webSocketStackSize = 8192;
+static const int webServerTaskStackSize = 1024 * 4;
+static const int webSocketStackSize = 1024 * 20; // Needs to be large enough to hold the file manager file list
 
 // Inspired by:
 // https://github.com/espressif/arduino-esp32/blob/master/libraries/WebServer/examples/MultiHomedServers/MultiHomedServers.ino

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -33,16 +33,15 @@ static const char *const webServerStateNames[] = {
 // Macros
 //----------------------------------------
 
-#define GET_PAGE(page, type, data) \
-    webServer->on(page, HTTP_GET, []() { \
-        String length;  \
-        if (settings.debugWebServer == true)    \
-            Serial.printf("WebServer: Sending %s (%p, %d bytes)\r\n", \
-                          page, (void *)data, sizeof(data));  \
-        webServer->sendHeader("Content-Encoding", "gzip"); \
-        length = String(sizeof(data));  \
-        webServer->sendHeader("Content-Length", length.c_str()); \
-        webServer->send_P(200, type, (const char *)data, sizeof(data)); \
+#define GET_PAGE(page, type, data)                                                                                     \
+    webServer->on(page, HTTP_GET, []() {                                                                               \
+        String length;                                                                                                 \
+        if (settings.debugWebServer == true)                                                                           \
+            Serial.printf("WebServer: Sending %s (%p, %d bytes)\r\n", page, (void *)data, sizeof(data));               \
+        webServer->sendHeader("Content-Encoding", "gzip");                                                             \
+        length = String(sizeof(data));                                                                                 \
+        webServer->sendHeader("Content-Length", length.c_str());                                                       \
+        webServer->send_P(200, type, (const char *)data, sizeof(data));                                                \
     });
 
 //----------------------------------------
@@ -64,7 +63,7 @@ static int last_ws_fd;
 
 static TaskHandle_t updateWebServerTaskHandle;
 static const uint8_t updateWebServerTaskPriority = 0; // 3 being the highest, and 0 being the lowest
-static const int webServerTaskStackSize = 4096; // Needs to be large enough to hold the file manager file list
+static const int webServerTaskStackSize = 4096;       // Needs to be large enough to hold the file manager file list
 static const int webSocketStackSize = 8192;
 
 // Inspired by:
@@ -953,13 +952,12 @@ bool webServerAssignResources(int httpPort = 80)
 
         // Starts task for updating webServer with handleClient
         if (task.updateWebServerTaskRunning == false)
-            xTaskCreate(
-                updateWebServerTask,
-                "UpdateWebServer",            // Just for humans
-                webServerTaskStackSize,       // Stack Size - needs to be large enough to hold the file manager list
-                nullptr,                      // Task input parameter
-                updateWebServerTaskPriority,
-                &updateWebServerTaskHandle); // Task handle
+            xTaskCreate(updateWebServerTask,
+                        "UpdateWebServer",      // Just for humans
+                        webServerTaskStackSize, // Stack Size - needs to be large enough to hold the file manager list
+                        nullptr,                // Task input parameter
+                        updateWebServerTaskPriority,
+                        &updateWebServerTaskHandle); // Task handle
 
         if (settings.debugWebServer == true)
             systemPrintln("Web Server: Started");
@@ -1027,7 +1025,7 @@ void webServerReleaseResources()
 
     online.webServer = false;
 
-    webServerStopSockets();      // Release socket resources
+    webServerStopSockets(); // Release socket resources
 
     if (webServer != nullptr)
     {
@@ -1060,8 +1058,7 @@ void webServerStopSockets()
         // Stop the httpd server
         esp_err_t status = httpd_stop(wsserver);
         if (status != ESP_OK)
-            systemPrintf("ERROR: wsserver failed to stop, status: %s!\r\n",
-                         esp_err_to_name(status));
+            systemPrintf("ERROR: wsserver failed to stop, status: %s!\r\n", esp_err_to_name(status));
         wsserver = nullptr;
     }
 }
@@ -1312,25 +1309,34 @@ static esp_err_t ws_handler(httpd_req_t *req)
     }
     if (settings.debugWebServer == true)
     {
-        const char * pktType;
+        const char *pktType;
         size_t length = ws_pkt.len;
         switch (ws_pkt.type)
         {
-        default: pktType = nullptr; break;
-        case HTTPD_WS_TYPE_CONTINUE: pktType = "HTTPD_WS_TYPE_CONTINUE"; break;
-        case HTTPD_WS_TYPE_TEXT:     pktType = "HTTPD_WS_TYPE_TEXT"; break;
-        case HTTPD_WS_TYPE_BINARY:   pktType = "HTTPD_WS_TYPE_BINARY"; break;
-        case HTTPD_WS_TYPE_CLOSE:    pktType = "HTTPD_WS_TYPE_CLOSE"; break;
-        case HTTPD_WS_TYPE_PING:     pktType = "HTTPD_WS_TYPE_PING"; break;
-        case HTTPD_WS_TYPE_PONG:     pktType = "HTTPD_WS_TYPE_PONG"; break;
+        default:
+            pktType = nullptr;
+            break;
+        case HTTPD_WS_TYPE_CONTINUE:
+            pktType = "HTTPD_WS_TYPE_CONTINUE";
+            break;
+        case HTTPD_WS_TYPE_TEXT:
+            pktType = "HTTPD_WS_TYPE_TEXT";
+            break;
+        case HTTPD_WS_TYPE_BINARY:
+            pktType = "HTTPD_WS_TYPE_BINARY";
+            break;
+        case HTTPD_WS_TYPE_CLOSE:
+            pktType = "HTTPD_WS_TYPE_CLOSE";
+            break;
+        case HTTPD_WS_TYPE_PING:
+            pktType = "HTTPD_WS_TYPE_PING";
+            break;
+        case HTTPD_WS_TYPE_PONG:
+            pktType = "HTTPD_WS_TYPE_PONG";
+            break;
         }
-        systemPrintf("Packet: %p, %d bytes, type: %d%s%s%s\r\n",
-                     ws_pkt.payload,
-                     length,
-                     ws_pkt.type,
-                     pktType ? " (" : "",
-                     pktType ? pktType : "",
-                     pktType ? ")" : "");
+        systemPrintf("Packet: %p, %d bytes, type: %d%s%s%s\r\n", ws_pkt.payload, length, ws_pkt.type,
+                     pktType ? " (" : "", pktType ? pktType : "", pktType ? ")" : "");
         if (length > 0x40)
             length = 0x40;
         dumpBuffer(ws_pkt.payload, length);
@@ -1379,7 +1385,7 @@ static const httpd_uri_t ws = {.uri = "/ws",
 //----------------------------------------
 // Display the HTTPD configuration
 //----------------------------------------
-void httpdDisplayConfig(struct httpd_config * config)
+void httpdDisplayConfig(struct httpd_config *config)
 {
     systemPrintf("httpd_config object:\r\n");
     systemPrintf("%10d: task_priority\r\n", config->task_priority);
@@ -1445,8 +1451,7 @@ bool websocketServerStart(void)
     }
 
     // Display the failure to start
-    systemPrintf("ERROR: wsserver failed to start, status: %s!\r\n",
-                 esp_err_to_name(status));
+    systemPrintf("ERROR: wsserver failed to start, status: %s!\r\n", esp_err_to_name(status));
     return false;
 }
 

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -822,7 +822,7 @@ bool webServerAssignResources(int httpPort = 80)
         }
         else
         {
-            //if (settings.debugNetworkLayer)
+            if (settings.debugNetworkLayer)
                 systemPrintf("mDNS started as %s.local\r\n", settings.mdnsHostName);
         }
 

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -816,6 +816,16 @@ bool webServerAssignResources(int httpPort = 80)
         /* https://github.com/espressif/arduino-esp32/blob/master/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
          */
 
+        if (MDNS.begin(&settings.mdnsHostName[0]) == false)
+        {
+            systemPrintln("Error setting up MDNS responder!");
+        }
+        else
+        {
+            //if (settings.debugNetworkLayer)
+                systemPrintf("mDNS started as %s.local\r\n", settings.mdnsHostName);
+        }
+
         webServer = new WebServer(httpPort);
         if (!webServer)
         {
@@ -926,6 +936,9 @@ bool webServerAssignResources(int httpPort = 80)
 
         // Start the web server
         webServer->begin();
+
+        if (settings.mdnsEnable == true)
+            MDNS.addService("http", "tcp", settings.httpPort); // Add service to MDNS
 
         // Starts task for updating webServer with handleClient
         if (task.updateWebServerTaskRunning == false)

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -2709,12 +2709,12 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         // Set the soft AP subnet mask, IP, gateway, DNS, and first DHCP addresses
         if (starting & WIFI_AP_SET_IP_ADDR)
         {
-            if (!softApSetIpAddress(_apIpAddress.toString().c_str(), _apSubnetMask.toString().c_str(),
-                                    _apGatewayAddress.toString().c_str(), _apDnsAddress.toString().c_str(),
-                                    _apFirstDhcpAddress.toString().c_str()))
-            {
-                break;
-            }
+            // if (!softApSetIpAddress(_apIpAddress.toString().c_str(), _apSubnetMask.toString().c_str(),
+            //                         _apGatewayAddress.toString().c_str(), _apDnsAddress.toString().c_str(),
+            //                         _apFirstDhcpAddress.toString().c_str()))
+            // {
+            //     break;
+            // }
             _started = _started | WIFI_AP_SET_IP_ADDR;
         }
 

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -1665,6 +1665,15 @@ void RTK_WIFI::softApEventHandler(arduino_event_id_t event, arduino_event_info_t
         if (settings.debugWifiState && _verbose)
             systemPrintf("_started: 0x%08x\r\n", _started);
         break;
+
+    case ARDUINO_EVENT_WIFI_AP_STACONNECTED:
+        if (settings.debugWifiState)
+            systemPrintln("Device connected to Soft AP!");
+        break;
+    case ARDUINO_EVENT_WIFI_AP_STADISCONNECTED:
+        if (settings.debugWifiState)
+            systemPrintln("Device disconnected from Soft AP!");
+        break;
     }
 }
 
@@ -2746,7 +2755,7 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         // Start the DNS server
         if (starting & WIFI_AP_START_DNS_SERVER)
         {
-            if (settings.debugWifiState)
+            if (settings.debugWifiState || settings.debugWebServer)
                 systemPrintf("Starting DNS on soft AP\r\n");
             if (dnsServer.start(53, "*", WiFi.softAPIP()) == false)
             {

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -2700,7 +2700,6 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         // Set the soft AP subnet mask, IP, gateway, DNS, and first DHCP addresses
         if (starting & WIFI_AP_SET_IP_ADDR)
         {
-            Serial.println("\n\r Running softAP set IP");
             if (!softApSetIpAddress(_apIpAddress.toString().c_str(), _apSubnetMask.toString().c_str(),
                                     _apGatewayAddress.toString().c_str(), _apDnsAddress.toString().c_str(),
                                     _apFirstDhcpAddress.toString().c_str()))

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -15,12 +15,20 @@
 #define WIFI_CONNECTION_STABLE_MSEC (15 * MILLISECONDS_IN_A_MINUTE)
 
 static const char *wifiAuthorizationName[] = {
-    "Open",     "WEP",           "WPA_PSK",  "WPA2_PSK", "WPA_WPA2_PSK", //"ENTERPRISE", 
+    "Open",
+    "WEP",
+    "WPA_PSK",
+    "WPA2_PSK",
+    "WPA_WPA2_PSK", //"ENTERPRISE",
     "WPA2_Enterprise",
-    "WPA3_PSK", "WPA2_WPA3_PSK", "WAPI_PSK", "OWE",      "WPA3_ENT_192",
+    "WPA3_PSK",
+    "WPA2_WPA3_PSK",
+    "WAPI_PSK",
+    "OWE",
+    "WPA3_ENT_192",
 
-    //Compatible with ESP32 core v3.2.1, 16 reported, 18 listed here:
-    //https://github.com/espressif/esp-idf/blob/master/components/esp_wifi/include/esp_wifi_types_generic.h#L86
+    // Compatible with ESP32 core v3.2.1, 16 reported, 18 listed here:
+    // https://github.com/espressif/esp-idf/blob/master/components/esp_wifi/include/esp_wifi_types_generic.h#L86
     //"WPA3_EXT_PSK",
     //"WPA3_EXT_PSK_MIXED_MODE",
     //"DPP",
@@ -3153,8 +3161,10 @@ void RTK_WIFI::verifyTables()
     // Verify the authorization name table
     if (WIFI_AUTH_MAX != wifiAuthorizationNameEntries)
     {
-        //https://github.com/espressif/esp-idf/blob/master/components/esp_wifi/include/esp_wifi_types_generic.h#L86
-        systemPrintf("ERROR: Fix wifiAuthorizationName list (%d) to match wifi_auth_mode_t (%d) in esp_wifi_types.h!\r\n", wifiAuthorizationNameEntries, WIFI_AUTH_MAX);
+        // https://github.com/espressif/esp-idf/blob/master/components/esp_wifi/include/esp_wifi_types_generic.h#L86
+        systemPrintf(
+            "ERROR: Fix wifiAuthorizationName list (%d) to match wifi_auth_mode_t (%d) in esp_wifi_types.h!\r\n",
+            wifiAuthorizationNameEntries, WIFI_AUTH_MAX);
         reportFatalError("Fix wifiAuthorizationName list to match wifi_auth_mode_t in esp_wifi_types.h!");
     }
 

--- a/Firmware/RTK_Everywhere/menuPP.ino
+++ b/Firmware/RTK_Everywhere/menuPP.ino
@@ -714,8 +714,6 @@ void updateLBand()
         // Stop L-Band is service is disabled
         else if (online.lband_gnss == true && pointPerfectLbandNeeded() == false)
         {
-            Serial.println("\n\r Taking L-Band offline");
-
             bool result = true;
 
             GNSS_MOSAIC *mosaic = (GNSS_MOSAIC *)gnss;


### PR DESCRIPTION
This PR:

* Disable the setting of DNS and DHCP addresses of Soft AP to allow WebServer to run correctly
* Increases webSocket task size (more RAM)
* Enables MDNS during Soft AP / Web Config
* Add missing AP events to networkEvent() handler