### PR TITLE
Add raw logging to Torch and Postcard

### DIFF
--- a/Firmware/RTK_Everywhere/AP-Config/index.html
+++ b/Firmware/RTK_Everywhere/AP-Config/index.html
@@ -458,11 +458,11 @@
 
                             <div style="margin-bottom:5px;">
                                 <button type="button" id="nmeaDefaults" class="btn btn-primary"
-                                    onClick="resetToSurveyingDefaults()">Reset to Surveying Defaults</button>
+                                    onClick="resetToSurveyingDefaults()">Reset to Defaults</button>
                             </div>
                             <div style="margin-bottom:5px;">
                                 <button type="button" id="loggingDefaults" class="btn btn-primary"
-                                    onClick="resetToLoggingDefaults()">Reset to Logging Defaults</button>
+                                    onClick="resetToLoggingDefaults()">Reset to PPP Logging</button>
                             </div>
                             <br>
                             <div id="mosaicNMEAStreamDropdowns">

--- a/Firmware/RTK_Everywhere/AP-Config/src/main.js
+++ b/Firmware/RTK_Everywhere/AP-Config/src/main.js
@@ -648,7 +648,6 @@ function parseIncoming(msg) {
         ge("enableARPLogging").dispatchEvent(new CustomEvent('change'));
         ge("enableAutoFirmwareUpdate").dispatchEvent(new CustomEvent('change'));
         ge("enableAutoReset").dispatchEvent(new CustomEvent('change'));
-        ge("useLocalizedDistribution").dispatchEvent(new CustomEvent('change'));
 
         updateECEFList();
         updateGeodeticList();
@@ -1435,6 +1434,15 @@ function resetToSurveyingDefaults() {
 
         ge("messageIntervalRTCMRover_RTCM1033").value = 10.0;
     }
+    else if (platformPrefix == "Postcard") {
+        ge("messageRateNMEA_GPRMC").value = 1;
+        ge("messageRateNMEA_GPGGA").value = 1;
+        ge("messageRateNMEA_GPGSV").value = 1;
+        ge("messageRateNMEA_GPGSA").value = 1;
+        ge("messageRateNMEA_GPVTG").value = 1;
+        ge("messageRateNMEA_GPGLL").value = 1;
+        ge("messageRateNMEA_GPGST").value = 1; //Supported on >= v4
+    }
 }
 function resetToLoggingDefaults() {
     zeroMessages();
@@ -1449,16 +1457,40 @@ function resetToLoggingDefaults() {
         ge("ubxMessageRate_RXM_SFRBX").value = 1;
     }
     else if (platformPrefix == "Torch") {
-        ge("messageRateNMEA_GPGGA").value = 0.5;
-        ge("messageRateNMEA_GPGSA").value = 0.5;
-        ge("messageRateNMEA_GPGST").value = 0.5;
-        ge("messageRateNMEA_GPGSV").value = 1.0;
-        ge("messageRateNMEA_GPRMC").value = 0.5;
+        ge("messageRateNMEA_GPGGA").value = 1;
+        ge("messageRateNMEA_GPGSA").value = 1;
+        ge("messageRateNMEA_GPGST").value = 1;
+        ge("messageRateNMEA_GPGSV").value = 5; // Limit to 1 per 5 seconds
+        ge("messageRateNMEA_GPRMC").value = 1;
 
-        ge("messageRateRTCMRover_RTCM1019").value = 1.0;
-        ge("messageRateRTCMRover_RTCM1020").value = 1.0;
-        ge("messageRateRTCMRover_RTCM1042").value = 1.0;
-        ge("messageRateRTCMRover_RTCM1046").value = 1.0;
+        ge("messageRateRTCMRover_RTCM1019").value = 30;
+        ge("messageRateRTCMRover_RTCM1020").value = 30;
+        ge("messageRateRTCMRover_RTCM1042").value = 30;
+        ge("messageRateRTCMRover_RTCM1046").value = 30;
+
+        ge("messageRateRTCMRover_RTCM1074").value = 30;
+        ge("messageRateRTCMRover_RTCM1084").value = 30;
+        ge("messageRateRTCMRover_RTCM1094").value = 30;
+        ge("messageRateRTCMRover_RTCM1124").value = 30;
+    }
+    else if (platformPrefix == "Postcard") {
+        ge("messageRateNMEA_GPRMC").value = 1;
+        ge("messageRateNMEA_GPGGA").value = 1;
+        ge("messageRateNMEA_GPGSV").value = 1;
+        ge("messageRateNMEA_GPGSA").value = 1;
+        ge("messageRateNMEA_GPVTG").value = 1;
+        ge("messageRateNMEA_GPGLL").value = 1;
+        ge("messageRateNMEA_GPGST").value = 1; // Supported on >= v4
+
+        ge("messageRateRTCMRover_RTCM1019").value = 30;
+        ge("messageRateRTCMRover_RTCM1020").value = 30;
+        ge("messageRateRTCMRover_RTCM1042").value = 30;
+        ge("messageRateRTCMRover_RTCM1046").value = 30;
+
+        ge("messageRateRTCMRover_RTCM107X").value = 30;
+        ge("messageRateRTCMRover_RTCM108X").value = 30;
+        ge("messageRateRTCMRover_RTCM109X").value = 30;
+        ge("messageRateRTCMRover_RTCM112X").value = 30;
     }
     else if (platformPrefix == "Facet mosaicX5") {
         ge("streamIntervalNMEA_0").value = 6; //msec500
@@ -1740,15 +1772,6 @@ document.addEventListener("DOMContentLoaded", (event) => {
         }
         else { //"pointPerfectService").value == 0 //Disabled
             hide("ppSettingsLBandNAConfig");
-        }
-    });
-
-    ge("useLocalizedDistribution").addEventListener("change", function () {
-        if (ge("useLocalizedDistribution").checked) {
-            show("localizedDistributionTileLevelDropdown");
-        }
-        else {
-            hide("localizedDistributionTileLevelDropdown");
         }
     });
 

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.h
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.h
@@ -111,6 +111,18 @@ class GNSS_LG290P : GNSS
     // Set the minimum satellite signal level for navigation.
     bool setMinCnoRadio(uint8_t cnoValue);
 
+    // Set all NMEA message report rates to one value
+    void setNmeaMessageRates(uint8_t msgRate);
+
+    // Given the name of a message, find it, and set the rate
+    bool setNmeaMessageRateByName(const char *msgName, uint8_t msgRate);
+
+    // Set all RTCM Rover message report rates to one value
+    void setRtcmRoverMessageRates(uint8_t msgRate);
+
+    // Given the name of a message, find it, and set the rate
+    bool setRtcmRoverMessageRateByName(const char *msgName, uint8_t msgRate);
+
   public:
     // Constructor
     GNSS_LG290P() : GNSS()

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -670,7 +670,7 @@ bool GNSS_LG290P::enableNMEA()
 
                 // If we are using IP based corrections, we need to send local data to the PPL
                 // The PPL requires being fed GPGGA/ZDA, and RTCM1019/1020/1042/1046
-                if (pointPerfectIsEnabled())
+                if (pointPerfectServiceUsesKeys())
                 {
                     // Mark PPL required messages as enabled if rate > 0
                     if (settings.lg290pMessageRatesNMEA[messageNumber] > 0)
@@ -693,7 +693,7 @@ bool GNSS_LG290P::enableNMEA()
             break; // Don't step through portNumbers
     }
 
-    if (pointPerfectIsEnabled())
+    if (pointPerfectServiceUsesKeys())
     {
         // Force on any messages that are needed for PPL
         // If firmware is 4 or higher, use setMessageRateOnPort, otherwise setMessageRate
@@ -873,7 +873,7 @@ bool GNSS_LG290P::enableRTCMRover()
 
                 // If we are using IP based corrections, we need to send local data to the PPL
                 // The PPL requires being fed GPGGA/ZDA, and RTCM1019/1020/1042/1046
-                if (pointPerfectIsEnabled())
+                if (pointPerfectServiceUsesKeys())
                 {
                     // Mark PPL required messages as enabled if rate > 0
                     if (settings.lg290pMessageRatesRTCMRover[messageNumber] > 0)
@@ -898,7 +898,7 @@ bool GNSS_LG290P::enableRTCMRover()
             break; // Don't step through portNumbers
     }
 
-    if (pointPerfectIsEnabled())
+    if (pointPerfectServiceUsesKeys())
     {
         enableMSM = true; // Force enable MSM output
 

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -39,7 +39,7 @@ void GNSS_LG290P::baseRtcmLowDataRate()
         settings.lg290pMessageRatesRTCMBase[x] = 0;
 
     settings.lg290pMessageRatesRTCMBase[getRtcmMessageNumberByName("RTCM3-1005")] =
-        10; // 1005 0.1Hz - Exclude antenna height
+        10;                                                                            // 1005 0.1Hz - Exclude antenna height
     settings.lg290pMessageRatesRTCMBase[getRtcmMessageNumberByName("RTCM3-107X")] = 2; // 1074 0.5Hz
     settings.lg290pMessageRatesRTCMBase[getRtcmMessageNumberByName("RTCM3-108X")] = 2; // 1084 0.5Hz
     settings.lg290pMessageRatesRTCMBase[getRtcmMessageNumberByName("RTCM3-109X")] = 2; // 1094 0.5Hz
@@ -726,7 +726,7 @@ bool GNSS_LG290P::enableNMEA()
 bool GNSS_LG290P::enableRTCMBase()
 {
     bool response = true;
-    bool enableMSM = false; // Goes true if we need to enable MSM output reporting
+    bool enableRTCM = false; // Goes true if we need to enable RTCM output reporting
 
     int portNumber = 1;
 
@@ -778,9 +778,9 @@ bool GNSS_LG290P::enableRTCMBase()
                                      lgMessagesRTCM[messageNumber].msgTextName);
                 }
 
-                // If any message is enabled, enable MSM output
+                // If any message is enabled, enable RTCM output
                 if (settings.lg290pMessageRatesRTCMBase[messageNumber] > 0)
-                    enableMSM = true;
+                    enableRTCM = true;
             }
         }
 
