### PR TITLE
pcUpdates

### DIFF
--- a/Firmware/RTK_Everywhere/Begin.ino
+++ b/Firmware/RTK_Everywhere/Begin.ino
@@ -1822,7 +1822,7 @@ bool i2cBusInitialization(TwoWire *i2cBus, int sda, int scl, int clockKHz)
     // Determine if any devices are on the bus
     if (deviceFound == false)
     {
-        systemPrintln("No devices found on the I2C bus");
+        systemPrintln("No devices found on this I2C bus");
         return false;
     }
     return true;

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -1310,6 +1310,7 @@ void setup()
     gnssDetectReceiverType(); // If we don't know the receiver from the platform, auto-detect it. Uses settings.
 
     DMW_b("commandIndexFillActual");
+    recordSystemSettings();   // Ensure the possible settings are saved - before we call commandIndexFillActual
     commandIndexFillActual(); // Shrink the commandIndex table now we're certain what GNSS we have
     loadSettings();           // Reload the settings after shrinking commandIndex
     recordSystemSettings();   // Save the reduced settings now we're certain what GNSS we have

--- a/Firmware/RTK_Everywhere/menuMessages.ino
+++ b/Firmware/RTK_Everywhere/menuMessages.ino
@@ -553,10 +553,16 @@ void checkGNSSArrayDefaults()
     if (present.gnss_zedf9p)
     {
         if (settings.dynamicModel == 254)
+        {
+            defaultsApplied = true;
             settings.dynamicModel = DYN_MODEL_PORTABLE;
+        }
 
         if (settings.enableExtCorrRadio == 254)
+        {
+            defaultsApplied = true;
             settings.enableExtCorrRadio = true;
+        }
 
         if (settings.ubxMessageRates[0] == 254)
         {
@@ -593,10 +599,16 @@ void checkGNSSArrayDefaults()
     else if (present.gnss_um980)
     {
         if (settings.dynamicModel == 254)
+        {
+            defaultsApplied = true;
             settings.dynamicModel = UM980_DYN_MODEL_SURVEY;
+        }
 
         if (settings.enableExtCorrRadio == 254)
+        {
+            defaultsApplied = true;
             settings.enableExtCorrRadio = false;
+        }
 
         if (settings.um980Constellations[0] == 254)
         {
@@ -640,10 +652,16 @@ void checkGNSSArrayDefaults()
     else if (present.gnss_mosaicX5)
     {
         if (settings.dynamicModel == 254)
+        {
+            defaultsApplied = true;
             settings.dynamicModel = MOSAIC_DYN_MODEL_QUASISTATIC;
+        }
 
         if (settings.enableExtCorrRadio == 254)
+        {
+            defaultsApplied = true;
             settings.enableExtCorrRadio = true;
+        }
 
         if (settings.mosaicConstellations[0] == 254)
         {
@@ -701,7 +719,10 @@ void checkGNSSArrayDefaults()
     else if (present.gnss_lg290p)
     {
         if (settings.enableExtCorrRadio == 254)
+        {
+            defaultsApplied = true;
             settings.enableExtCorrRadio = false;
+        }
 
         if (settings.lg290pConstellations[0] == 254)
         {

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1318,7 +1318,7 @@ const RTK_Settings_Entry rtkSettingsEntries[] =
     { 1, 1, 0, 1, 1, 1, 1, 1, 1, ALL, _int,      0, & settings.correctionsSourcesLifetime_s, "correctionsSourcesLifetime",  },
     { 1, 1, 1, 1, 1, 1, 1, 1, 1, ALL, tCorrSPri, CORR_NUM, & settings.correctionsSourcesPriority, "correctionsPriority_",  },
     { 0, 0, 0, 1, 1, 1, 1, 1, 1, ALL, _bool,     0, & settings.debugCorrections, "debugCorrections",  },
-    { 1, 1, 0, 1, 1, 1, 0, 1, 1, ALL, _bool,     0, & settings.enableExtCorrRadio, "enableExtCorrRadio",  },
+    { 1, 1, 0, 1, 1, 1, 0, 1, 1, ALL, _uint8_t,  0, & settings.enableExtCorrRadio, "enableExtCorrRadio",  }, // uint8_t needed for 254
     { 1, 1, 0, 1, 1, 0, 0, 1, 0, NON, _uint8_t,  0, & settings.extCorrRadioSPARTNSource, "extCorrRadioSPARTNSource",  },
 
 //                         F
@@ -1588,7 +1588,7 @@ const RTK_Settings_Entry rtkSettingsEntries[] =
     { 0, 0, 0, 1, 1, 1, 1, 1, 1, ALL, _int,      0, & settings.gnssHandlerBufferSize, "gnssHandlerBufferSize",  },
 
     // Rover operation
-    { 1, 1, 0, 1, 1, 1, 1, 1, 1, ALL, _uint8_t,  0, & settings.dynamicModel, "dynamicModel",  },
+    { 1, 1, 0, 1, 1, 1, 1, 1, 0, ALL, _uint8_t,  0, & settings.dynamicModel, "dynamicModel",  },
     { 0, 0, 0, 1, 1, 1, 1, 1, 1, ALL, _bool,     0, & settings.enablePrintRoverAccuracy, "enablePrintRoverAccuracy",  },
     { 1, 1, 0, 1, 1, 1, 1, 1, 1, ALL, _int16_t,  0, & settings.minCNO, "minCNO",  },
     { 1, 1, 0, 1, 1, 1, 1, 1, 1, ALL, _uint8_t,  0, & settings.minElev, "minElev",  },


### PR DESCRIPTION
* Ensure the default for `settings.enableExtCorrRadio` (254) can be saved correctly until `checkGNSSArrayDefaults` is called
* Ensure settings are saved after `settings.enableExtCorrRadio` is initialized
* These issues combined were allowing `enableExtCorrRadio` to be set `true` on Postcard, making Ext Radio the highest correction source - preventing NTRIP corrections