### PR TITLE
Fix cellular (PPP) UART

### DIFF
--- a/Firmware/RTK_Everywhere/Cellular.ino
+++ b/Firmware/RTK_Everywhere/Cellular.ino
@@ -184,8 +184,8 @@ void cellularStart(NetIndex_t index, uintptr_t parameter, bool debug)
 
     displayMessage("Cellular Start", 500);
 
-    // Starting the cellular modem
-    CELLULAR.begin(CELLULAR_MODEM_MODEL);
+    // Starting the cellular modem - using UART2 and 115200 baud. (The GNSS is using UART1...)
+    CELLULAR.begin(CELLULAR_MODEM_MODEL, 2, 115200);
 
     // Specify the timer expiration date - for the SIM check delay
     laraTimer = millis() + parameter;


### PR DESCRIPTION
In [this commit](https://github.com/sparkfun/SparkFun_RTK_Everywhere_Firmware/pull/930/changes/92f668afb59dd9e9e3ac1151b328ae18d26d2fff) I swapped around the HardwareSerial UART numbering. I hadn't spotted that ```CELLULAR.begin``` (PPP) defaults to using UART1... This PR nudges it onto UART2.