### PR TITLE
Prevent crash in networkUserAdd debug print

### DIFF
--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -2588,7 +2588,12 @@ void networkUserAdd(NETCONSUMER_t consumer, const char *fileName, uint32_t lineN
 
     // Display the user
     if (settings.debugNetworkLayer)
-        systemPrintf("%s adding user %s\r\n", networkInterfaceTable[index].name, networkConsumerTable[consumer]);
+    {
+        if (index < NETWORK_OFFLINE)
+            systemPrintf("%s adding user %s\r\n", networkInterfaceTable[index].name, networkConsumerTable[consumer]);
+        else
+            systemPrintf("NETWORK_ANY adding user %s\r\n", networkConsumerTable[consumer]);
+    }
 
     // Remember this network interface
     networkConsumerIndexLast[consumer] = index;


### PR DESCRIPTION
With `settings.debugNetworkLayer` enabled, going into WiFi web config mode causes a crash:

`networkInterfaceTable[index].name` goes out of bounds; `index` is equal to `NETWORK_OFFLINE`, not less than it

I'm not sure if my fix is what is actually wanted / needed? But at least it prevents the code from going bang...