### PR TITLE
For web config on EVK, require NETWORK_ETHERNET not NETWORK_ANY

### DIFF
--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -1155,7 +1155,7 @@ void webServerStart()
 
         // Start the network
         if (networkInterfaceHasInternet(NETWORK_ETHERNET))
-            networkConsumerAdd(NETCONSUMER_WEB_CONFIG, NETWORK_ANY, __FILE__, __LINE__);
+            networkConsumerAdd(NETCONSUMER_WEB_CONFIG, NETWORK_ETHERNET, __FILE__, __LINE__);
         else if ((settings.wifiConfigOverAP == false) || networkInterfaceHasInternet(NETWORK_WIFI_STATION))
             networkConsumerAdd(NETCONSUMER_WEB_CONFIG, NETWORK_ANY, __FILE__, __LINE__);
         else if (settings.wifiConfigOverAP)


### PR DESCRIPTION
I'm still seeing the EVK default to WiFi when selecting web config, even if Ethernet is connected
This change forces NETWORK_ETHERNET - if Ethernet is connected and has Internet