### PR TITLE
Update compile_with_docker.bat

### DIFF
--- a/Firmware/compile_with_docker.bat
+++ b/Firmware/compile_with_docker.bat
@@ -1,3 +1,6 @@
+::Uncomment "docker builder prune -f" below to clear the build cache
+::This will resolve issues with arduino-cli not being able to find the latest libraries
+::docker builder prune -f
 docker build -t rtk_everywhere_firmware --no-cache-filter deployment .
 docker create --name=rtk_everywhere rtk_everywhere_firmware:latest
 docker cp rtk_everywhere:/RTK_Everywhere.ino.bin .


### PR DESCRIPTION
Add comments showing how to clear the build cache
Clearing the cache allows the arduino-cli to use libraries that have been updated since the previous build