@@ -791,14 +791,14 @@ bool GNSS_LG290P::enableRTCMBase()
             break; // Don't step through portNumbers
     }
 
-    if (enableMSM == true)
+    if (enableRTCM == true)
     {
         if (settings.debugGnss)
-            systemPrintln("Enabling Base RTCM MSM output");
+            systemPrintln("Enabling Base RTCM output");
 
         // PQTMCFGRTCM fails to respond with OK over UART2 of LG290P, so don't look for it
         _lg290p->sendOkCommand(
-            "PQTMCFGRTCM,W,7,0,-90,07,06,2,1"); // Enable MSM7, output regular intervals, interval (seconds)
+            "PQTMCFGRTCM,W,4,0,-90,07,06,2,1"); // Enable MSM4, output regular intervals, interval (seconds)
     }
 
     return (response);
@@ -814,14 +814,29 @@ bool GNSS_LG290P::enableRTCMRover()
     bool rtcm1020Enabled = false;
     bool rtcm1042Enabled = false;
     bool rtcm1046Enabled = false;
-    bool enableMSM = false; // Goes true if we need to enable MSM output reporting
+    bool enableRTCM = false; // Goes true if we need to enable RTCM output reporting
 
     int portNumber = 1;
+
+    int minimumRtcmRate = 1000;
 
     while (portNumber < 4)
     {
         for (int messageNumber = 0; messageNumber < MAX_LG290P_RTCM_MSG; messageNumber++)
         {
+            // 1019 to 1046 can only be set to 1 fix per report
+            // 107x to 112x can be set to 1-1200 fixes between reports
+            // So we set all RTCM to 1, and set PQTMCFGRTCM to the lowest value found
+
+            // Capture the message with the lowest rate
+            if (settings.lg290pMessageRatesRTCMRover[messageNumber] > 0 && settings.lg290pMessageRatesRTCMRover[messageNumber] < minimumRtcmRate)
+                minimumRtcmRate = settings.lg290pMessageRatesRTCMRover[messageNumber];
+
+            // Force all RTCM messages to 1 or 0. See above for reasoning.
+            int rate = settings.lg290pMessageRatesRTCMRover[messageNumber];
+            if (rate > 1)
+                rate = 1;
+
             // Check if this RTCM message is supported by the current LG290P firmware
             if (lg290pFirmwareVersion >= lgMessagesRTCM[messageNumber].firmwareVersionSupported)
             {
@@ -836,12 +851,12 @@ bool GNSS_LG290P::enableRTCMRover()
                     {
                         // If any one of the commands fails, report failure overall
                         response &= _lg290p->setMessageRateOnPort(lgMessagesRTCM[messageNumber].msgTextName,
-                                                                  settings.lg290pMessageRatesRTCMRover[messageNumber],
+                                                                  rate,
                                                                   portNumber);
                     }
                     else
                         response &= _lg290p->setMessageRate(lgMessagesRTCM[messageNumber].msgTextName,
-                                                            settings.lg290pMessageRatesRTCMRover[messageNumber]);
+                                                            rate);
 
                     if (response == false && settings.debugGnss)
                         systemPrintf("Enable RTCM failed at messageNumber %d %s\r\n", messageNumber,
@@ -850,6 +865,8 @@ bool GNSS_LG290P::enableRTCMRover()
                 else
                 {
                     // X found. This is RTCM-1??X message. Assign 'offset' of 0
+
+                    // The rate of these type of messages can be 1 to 1200, so we allow the full rate
 
                     // If firmware is 4 or higher, use setMessageRateOnPort, otherwise setMessageRate
                     if (lg290pFirmwareVersion >= 4)
@@ -860,16 +877,17 @@ bool GNSS_LG290P::enableRTCMRover()
                     }
                     else
                         response &= _lg290p->setMessageRate(lgMessagesRTCM[messageNumber].msgTextName,
-                                                            settings.lg290pMessageRatesRTCMRover[messageNumber], 0);
+                                                            settings.lg290pMessageRatesRTCMRover[messageNumber],
+                                                            0);
 
                     if (response == false && settings.debugGnss)
                         systemPrintf("Enable RTCM failed at messageNumber %d %s\r\n", messageNumber,
                                      lgMessagesRTCM[messageNumber].msgTextName);
                 }
 
-                // If any message is enabled, enable MSM output
+                // If any message is enabled, enable RTCM output
                 if (settings.lg290pMessageRatesRTCMRover[messageNumber] > 0)
-                    enableMSM = true;
+                    enableRTCM = true;
 
                 // If we are using IP based corrections, we need to send local data to the PPL
                 // The PPL requires being fed GPGGA/ZDA, and RTCM1019/1020/1042/1046
@@ -900,7 +918,7 @@ bool GNSS_LG290P::enableRTCMRover()
 
     if (pointPerfectServiceUsesKeys())
     {
-        enableMSM = true; // Force enable MSM output
+        enableRTCM = true; // Force enable RTCM output
 
         // Force on any messages that are needed for PPL
         if (rtcm1019Enabled == false)
@@ -931,14 +949,22 @@ bool GNSS_LG290P::enableRTCMRover()
         }
     }
 
