### PR TITLE
Add separate SD for mosaic X5. Add savePossibleSettings

### DIFF
--- a/Firmware/RTK_Everywhere/Begin.ino
+++ b/Firmware/RTK_Everywhere/Begin.ino
@@ -652,6 +652,7 @@ void beginBoard()
         present.invertedFastPowerOff = true;
         present.gnss_to_uart = true;
         present.gnss_to_uart2 = true;
+        present.mosaicMicroSd;
         present.microSdCardDetectLow = true; // Except microSD is connected to mosaic... present.microSd is false
 
         present.minCno = true;

--- a/Firmware/RTK_Everywhere/GNSS.ino
+++ b/Firmware/RTK_Everywhere/GNSS.ino
@@ -198,6 +198,7 @@ void gnssDetectReceiverType()
         present.minCno = true;
         present.minElevation = true;
         present.dynamicModel = true;
+        present.mosaicMicroSd = true;
         // present.needsExternalPpl = true; // Nope. No L-Band support...
 
 #endif // COMPILE_MOSAICX5

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
@@ -2975,7 +2975,7 @@ bool GNSS_MOSAIC::isPresentOnSerial(HardwareSerial *serialPort, const char *comm
 
     if (retries == retryLimit)
     {
-        systemPrintln("Could not communicate with mosaic-X5! Attempting a soft reset...");
+        systemPrintln("Could not communicate with mosaic-X5 at selected baud rate. Attempting a soft reset...");
 
         sendWithResponse(serialPort, "erst,soft,none\n\r", "ResetReceiver");
 
@@ -2991,7 +2991,7 @@ bool GNSS_MOSAIC::isPresentOnSerial(HardwareSerial *serialPort, const char *comm
 
         if (retries == retryLimit)
         {
-            systemPrintln("Could not communicate with mosaic-X5!");
+            systemPrintln("Could not communicate with mosaic-X5 at selected baud rate");
             return(false);
         }
     }

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -1688,7 +1688,7 @@ bool parseLine(char *str)
     // Last catch
     if (knownSetting == false)
     {
-        log_d("Unknown setting %s", settingName);
+        log_d("Unknown / unwanted setting %s", settingName);
     }
 
     return (true);

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -227,8 +227,21 @@ void recordSystemSettingsToFile(File *settingsFile)
     for (int i = 0; i < numRtkSettingsEntries; i++)
     {
         // Do not record this setting if it is not supported by the current platform
-        if (settingAvailableOnPlatform(i) == false)
-            continue;
+        // But oh what a tangled web we weave...
+        // Thanks to Facet Flex, initially we should be saving all possible settings.
+        // Later, once we know what Flex GNSS is present, we save only the available
+        // settings for that platform. Passing usePossibleSettings in as a parameter
+        // would be messy. So, we'll use a global flag which is updated by commandIndexFill
+        if (savePossibleSettings)
+        {
+            if (settingPossibleOnPlatform(i) == false)
+                continue;
+        }
+        else
+        {
+            if (settingAvailableOnPlatform(i) == false)
+                continue;
+        }
 
         switch (rtkSettingsEntries[i].type)
         {

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -1313,9 +1313,7 @@ void setup()
     gnssDetectReceiverType(); // If we don't know the receiver from the platform, auto-detect it. Uses settings.
 
     DMW_b("commandIndexFillActual");
-    recordSystemSettings();   // Ensure the possible settings are saved - before we call commandIndexFillActual
     commandIndexFillActual(); // Shrink the commandIndex table now we're certain what GNSS we have
-    loadSettings();           // Reload the settings after shrinking commandIndex
     recordSystemSettings();   // Save the reduced settings now we're certain what GNSS we have
 
     DMW_b("beginGnssUart");

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -390,6 +390,9 @@ const int sdSizeCheckStackSize = 3000;
 bool sdSizeCheckTaskComplete;
 
 char logFileName[sizeof("SFE_Reference_Station_230101_120101.ubx_plusExtraSpace")] = {0};
+
+bool savePossibleSettings = true; // Save possible vs. available settings. See recordSystemSettingsToFile for details
+
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 // WiFi support
@@ -1589,12 +1592,14 @@ void logUpdate()
     {
         if (logTimeExceeded())
         {
-            systemPrintln("Log file: maximum logging time reached");
+            if (!inMainMenu)
+                systemPrintln("Log file: maximum logging time reached");
             endSD(false, true); // Close down SD.
         }
         else
         {
-            systemPrintln("Log file: log length reached");
+            if (!inMainMenu)
+                systemPrintln("Log file: log length reached");
             endLogging(false, true); //(gotSemaphore, releaseSemaphore) Close file. Reset parser stats.
             beginLogging();          // Create new file based on current RTC.
             setLoggingType();        // Determine if we are standard, PPP, or custom. Changes logging icon accordingly.
@@ -1610,7 +1615,7 @@ void logUpdate()
             {
                 lastFileReport = millis();
 
-                if (settings.enablePrintLogFileStatus)
+                if ((settings.enablePrintLogFileStatus) && (!inMainMenu))
                 {
                     systemPrintf("Log file size: %lld", logFileSize);
 

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -368,6 +368,8 @@ const char *ringBufferSemaphoreHolder = "None";
 // Display used/free space in menu and config page
 uint64_t sdCardSize;
 uint64_t sdFreeSpace;
+uint64_t mosaicSdCardSize;
+uint64_t mosaicSdFreeSpace;
 bool outOfSDSpace;
 const uint32_t sdMinAvailableSpace = 10000000; // Minimum available bytes before SD is marked as out of space
 

--- a/Firmware/RTK_Everywhere/Tasks.ino
+++ b/Firmware/RTK_Everywhere/Tasks.ino
@@ -1600,7 +1600,7 @@ void handleGnssDataTask(void *e)
                                 }
                             }
 
-                            if (PERIODIC_DISPLAY(PD_SD_LOG_WRITE) && (bytesSent > 0))
+                            if (PERIODIC_DISPLAY(PD_SD_LOG_WRITE) && (bytesSent > 0) && (!inMainMenu))
                             {
                                 PERIODIC_CLEAR(PD_SD_LOG_WRITE);
                                 systemPrintf("SD %d bytes written to log file\r\n", bytesToSend);
@@ -1613,7 +1613,7 @@ void handleGnssDataTask(void *e)
                             {
                                 newEventToRecord = false;
 
-                                if (settings.enablePrintLogFileStatus)
+                                if ((settings.enablePrintLogFileStatus) && (!inMainMenu))
                                     systemPrintln("Log file: recording event");
 
                                 // Record trigger count with Time Of Week of rising edge (ms), Millisecond fraction of Time Of Week of
@@ -1651,7 +1651,7 @@ void handleGnssDataTask(void *e)
                                 char ARPData[82]; // Max NMEA sentence length is 82
                                 snprintf(ARPData, sizeof(ARPData), "%.4f,%.4f,%.4f,%.4f", x, y, z, h);
 
-                                if (settings.enablePrintLogFileStatus)
+                                if ((settings.enablePrintLogFileStatus) && (!inMainMenu))
                                     systemPrintf("Log file: recording Antenna Reference Position %s\r\n", ARPData);
 
                                 char nmeaMessage[82]; // Max NMEA sentence length is 82

--- a/Firmware/RTK_Everywhere/menuCommands.ino
+++ b/Firmware/RTK_Everywhere/menuCommands.ino
@@ -3548,6 +3548,8 @@ bool commandIndexFillActual()
 }
 bool commandIndexFill(bool usePossibleSettings)
 {
+    savePossibleSettings = usePossibleSettings; // Update savePossibleSettings
+
     int i;
     const char *iCommandName;
     int j;

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -235,7 +235,7 @@ void menuMain()
         else if (incoming == 4)
             menuPorts();
 #ifdef COMPILE_MOSAICX5
-        else if (incoming == 5 && productVariant == RTK_FACET_MOSAIC)
+        else if (incoming == 5 && present.gnss_mosaicX5)
             menuLogMosaic();
 #endif                                                         // COMPILE_MOSAICX5
         else if (incoming == 5 && productVariant != RTK_TORCH) // Torch does not have logging

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1871,6 +1871,7 @@ struct struct_present
     bool imu_zedf9r = false;
 
     bool microSd = false;
+    bool mosaicMicroSd = false;
     bool microSdCardDetectLow = false; // Card detect low = SD in place
     bool microSdCardDetectHigh = false; // Card detect high = SD in place
     bool microSdCardDetectGpioExpanderHigh = false; // Card detect on GPIO5, high = SD in place

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -658,8 +658,6 @@ struct Settings
     //Once we detect the platform or receiver, no need to re-detect
     //ProductVariant previouslyDetectedPlatform = RTK_UNKNOWN; //Because LFS is started after deviceID, this is mute
     gnssReceiverType_e detectedGnssReceiver = GNSS_RECEIVER_UNKNOWN;
-    bool detectedTilt = false;
-    bool testedTilt = false;
 
     // Antenna
     int16_t antennaHeight_mm = 1800;    // Aka Pole length
@@ -749,6 +747,10 @@ struct Settings
     // HTTP
     bool debugHttpClientData = false;  // Debug the HTTP Client (ZTP) data flow
     bool debugHttpClientState = false; // Debug the HTTP Client state machine
+
+    // IMU
+    bool detectedTilt = false;
+    bool testedTilt = false;
 
     // Log file
     bool alignedLogFiles = false; // If true, align log files as per #630
@@ -1239,8 +1241,6 @@ const RTK_Settings_Entry rtkSettingsEntries[] =
 
     // Detected GNSS Receiver - for Flex. Save / load first so settingAvailableOnPlatform is correct on Flex
     { 0, 0, 0, 0, 0, 0, 0, 0, 0, ALL, tGnssReceiver,     0, & settings.detectedGnssReceiver, "detectedGnssReceiver",  },
-    { 0, 0, 0, 0, 0, 0, 0, 0, 0, ALL, _bool,     0, & settings.detectedTilt, "detectedTilt",  },
-    { 0, 0, 0, 0, 0, 0, 0, 0, 0, ALL, _bool,     0, & settings.testedTilt, "testedTilt",  },
 
     // Common settings which use the same name on multiple Facet Flex platforms
     // We need these - for Facet Flex - because:
@@ -1395,6 +1395,10 @@ const RTK_Settings_Entry rtkSettingsEntries[] =
     // HTTP
     { 0, 0, 0, 1, 1, 1, 1, 1, 1, ALL, _bool,     0, & settings.debugHttpClientData, "debugHttpClientData",  },
     { 0, 0, 0, 1, 1, 1, 1, 1, 1, ALL, _bool,     0, & settings.debugHttpClientState, "debugHttpClientState",  },
+
+    // IMU
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, ALL, _bool,     0, & settings.detectedTilt, "detectedTilt",  },
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, ALL, _bool,     0, & settings.testedTilt, "testedTilt",  },
 
 //                         F
 //                         a


### PR DESCRIPTION
This PR:
* Solves the logging issue I was seeing on Facet Flex mosaic X5
    * The logging would hang silently, randomly
    * I traced it to the SD size and free space reporting: both the X5 and the microSd code were updating the same `sdCardSize` and `sdFreeSpace` globals
    * If the X5 free space got its foot in the door, it appeared that the free space was _increasing_ (it has a larger SD card). So there was no reduction in free space and so logging was assumed to have stopped...
    * The solution is to create separate `mosaicSdCardSize` and `mosaicSdFreeSpace`. The mosaic values can overwrite the microSd values - but only if that's the only SD present
* Further improves the saving of settings on Facet Flex
    * Previously we were _saving_ the reduced (actual) settings, before we knew what GNSS was present
    * These changes ensure the full possible settings are saved initially, then truncated to the reduced actual settings once the GNSS is known