### PR TITLE
Add forceMenuExit

### DIFF
--- a/Firmware/RTK_Everywhere/Bluetooth.ino
+++ b/Firmware/RTK_Everywhere/Bluetooth.ino
@@ -64,7 +64,7 @@ void bluetoothUpdate()
             bluetoothState = BT_CONNECTED;
             // LED is controlled by tickerBluetoothLedUpdate()
 
-            btPrintEchoExit = false; // Reset the exiting of config menus and/or command modes
+            forceMenuExit = false; // Reset the exiting of config menus and/or command modes
 
 #ifdef COMPILE_AUTHENTICATION
             if (sendAccessoryHandshakeOnBtConnect)
@@ -80,7 +80,7 @@ void bluetoothUpdate()
             systemPrintln("BT client disconnected");
 
             btPrintEcho = false;
-            btPrintEchoExit = true; // Force exit all config menus and/or command modes
+            forceMenuExit = true; // Force exit all config menus and/or command modes
             printEndpoint = PRINT_ENDPOINT_SERIAL;
 
             bluetoothState = BT_NOTCONNECTED;

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -873,7 +873,7 @@ int systemTime_minutes;               // Used to test if logging is less than ma
 uint32_t powerPressedStartTime;       // Times how long the user has been holding the power button, used for power down
 bool inMainMenu;                      // Set true when in the serial config menu system.
 bool btPrintEcho;                     // Set true when in the serial config menu system via Bluetooth.
-bool btPrintEchoExit;                 // When true, exit all config menus.
+volatile bool forceMenuExit;          // When true, exit all config menus.
 bool sendAccessoryHandshakeOnBtConnect = false; // Send accessory handshake on BT connect
 
 bool forceDisplayUpdate = true; // Goes true when setup is pressed, causes the display to refresh in real-time

--- a/Firmware/RTK_Everywhere/Tasks.ino
+++ b/Firmware/RTK_Everywhere/Tasks.ino
@@ -2160,6 +2160,7 @@ void buttonCheckTask(void *e)
                         beepOff();
                     }
 
+                    forceMenuExit = true; // Force menu exit to go immediately into web config
                     forceSystemStateUpdate = true; // Immediately go to this new state
                     changeState(STATE_WEB_CONFIG_NOT_STARTED);
                 }
@@ -2179,6 +2180,10 @@ void buttonCheckTask(void *e)
                         beepOff();
                     }
 
+                    // Force menu exit to go immediately into Rover
+                    // (User can open the menu while in web config)
+                    forceMenuExit = true;
+                    
                     forceSystemStateUpdate = true; // Immediately go to this new state
                     changeState(STATE_ROVER_NOT_STARTED);
                 }

--- a/Firmware/RTK_Everywhere/menuCommands.ino
+++ b/Firmware/RTK_Everywhere/menuCommands.ino
@@ -20,10 +20,10 @@ void menuCommands()
     {
         InputResponse response = getUserInputString(cmdBuffer, sizeof(cmdBuffer), false); // Turn off echo
 
-        if (btPrintEchoExit == true)
+        if (forceMenuExit == true) // BT disconnect etc. forces menu exit
         {
-            systemPrintln("BT Connection lost. Exiting command mode...");
-            btPrintEchoExit = false;
+            systemPrintln("Command mode forced exit...");
+            // Don't clear forceMenuExit here. We want to exit the menus completely
             break; // Exit while(1) loop
         }
 
@@ -290,7 +290,7 @@ t_cliResult processCommand(char *cmdBuffer)
                 commandSendExecuteOkResponse(tokens[0], tokens[1]);
                 espnowRequestPair = true; // Start ESP-NOW pairing process
                 // Force exit all config menus and/or command modes to allow OTA state machine to run
-                btPrintEchoExit = true;
+                forceMenuExit = true;
                 return (CLI_EXIT); // Exit the CLI to allow OTA state machine to run
             }
             else if (strcmp(tokens[1], "PAIRSTOP") == 0)
@@ -298,7 +298,7 @@ t_cliResult processCommand(char *cmdBuffer)
                 commandSendExecuteOkResponse(tokens[0], tokens[1]);
                 espnowRequestPair = false; // Stop ESP-NOW pairing process
                 // Force exit all config menus and/or command modes to allow OTA state machine to run
-                btPrintEchoExit = true;
+                forceMenuExit = true;
                 return (CLI_EXIT); // Exit the CLI to allow OTA state machine to run
             }
             else if (strcmp(tokens[1], "REBOOT") == 0)
@@ -320,7 +320,7 @@ t_cliResult processCommand(char *cmdBuffer)
                 otaRequestFirmwareUpdate = true;
 
                 // Force exit all config menus and/or command modes to allow OTA state machine to run
-                btPrintEchoExit = true;
+                forceMenuExit = true;
                 return (CLI_EXIT); // Exit the CLI to allow OTA state machine to run
             }
             else
@@ -2411,7 +2411,7 @@ SettingValueResponse getSettingValue(bool inCommands, const char *settingName, c
         otaRequestFirmwareVersionCheck = true;
 
         // Force exit all config menus and/or command modes to allow OTA state machine to run
-        btPrintEchoExit = true;
+        forceMenuExit = true;
     }
 
     // Special actions

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -12,9 +12,9 @@ void menuMain()
 
     inMainMenu = true;
 
-    // Clear btPrintEchoExit on entering the menu, to prevent dropping straight
+    // Clear forceMenuExit on entering the menu, to prevent dropping straight
     // through if the BT connection was dropped while we had the menu closed
-    btPrintEchoExit = false;
+    forceMenuExit = false;
 
     displaySerialConfig(); // Display 'Serial Config' while user is configuring
 
@@ -182,8 +182,8 @@ void menuMain()
 
     recordSystemSettings(); // Once all menus have exited, record the new settings to LittleFS and config file
 
-    clearBuffer();           // Empty buffer of any newline chars
-    btPrintEchoExit = false; // We are out of the menu system
+    clearBuffer();         // Empty buffer of any newline chars
+    forceMenuExit = false; // We are out of the menu system
     inMainMenu = false;
 
     // Change the USB serial output behavior if necessary

--- a/Firmware/RTK_Everywhere/support.ino
+++ b/Firmware/RTK_Everywhere/support.ino
@@ -328,7 +328,11 @@ InputResponse getUserInputString(char *userString, uint16_t stringSize, bool loc
 
         //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
-        if (btPrintEchoExit) // User has disconnected from BT. Force exit all menus.
+        // User has disconnected from BT
+        // Or user has selected web config on Torch
+        // Or CLI_EXIT in progress
+        // Force exit all menus.
+        if (forceMenuExit)
             return INPUT_RESPONSE_TIMEOUT;
 
         // Get the next input character


### PR DESCRIPTION
Rename ```btPrintEchoExit``` to ```forceMenuExit```
Don't clear ```forceMenuExit``` in ```menuCommands```. We want to completely exit the menus.
Torch double-tap sets ```forceMenuExit``` ```true```. Firmware immediately exits menu and goes into web config mode.