-    if (enableMSM == true)
+    // If any RTCM message is enabled, send CFGRTCM
+    // PQTMCFGRTCM only controls RTCM-1005 type messages, not RTCM-107x MSM messages (confusingly)
+    if (enableRTCM == true)
     {
         if (settings.debugCorrections)
-            systemPrintln("Enabling Rover RTCM MSM output");
+            systemPrintf("Enabling Rover RTCM MSM output with rate of %d\r\n", minimumRtcmRate);
+
+        // Enable MSM4, output at a rate equal to the minimum RTCM rate (EPH Mode = 2)
+        // PQTMCFGRTCM, W, <MSM_Type>, <MSM_Mode>, <MSM_ElevThd>, <Reserved>, <Reserved>, <EPH_Mode>, <EPH_Interval>
+        // We could set the MSM_ElevThd to (settings.minElev * -1) but there may be unintended consequences
+
+        char msmCommand[40] = {0};
+        snprintf(msmCommand, sizeof(msmCommand), "PQTMCFGRTCM,W,4,0,-90,07,06,2,%d", minimumRtcmRate);
 
         // PQTMCFGRTCM fails to respond with OK over UART2 of LG290P, so don't look for it
-        _lg290p->sendOkCommand(
-            "PQTMCFGRTCM,W,7,0,-90,07,06,2,1"); // Enable MSM7, output regular intervals, interval (seconds)
+        _lg290p->sendOkCommand(msmCommand);
     }
 
     return (response);
