### PR TITLE
Dockerfile : use arduino-cli nightly-latest

### DIFF
--- a/Firmware/Dockerfile
+++ b/Firmware/Dockerfile
@@ -48,7 +48,8 @@ RUN pip install pyserial
 
 # Setup Arduino CLI
 #RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=/usr/local/bin sh
-RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
+#RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
+RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s nightly-latest
 
 # Start config file
 RUN arduino-cli config init --additional-urls https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json,https://espressif.github.io/arduino-esp32/package_esp32_dev_index.json


### PR DESCRIPTION
This allows arduino-cli to find the latest libraries (e.g. SEMP 1.0.6) when running docker build with "--no-cache-filter deployment".

If I run docker build --no-cache, it works fine and finds SEMP 1.0.6
If I then run docker build --no-cache-filter deployment to re-use the local image, it fails to find SEMP 1.0.6
Using arduino-cli nightly-latest fixes this
