### PR TITLE
Fix lg290pNewSettingValue when setting lg290pConstellations

### DIFF
--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -3019,7 +3019,7 @@ bool lg290pNewSettingValue(RTK_Settings_Types type,
                     (strcmp(suffix, lg290pConstellationNames[x]) == 0))
                 {
                     settings.lg290pConstellations[x] = d;
-                    break;
+                    return true;
                 }
             }
             break;


### PR DESCRIPTION
Should resolve #852 . The root issue in #852 is that the LG290P constellations settings were not being updated correctly when the profile was read from storage. This left ```settings.lg290pConstellations[0] == 254``` which in turn caused ```settings.enableGalileoHas``` to be re-initialized to ```false```.