@@ -1267,15 +1293,17 @@ uint8_t GNSS_LG290P::getLoggingType()
         // GST is not available/default
         if (getActiveNmeaMessageCount() == 6 && getActiveRtcmMessageCount() == 0)
             logType = LOGGING_STANDARD;
+        else if (getActiveNmeaMessageCount() == 1 && getActiveRtcmMessageCount() == 8)
+            logType = LOGGING_PPP;
     }
     else
     {
         // GST *is* available/default
         if (getActiveNmeaMessageCount() == 7 && getActiveRtcmMessageCount() == 0)
             logType = LOGGING_STANDARD;
+        else if (getActiveNmeaMessageCount() == 1 && getActiveRtcmMessageCount() == 8)
+            logType = LOGGING_PPP;
     }
-
-    // What RTCM messages need to be logged to reach LOGGING_PPP?
 
     return ((uint8_t)logType);
 }
@@ -1742,28 +1770,33 @@ void GNSS_LG290P::menuMessages()
         {
             // setMessageRate() on the LG290P sets the output of a message
             // 'Output once every N position fixes'
+            // Slowest update rate of LG290P is an update per second, (0.5Hz not allowed)
+
+            int rtcmReportRate = 1;
+            if (incoming == 11)
+                rtcmReportRate = 30;
 
             setNmeaMessageRates(0); // Turn off all NMEA messages
             setNmeaMessageRateByName("GGA", 1);
 
             setRtcmRoverMessageRates(0); // Turn off all RTCM messages
-            setRtcmRoverMessageRateByName("RTCM3-1019", 1);
-            setRtcmRoverMessageRateByName("RTCM3-1020", 1);
-            setRtcmRoverMessageRateByName("RTCM3-1042", 1);
-            setRtcmRoverMessageRateByName("RTCM3-1046", 1);
-            setRtcmRoverMessageRateByName("RTCM3-107X", 1);
-            setRtcmRoverMessageRateByName("RTCM3-108X", 1);
-            setRtcmRoverMessageRateByName("RTCM3-109X", 1);
-            setRtcmRoverMessageRateByName("RTCM3-112X", 1);
+            setRtcmRoverMessageRateByName("RTCM3-1019", rtcmReportRate);
+            setRtcmRoverMessageRateByName("RTCM3-1020", rtcmReportRate);
+            setRtcmRoverMessageRateByName("RTCM3-1042", rtcmReportRate);
+            setRtcmRoverMessageRateByName("RTCM3-1046", rtcmReportRate);
+            setRtcmRoverMessageRateByName("RTCM3-107X", rtcmReportRate);
+            setRtcmRoverMessageRateByName("RTCM3-108X", rtcmReportRate);
+            setRtcmRoverMessageRateByName("RTCM3-109X", rtcmReportRate);
+            setRtcmRoverMessageRateByName("RTCM3-112X", rtcmReportRate);
+
+            setRate(1); // Go to 1 Hz
 
             if (incoming == 12)
             {
-                setRate(1); // Go to 1 second between desired solution reports
                 systemPrintln("Reset to High-rate PPP Logging Defaults (NMEAx1 / RTCMx8 - 1Hz)");
             }
             else
             {
-                setRate(30); // Go to 30 seconds between desired solution reports
                 systemPrintln("Reset to PPP Logging Defaults (NMEAx1 / RTCMx8 - 30 second decimation)");
             }
         }

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -1731,8 +1731,8 @@ void GNSS_LG290P::menuMessages()
         systemPrintln("4) Set PQTM Messages");
 
         systemPrintln("10) Reset to Defaults");
