### PR TITLE
Move station coordinate file deletion into parseIncomingSettings

### DIFF
--- a/Firmware/RTK_Everywhere/AP-Config/src/main.js
+++ b/Firmware/RTK_Everywhere/AP-Config/src/main.js
@@ -2253,7 +2253,7 @@ function updateECEFList() {
 
     $("#StationCoordinatesECEF option").each(function () {
         var parts = $(this).text().split(' ');
-        var nickname = parts[0].substring(0, 15);
+        var nickname = parts[0].substring(0, 19);
         $(this).text(nickname + ': ' + parts[1] + ' ' + parts[2] + ' ' + parts[3]).text;
     });
 }
@@ -2383,7 +2383,7 @@ function updateGeodeticList() {
 
     $("#StationCoordinatesGeodetic option").each(function () {
         var parts = $(this).text().split(' ');
-        var nickname = parts[0].substring(0, 15);
+        var nickname = parts[0].substring(0, 19);
 
         if (parts.length >= 7) {
             $(this).text(nickname + ': ' + parts[1] + ' ' + parts[2] + ' ' + parts[3]

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -651,6 +651,9 @@ bool parseIncomingSettings()
     char settingName[100] = {'\0'};
     char valueStr[150] = {'\0'}; // stationGeodetic1,ANameThatIsTooLongToBeDisplayed 40.09029479 -105.18505761 1560.089
 
+    bool stationGeodeticSeen = false;
+    bool stationECEFSeen = false;
+
     char *commaPtr = incomingSettings;
     char *headPtr = incomingSettings;
 
@@ -677,6 +680,24 @@ bool parseIncomingSettings()
 
         if (settings.debugWebServer == true)
             systemPrintf("settingName: %s value: %s\r\n", settingName, valueStr);
+
+        // Check for first stationGeodetic
+        if ((strstr(settingName, "stationGeodetic") != nullptr) && (!stationGeodeticSeen))
+        {
+            stationGeodeticSeen = true;
+            removeFile(stationCoordinateGeodeticFileName);
+            if (settings.debugWebServer == true)
+                systemPrintln("Station geodetic coordinate file removed");
+        }
+
+        // Check for first stationECEF
+        if ((strstr(settingName, "stationECEF") != nullptr) && (!stationECEFSeen))
+        {
+            stationECEFSeen = true;
+            removeFile(stationCoordinateECEFFileName);
+            if (settings.debugWebServer == true)
+                systemPrintln("Station ECEF coordinate file removed");
+        }
 
         updateSettingWithValue(false, settingName, valueStr);
 

--- a/Firmware/RTK_Everywhere/menuCommands.ino
+++ b/Firmware/RTK_Everywhere/menuCommands.ino
@@ -1097,13 +1097,7 @@ SettingValueResponse updateSettingWithValue(bool inCommands, const char *setting
     else if (strcmp(settingName, "measurementRateHz") == 0)
     {
         settings.measurementRateMs = 1000 / settingValue; // Convert Hz to ms
-        gnssConfigure(GNSS_CONFIG_FIX_RATE);                  // Request receiver to use new settings
-
-        // This is one of the first settings to be received. If seen, remove the station files.
-        removeFile(stationCoordinateECEFFileName);
-        removeFile(stationCoordinateGeodeticFileName);
-        if (settings.debugWebServer == true)
-            systemPrintln("Station coordinate files removed");
+        gnssConfigure(GNSS_CONFIG_FIX_RATE);              // Request receiver to use new settings
         knownSetting = true;
     }
 


### PR DESCRIPTION
Doing the deletion in ```updateSettingWithValue``` when ```measurementRateHz``` arrives no longer works because the web config only sends the changes, not the full settings