### PR TITLE
Update web config BT options - include accessory mode

### DIFF
--- a/Firmware/RTK_Everywhere/AP-Config/index.html
+++ b/Firmware/RTK_Everywhere/AP-Config/index.html
@@ -2212,7 +2212,8 @@
                         <option value="0">SPP</option>
                         <option value="1">BLE</option>
                         <option value="2">SPP & BLE</option>
-                        <option value="3">Off</option>
+                        <option value="3">Accessory Mode</option>
+                        <option value="4">Off</option>
                     </select>
                     <span class="tt" data-bs-placement="right"
                         title="Communicate using Classic Bluetooth Serial Port Profile (SPP), Bluetooth Low-Energy (BLE), or turn Bluetooth off. Default: SPP & BLE.">


### PR DESCRIPTION
I _think_ we're stuck with Accessory Mode - for now at least.

This PR corrects the BT options in web config, adding "Accessory Mode" and bumping "Off".