-        systemPrintln("11) Reset to PPP Logging (NMEAx1 / RTCMx8 - 30 second decimation)");
-        systemPrintln("12) Reset to High-rate PPP Logging (NMEAx1 / RTCMx8 - 1Hz)");
+        systemPrintln("11) Reset to PPP Logging (NMEAx7 / RTCMx8 - 30 second decimation)");
+        systemPrintln("12) Reset to High-rate PPP Logging (NMEAx7 / RTCMx8 - 1Hz)");
 
         systemPrintln("x) Exit");
 

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -1293,7 +1293,7 @@ uint8_t GNSS_LG290P::getLoggingType()
         // GST is not available/default
         if (getActiveNmeaMessageCount() == 6 && getActiveRtcmMessageCount() == 0)
             logType = LOGGING_STANDARD;
-        else if (getActiveNmeaMessageCount() == 1 && getActiveRtcmMessageCount() == 8)
+        else if (getActiveNmeaMessageCount() == 6 && getActiveRtcmMessageCount() == 8)
             logType = LOGGING_PPP;
     }
     else
@@ -1301,7 +1301,7 @@ uint8_t GNSS_LG290P::getLoggingType()
         // GST *is* available/default
         if (getActiveNmeaMessageCount() == 7 && getActiveRtcmMessageCount() == 0)
             logType = LOGGING_STANDARD;
-        else if (getActiveNmeaMessageCount() == 1 && getActiveRtcmMessageCount() == 8)
+        else if (getActiveNmeaMessageCount() == 7 && getActiveRtcmMessageCount() == 8)
             logType = LOGGING_PPP;
     }
 
@@ -1776,8 +1776,9 @@ void GNSS_LG290P::menuMessages()
             if (incoming == 11)
                 rtcmReportRate = 30;
 
-            setNmeaMessageRates(0); // Turn off all NMEA messages
-            setNmeaMessageRateByName("GGA", 1);
+            // Reset NMEA rates to defaults
+            for (int x = 0; x < MAX_LG290P_NMEA_MSG; x++)
+                settings.lg290pMessageRatesNMEA[x] = lgMessagesNMEA[x].msgDefaultRate;
 
             setRtcmRoverMessageRates(0); // Turn off all RTCM messages
             setRtcmRoverMessageRateByName("RTCM3-1019", rtcmReportRate);

--- a/Firmware/RTK_Everywhere/GNSS_UM980.h
+++ b/Firmware/RTK_Everywhere/GNSS_UM980.h
@@ -465,6 +465,18 @@ class GNSS_UM980 : GNSS
     //   modelNumber: Number of the model to use, provided by radio library
     bool setModel(uint8_t modelNumber);
 
+    // Set all NMEA message report rates to one value
+    void setNmeaMessageRates(uint8_t msgRate);
+
+    // Given the name of a message, find it, and set the rate
+    bool setNmeaMessageRateByName(const char *msgName, uint8_t msgRate);
+
+    // Set all RTCM Rover message report rates to one value
+    void setRtcmRoverMessageRates(uint8_t msgRate);
+
+    // Given the name of a message, find it, and set the rate
+    bool setRtcmRoverMessageRateByName(const char *msgName, uint8_t msgRate);
+
     bool setRadioBaudRate(uint32_t baud);
 
     // Specify the interval between solutions

--- a/Firmware/RTK_Everywhere/GNSS_UM980.ino
+++ b/Firmware/RTK_Everywhere/GNSS_UM980.ino
@@ -1373,6 +1373,7 @@ void GNSS_UM980::menuMessages()
             // Reset NMEA rates to defaults
             for (int x = 0; x < MAX_UM980_NMEA_MSG; x++)
                 settings.um980MessageRatesNMEA[x] = umMessagesNMEA[x].msgDefaultRate;
+            setNmeaMessageRateByName("GPGSV", 5); //Limit GSV updates to 1 every 5 seconds
 
             setRtcmRoverMessageRates(0); // Turn off all RTCM messages
             setRtcmRoverMessageRateByName("RTCM1019", reportRate);
@@ -1386,11 +1387,11 @@ void GNSS_UM980::menuMessages()
 
             if (incoming == 12)
             {
-                systemPrintln("Reset to High-rate PPP Logging (NMEAx1 / RTCMx8 - 1Hz)");
+                systemPrintln("Reset to High-rate PPP Logging (NMEAx5 / RTCMx8 - 1Hz)");
             }
             else
             {
-                systemPrintln("Reset to PPP Logging (NMEAx1 / RTCMx8 - 30 second decimation)");
+                systemPrintln("Reset to PPP Logging (NMEAx5 / RTCMx8 - 30 second decimation)");
             }
         }
 

--- a/Firmware/RTK_Everywhere/GNSS_UM980.ino
+++ b/Firmware/RTK_Everywhere/GNSS_UM980.ino
@@ -1370,18 +1370,19 @@ void GNSS_UM980::menuMessages()
             if (incoming == 12)
                 reportRate = 1;
 
-            setNmeaMessageRates(0); // Turn off all NMEA messages
-            setNmeaMessageRateByName("GPGGA", reportRate);
+            // Reset NMEA rates to defaults
+            for (int x = 0; x < MAX_UM980_NMEA_MSG; x++)
+                settings.um980MessageRatesNMEA[x] = umMessagesNMEA[x].msgDefaultRate;
 
             setRtcmRoverMessageRates(0); // Turn off all RTCM messages
-            setRtcmRoverMessageRateByName("RTCM31019", reportRate);
-            setRtcmRoverMessageRateByName("RTCM31020", reportRate);
-            setRtcmRoverMessageRateByName("RTCM31042", reportRate);
-            setRtcmRoverMessageRateByName("RTCM31046", reportRate);
-            setRtcmRoverMessageRateByName("RTCM31074", reportRate);
-            setRtcmRoverMessageRateByName("RTCM31084", reportRate);
-            setRtcmRoverMessageRateByName("RTCM31094", reportRate);
-            setRtcmRoverMessageRateByName("RTCM31124", reportRate);
+            setRtcmRoverMessageRateByName("RTCM1019", reportRate);
+            setRtcmRoverMessageRateByName("RTCM1020", reportRate);
+            setRtcmRoverMessageRateByName("RTCM1042", reportRate);
+            setRtcmRoverMessageRateByName("RTCM1046", reportRate);
+            setRtcmRoverMessageRateByName("RTCM1074", reportRate);
+            setRtcmRoverMessageRateByName("RTCM1084", reportRate);
+            setRtcmRoverMessageRateByName("RTCM1094", reportRate);
+            setRtcmRoverMessageRateByName("RTCM1124", reportRate);
 
             if (incoming == 12)
             {

--- a/Firmware/RTK_Everywhere/GNSS_UM980.ino
+++ b/Firmware/RTK_Everywhere/GNSS_UM980.ino
@@ -519,7 +519,7 @@ bool GNSS_UM980::enableNMEA()
 
             // If we are using IP based corrections, we need to send local data to the PPL
             // The PPL requires being fed GPGGA/ZDA, and RTCM1019/1020/1042/1046
-            if (pointPerfectIsEnabled())
+            if (pointPerfectServiceUsesKeys())
             {
                 // Mark PPL required messages as enabled if rate > 0
                 if (settings.um980MessageRatesNMEA[messageNumber] > 0)
@@ -533,7 +533,7 @@ bool GNSS_UM980::enableNMEA()
         }
     }
 
-    if (pointPerfectIsEnabled())
+    if (pointPerfectServiceUsesKeys())
     {
         // Force on any messages that are needed for PPL
         if (gpggaEnabled == false)
@@ -599,7 +599,7 @@ bool GNSS_UM980::enableRTCMRover()
 
             // If we are using IP based corrections, we need to send local data to the PPL
             // The PPL requires being fed GPGGA/ZDA, and RTCM1019/1020/1042/1046
-            if (pointPerfectIsEnabled())
+            if (pointPerfectServiceUsesKeys())
             {
                 // Mark PPL required messages as enabled if rate > 0
                 if (settings.um980MessageRatesRTCMRover[messageNumber] > 0)
@@ -617,7 +617,7 @@ bool GNSS_UM980::enableRTCMRover()
         }
     }
 
-    if (pointPerfectIsEnabled())
+    if (pointPerfectServiceUsesKeys())
     {
         // Force on any messages that are needed for PPL
         if (rtcm1019Enabled == false)

--- a/Firmware/RTK_Everywhere/menuMessages.ino
+++ b/Firmware/RTK_Everywhere/menuMessages.ino
@@ -166,7 +166,7 @@ void menuMessagesBaseRTCM()
         systemPrintln();
         systemPrintln("Menu: GNSS Messages - Base RTCM");
 
-        systemPrintln("1) Set RXM Messages for Base Mode");
+        systemPrintln("1) Set RTCM Messages for Base Mode");
 
         systemPrintf("2) Reset to Defaults (%s)\r\n", gnss->getRtcmDefaultString());
         systemPrintf("3) Reset to Low Bandwidth Link (%s)\r\n", gnss->getRtcmLowDataRateString());


### PR DESCRIPTION
This adds a serial and Web Config option to 'Set Defaults to PPP Logging' to the Torch and Postcard platforms. By default, the following sentences are enabled on the LG290P and UM980:

* RTCM1019
* RTCM1020
* RTCM1042
* RTCM1046
* RTCM1074
* RTCM1084
* RTCM1094
* RTCM1124

These messages are enabled at 1/30Hz or once every 30 seconds. This is to minimize the size of the logs and because the major services decimate any submission to every 30 seconds anyway.

The default NMEA messages are enabled at 1Hz so that if a user connects over Bluetooth (likely with the Torch), the device will act normal (if a little slower than the default 2Hz). This is to reduce log size, but also allow the user and the display on the Postcard (the SIV indicator requires GSV which is the biggest data offender), to continue to act normal.

There are two ways to get data off the Torch: either by logging the incoming Bluetooth data, such as in SW Maps 'Log to File':

<img width="186" height="122" alt="image" src="https://github.com/user-attachments/assets/2b5bf0e2-60b7-4d4f-889f-e32b93897321" />

Or by connecting over USB and configuring [GNSS output over USB](https://docs.sparkfun.com/SparkFun_RTK_Everywhere_Firmware/menu_ports/#output-gnss-data-over-usb). 

The Postcard is the same as the Torch, as well as logging directly to microSD assuming the Portability Shield is attached. Theoretically UART2 of the LG290P is also connected to port B of the CH342, so it could be used for logging but only UART1 (connected to the ESP32) of the LG290P is configured, so this would require manual configuration.