### PR TITLE
Add Soft_AP_Channels test program

### DIFF
--- a/Firmware/Test Sketches/Soft_AP_Channels/Soft_AP_Channels.ino
+++ b/Firmware/Test Sketches/Soft_AP_Channels/Soft_AP_Channels.ino
@@ -1,0 +1,397 @@
+/*
+Soft_AP_Channels.ino
+
+Sketch to verify channel switching during Soft AP operation
+*/
+
+#include <esp_wifi.h>
+#include <Network.h>
+#include <WiFi.h>
+
+#define CHANNEL_CHANGE_MSEC     (10 * 1000)
+
+IPAddress apDhcpFirstAddress = IPAddress("0.0.0.0");
+IPAddress apDnsAddress = IPAddress("0.0.0.0");
+IPAddress apGatewayAddress = IPAddress("0.0.0.0");
+IPAddress apIpAddress = IPAddress("192.168.100.1");
+byte apMacAddress[6];
+const char * apPassword = "Password";   // WiFi network password
+const char * apSsid = "Test";           // WiFi network name
+IPAddress apSubnetMask = IPAddress("255.255.255.0");
+bool apUserConnected;
+const char * hostName = "test-AP";
+uint32_t lastChannelChangeMsec;
+volatile bool staConnected;
+bool waitForScanComplete;
+volatile bool wifiScanDone;
+int wifiChannel;
+
+bool RTK_CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC = false;
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+void setup()
+{
+    char data;
+    int length;
+
+    // Initialize serial and wait for port to open:
+    Serial.begin(115200);
+    while (!Serial);  // Wait for native USB serial port to connect
+    Serial.println();
+    Serial.println(__FILE__);
+
+    // Read the WiFi network name (SSID)
+/*
+    length = 0;
+    do
+    {
+        Serial.println("Please enter the WiFi network name (SSID):");
+        do
+        {
+            while (!Serial.available());
+            data = Serial.read();
+            if ((data == '\n') || (data == '\r'))
+                break;
+            apSsid[length++] = data;
+        } while (1);
+        apSsid[length] = 0;
+    } while (!length);
+    Serial.printf("AP SSID: %s\n", apSsid);
+    Serial.println();
+
+    // Read the WiFi network password
+    length = 0;
+    do
+    {
+        Serial.println("Please enter the WiFi network password:");
+        do
+        {
+            while (!Serial.available());
+            data = Serial.read();
+            if ((data == '\n') || (data == '\r'))
+                break;
+            apPassword[length++] = data;
+        } while (1);
+        apPassword[length] = 0;
+    } while (!length);
+    Serial.printf("Password: %s\n", apPassword);
+    Serial.println();
+*/
+
+    // Start the WiFi soft AP
+    do
+    {
+        // Start WiFi in the soft AP mode
+        if (WiFi.mode((wifi_mode_t)WIFI_MODE_APSTA) == false)
+            reportFatalError("Failed to set WiFi AP mode!");
+
+        // Start the soft AP protocol
+        if (esp_wifi_set_protocol(WIFI_IF_AP,
+                                  WIFI_PROTOCOL_11B
+                                  | WIFI_PROTOCOL_11G
+                                  | WIFI_PROTOCOL_11N) != ESP_OK)
+            reportFatalError("Failed to set the Soft AP protocol!");
+
+        // Start the WiFi Station protocol
+        if (esp_wifi_set_protocol(WIFI_IF_STA,
+                                  WIFI_PROTOCOL_11B
+                                  | WIFI_PROTOCOL_11G
+                                  | WIFI_PROTOCOL_11N) != ESP_OK)
+            reportFatalError("Failed to set the Station protocol!");
+
+        // Set the soft AP subnet mask, IP, gateway, DNS, and first DHCP addresses
+        if (WiFi.AP.config(IPAddress(apIpAddress),
+                           IPAddress(apGatewayAddress),
+                           IPAddress(apSubnetMask),
+                           IPAddress(apDhcpFirstAddress),
+                           IPAddress(apDnsAddress)) == false)
+        {
+            reportFatalError("Failed to set the Soft AP IP address!");
+        }
+
+        // Set the soft AP SSID and password
+        wifiChannel = 1;
+        if (WiFi.AP.create(apSsid, apPassword, wifiChannel) == false)
+            reportFatalError("Failed to set the Soft AP SSID and password!");
+        Serial.printf("Soft AP using channel %d\r\n", wifiChannel);
+
+        // Get the soft AP MAC address
+        WiFi.AP.macAddress(apMacAddress);
+
+        // Display the host name
+        Serial.printf("Host name: %s\r\n", hostName);
+
+        // Set the soft AP host name
+        if (WiFi.AP.setHostname(hostName) == false)
+            reportFatalError("Failed to set the Soft AP host name!");
+    } while (0);
+
+    // Handle the network events
+    Network.onEvent(networkEvent);
+}
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+void loop()
+{
+    uint32_t currentMsec;
+    static uint32_t lastChannelChangeMsec;
+    int nextWifiChannel;
+
+    // Wait for the WiFi scan to complete
+    if (wifiScanDone)
+    {
+        waitForScanComplete = false;
+
+        // Stop use of WiFi
+        if (WiFi.mode((wifi_mode_t)WIFI_MODE_AP) == false)
+            reportFatalError("Failed to stop WiFi STA mode!");
+    }
+
+    if (waitForScanComplete)
+        return;
+
+    // Attempt to change the channel
+    currentMsec = millis();
+    if ((currentMsec - lastChannelChangeMsec) >= CHANNEL_CHANGE_MSEC)
+    {
+        lastChannelChangeMsec = currentMsec;
+        nextWifiChannel = 0;
+        switch(wifiChannel)
+        {
+        case 0:
+            nextWifiChannel = 1;
+            break;
+
+        case 1:
+            nextWifiChannel = 6;
+            break;
+
+        case 4:
+            nextWifiChannel = 6;
+            break;
+
+        case 6:
+            nextWifiChannel = 11;
+            break;
+
+        case 11:
+            nextWifiChannel = 1;
+
+            // Attempt to scan WiFi for access points
+            if (esp_wifi_scan_start(nullptr, false) != ESP_OK)
+                Serial.printf("Failed to start WiFi scan!\r\n");
+            else
+            {
+                Serial.printf("Started WiFi scan\r\n");
+                waitForScanComplete = true;
+            }
+            break;
+        }
+
+        // Attempt to set the next WiFi channel
+        if (esp_wifi_set_channel(wifiChannel, WIFI_SECOND_CHAN_NONE) != ESP_OK)
+        {
+            if (wifiChannel == 0)
+                Serial.printf("ERROR: Failed to set the WiFi channel %d\r\n",
+                               nextWifiChannel);
+            else
+                Serial.printf("ERROR: Failed to set the WiFi channel %d, stuck on channel %d\r\n",
+                              nextWifiChannel, wifiChannel);
+            if (waitForScanComplete || staConnected)
+                Serial.printf("Documented restriction in esp_wifi_set_channel Attention 2\r\n");
+            if (apUserConnected)
+                Serial.printf("Documented restriction in esp_wifi_set_channel Attention 3\r\n");
+        }
+        else
+        {
+            if (wifiChannel == 0)
+                Serial.printf("Soft AP switching from unknown channel to channel %d\r\n",
+                               nextWifiChannel);
+            else
+                Serial.printf("Soft AP switching from channel %d to channel %d\r\n",
+                               wifiChannel, nextWifiChannel);
+            wifiChannel = nextWifiChannel;
+        }
+    }
+
+    // Restart WiFi station
+    if (wifiScanDone)
+    {
+        wifiScanDone = false;
+
+        // Restart WiFi station
+        if (WiFi.mode((wifi_mode_t)WIFI_MODE_APSTA) == false)
+            reportFatalError("Failed to restart WiFi STA mode!");
+
+        // Start the WiFi Station protocol
+        if (esp_wifi_set_protocol(WIFI_IF_STA,
+                                  WIFI_PROTOCOL_11B
+                                  | WIFI_PROTOCOL_11G
+                                  | WIFI_PROTOCOL_11N) != ESP_OK)
+            reportFatalError("Failed to set the Station protocol!");
+
+        // Set the soft AP SSID and password
+        if (WiFi.AP.create(apSsid, apPassword, nextWifiChannel) == false)
+            reportFatalError("Failed to set the Soft AP SSID and password!");
+        else
+        {
+            wifiChannel = nextWifiChannel;
+            Serial.printf("Soft AP using channel %d\r\n", wifiChannel);
+        }
+    }
+}
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+// Process network events
+void networkEvent(arduino_event_id_t event, arduino_event_info_t info)
+{
+    int index;
+
+    Serial.printf("event: %d (%s)\r\n", event, Network.eventName(event));
+
+    // Process the event
+    switch (event)
+    {
+    // WiFi
+    case ARDUINO_EVENT_WIFI_OFF:
+        break;
+
+    case ARDUINO_EVENT_WIFI_READY:
+        break;
+
+    case ARDUINO_EVENT_WIFI_SCAN_DONE:
+        wifiScanDone = true;
+        break;
+
+    case ARDUINO_EVENT_WIFI_STA_START:
+        break;
+
+    case ARDUINO_EVENT_WIFI_STA_STOP:
+        break;
+
+    case ARDUINO_EVENT_WIFI_STA_CONNECTED:
+        staConnected = true;
+        break;
+
+    case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
+        staConnected = false;
+        break;
+
+    case ARDUINO_EVENT_WIFI_STA_AUTHMODE_CHANGE:
+        break;
+
+    case ARDUINO_EVENT_WIFI_STA_GOT_IP:
+        break;
+
+    case ARDUINO_EVENT_WIFI_STA_GOT_IP6:
+        break;
+
+    case ARDUINO_EVENT_WIFI_STA_LOST_IP:
+        break;
+
+    case ARDUINO_EVENT_WIFI_AP_START:
+        break;
+
+    case ARDUINO_EVENT_WIFI_AP_STOP:
+        break;
+
+    case ARDUINO_EVENT_WIFI_AP_STACONNECTED:
+        apUserConnected = true;
+        break;
+
+    case ARDUINO_EVENT_WIFI_AP_STADISCONNECTED:
+        apUserConnected = false;
+        break;
+
+    case ARDUINO_EVENT_WIFI_AP_STAIPASSIGNED:
+        break;
+
+    case ARDUINO_EVENT_WIFI_AP_PROBEREQRECVED:
+        break;
+
+    case ARDUINO_EVENT_WIFI_AP_GOT_IP6:
+        break;
+    }
+}
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+void displayIpAddress(IPAddress ip) {
+
+  // Display the IP address
+  Serial.println(ip.toString().c_str());
+}
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+void displayWiFiIpAddress() {
+
+  // Display the IP address
+  Serial.print ("IP Address: ");
+  IPAddress ip = WiFi.localIP();
+  displayIpAddress(ip);
+}
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+void displayWiFiMacAddress() {
+  // Display the MAC address
+  byte mac[6];
+  WiFi.macAddress(mac);
+  Serial.print("MAC address: ");
+  Serial.print(mac[5], HEX);
+  Serial.print(":");
+  Serial.print(mac[4], HEX);
+  Serial.print(":");
+  Serial.print(mac[3], HEX);
+  Serial.print(":");
+  Serial.print(mac[2], HEX);
+  Serial.print(":");
+  Serial.print(mac[1], HEX);
+  Serial.print(":");
+  Serial.println(mac[0], HEX);
+}
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+void displayWiFiNetwork() {
+
+  // Display the SSID
+  Serial.print("SSID: ");
+  Serial.println(WiFi.SSID());
+
+  // Display the receive signal strength
+  long rssi = WiFi.RSSI();
+  Serial.print("Signal strength (RSSI):");
+  Serial.println(rssi);
+}
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+void displayWiFiSubnetMask() {
+
+  // Display the subnet mask
+  Serial.print ("Subnet Mask: ");
+  IPAddress ip = WiFi.subnetMask();
+  displayIpAddress(ip);
+}
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+// Print the error message every 15 seconds
+void reportFatalError(const char *errorMsg)
+{
+    // Empty the FIFO of any incoming data
+    while (Serial.available())
+        Serial.read();
+    while (1)
+    {
+        // Allow carriage return to reset the system
+        if (Serial.available() && (Serial.read() == '\r'))
+        {
+            Serial.println("System reset");
+            Serial.flush();
+            ESP.restart();
+        }
+
+        // Periodically display the halted message
+        Serial.print("HALTED: ");
+        Serial.print(errorMsg);
+        Serial.println();
+        sleep(15);
+    }
+}

--- a/Firmware/Test Sketches/Soft_AP_Channels/makefile
+++ b/Firmware/Test Sketches/Soft_AP_Channels/makefile
@@ -1,0 +1,306 @@
+######################################################################
+# makefile
+#
+# Builds the EVK firmware
+######################################################################
+
+##########
+# Source files
+##########
+
+SKETCH=Soft_AP_Channels
+ESP_CORE_VERSION=3.0.7
+ESP_IDF_VERSION=idf-release_v5.1-632e0c2a
+
+# Uncomment all five lines for a complete update
+#EXECUTABLES = arduino-config lib-update
+EXECUTABLES += RTK
+
+PARTITION_CSV_FILE=RTKEverywhere
+
+ifeq ($(OS),Windows_NT)
+# Windows NT utilities
+CLEAR=cls
+COPY=copy
+DELETE=del /s
+DIR_LISTING=dir
+ENABLE_EXECUTION=
+TERMINAL_APP=
+TERMINAL_PORT=
+TERMINAL_PORT_LG209P=
+TERMINAL_PORT_TORCH=
+TERMINAL_PARAMS=
+
+# Windows NT generic paths
+USER_DIRECTORY_PATH=C:\Users\$(USERNAME)\
+TMP_PATH=$(USER_DIRECTORY_PATH)
+ARDUINO_LIBRARY_PATH=$(USER_DIRECTORY_PATH)Documents\Arduino\libraries
+HOME_BOARD_PATH=$(USER_DIRECTORY_PATH)AppData\Local\Arduino15\packages\esp32
+PATCH_SRC_PATH=Patch\
+
+# Windows NT patch source paths
+FIRMWARE_PATH=..\
+RTK_EVERYWHERE_PATH=.\
+AP_CONFIG_PATH=$(RTK_EVERYWHERE_PATH)AP-Config
+PARTITION_SRC_PATH=$(FIRMWARE_PATH)$(PARTITION_CSV_FILE).csv
+PATCH_SRC_PATH=$(RTK_EVERYWHERE_PATH)Patch\
+
+# Windows NT patch destination paths
+MBED_LIB_DEST_PATH=$(HOME_BOARD_PATH)\tools\esp32-arduino-libs\${{ env.ESP_IDF }}\esp32/lib\
+NET_EVENT_PATCH_PATH=$(HOME_BOARD_PATH)\hardware\esp32\$(ESP_CORE_VERSION)\libraries\Network\src\
+PARTITION_DST_PATH=$(HOME_BOARD_PATH)\hardware\esp32\$(ESP_CORE_VERSION)\tools\partitions\$(PARTITION_CSV_FILE).csv
+
+# Windows Sketch path
+BUILD_PATH=build\esp32.esp32.esp32\
+RTK_BIN_PATH=$(BUILD_PATH)$(SKETCH).ino.bin
+
+# Windows upload support
+BOOT_LOADER_PATH=$(USER_DIRECTORY_PATH)SparkFun\SparkFun_RTK_Firmware_Uploader\RTK_Firmware_Uploader\resource\
+ESPTOOL_PATH=$(USER_DIRECTORY_PATH)Arduino\hardware\espressif\esp32\tools\esptool\
+
+else
+# Linux utilities
+CLEAR=clear
+COPY=cp
+DELETE=rm -Rf
+DIR_LISTING=ls
+ENABLE_EXECUTION=chmod +x
+TERMINAL_APP=minicom
+TERMINAL_PORT=/dev/ttyUSB0
+TERMINAL_PORT_LG290P=/dev/ttyACM0
+TERMINAL_PORT_TORCH=/dev/ttyACM1
+TERMINAL_PARAMS=-b 115200 -8 < /dev/tty
+
+# Linux generic paths
+USER_DIRECTORY_PATH=~/
+TMP_PATH=/tmp/
+ARDUINO_LIBRARY_PATH=$(USER_DIRECTORY_PATH)Arduino/libraries
+ESP_IDF_PATH=$(HOME_BOARD_PATH)/tools/esp32-arduino-libs
+HOME_BOARD_PATH=$(USER_DIRECTORY_PATH).arduino15/packages/esp32
+
+# Linux patch source paths
+FIRMWARE_PATH=../../
+RTK_EVERYWHERE_PATH=./
+AP_CONFIG_PATH=$(RTK_EVERYWHERE_PATH)AP-Config
+PARTITION_SRC_PATH=$(FIRMWARE_PATH)$(PARTITION_CSV_FILE).csv
+PATCH_SRC_PATH=$(RTK_EVERYWHERE_PATH)Patch/
+
+# Linux patch destination paths
+BT_LIB_DEST_PATH=$(ESP_IDF_PATH)/$(ESP_IDF_VERSION)/esp32/lib/
+MBED_LIB_DEST_PATH=$(ESP_IDF_PATH)/$(ESP_IDF_VERSION)/esp32/lib/
+NET_EVENT_PATCH_PATH=$(HOME_BOARD_PATH)/hardware/esp32/$(ESP_CORE_VERSION)/libraries/Network/src/
+PARTITION_DST_PATH=$(HOME_BOARD_PATH)/hardware/esp32/$(ESP_CORE_VERSION)/tools/partitions/$(PARTITION_CSV_FILE).csv
+
+# Linux Sketch path
+BUILD_PATH=build/esp32.esp32.esp32/
+RTK_BIN_PATH=$(BUILD_PATH)$(SKETCH).ino.bin
+
+# Linux upload support
+BOOT_LOADER_PATH=~/SparkFun/SparkFun_RTK_Firmware_Uploader/RTK_Firmware_Uploader/resource/
+ESPTOOL_PATH=~/Arduino/hardware/espressif/esp32/tools/esptool/
+
+endif
+
+##########
+# Buid tools and rules
+##########
+
+##########
+# Buid all the sources - must be first
+##########
+
+.PHONY: all
+
+all: $(EXECUTABLES)
+
+##########
+# Buid RTK firmware
+##########
+
+.PHONY: arduino-config
+
+arduino-config:
+	arduino-cli config init --overwrite --additional-urls "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json,https://espressif.github.io/arduino-esp32/package_esp32_dev_index.json"
+
+.PHONY: index-update
+
+index-update:
+	fgrep "update-index" $(FIRMWARE_PATH)Dockerfile > $(TMP_PATH)arduino_core_update.sh
+	sed -i 's|RUN arduino-cli|arduino-cli|' $(TMP_PATH)arduino_core_update.sh
+	$(ENABLE_EXECUTION) $(TMP_PATH)arduino_core_update.sh
+	$(TMP_PATH)arduino_core_update.sh
+	rm $(TMP_PATH)arduino_core_update.sh
+
+.PHONY: core-install
+
+core-install:	index-update
+	$(DELETE) $(HOME_BOARD_PATH)
+	arduino-cli core install "esp32:esp32@${ESP_CORE_VERSION}"
+
+.PHONY: lib-install
+
+lib-install:	index-update
+	fgrep "lib install" $(FIRMWARE_PATH)Dockerfile > $(TMP_PATH)arduino_library_update.sh
+	sed -i 's|RUN arduino-cli|arduino-cli|' $(TMP_PATH)arduino_library_update.sh
+	$(ENABLE_EXECUTION) $(TMP_PATH)arduino_library_update.sh
+	$(TMP_PATH)arduino_library_update.sh
+	rm $(TMP_PATH)arduino_library_update.sh
+
+.PHONY: get-idf-version
+
+get-idf-version:
+	ESP_IDF_VERSION=$(ls ~/.arduino15/packages/esp32/tools/esp32-arduino-libs | grep idf-release)
+	echo "ESP IDF Version: ${ESP_IDF_VERSION}"
+
+$(PARTITION_DST_PATH):	$(PARTITION_SRC_PATH)
+	$(COPY)  $(PARTITION_SRC_PATH)  $(PARTITION_DST_PATH)
+
+.PHONY: partition
+
+partition:	$(PARTITION_DST_PATH)
+
+$(MBED_LIB_DEST_PATH)libmbedtls.a: 	$(PATCH_SRC_PATH)libmbedtls.a  $(ESP_IDF_PATH)
+	$(DIR_LISTING) $(ESP_IDF_PATH)
+	echo "ESP IDF Version: $(ESP_IDF_VERSION)"
+	$(COPY)  $<  $@
+
+$(MBED_LIB_DEST_PATH)libmbedtls_2.a: 	$(PATCH_SRC_PATH)libmbedtls_2.a
+	$(COPY)  $<  $@
+
+$(MBED_LIB_DEST_PATH)libmbedcrypto.a: 	$(PATCH_SRC_PATH)libmbedcrypto.a
+	$(COPY)  $<  $@
+
+$(MBED_LIB_DEST_PATH)libmbedx509.a: 	$(PATCH_SRC_PATH)libmbedx509.a
+	$(COPY)  $<  $@
+
+$(BT_LIB_DEST_PATH)libbt.a: 	$(PATCH_SRC_PATH)libbt.a
+	$(COPY)  $<  $@
+
+.PHONY: patch
+
+patch:
+	touch   $(PATCH_SRC_PATH)libmbedtls.a
+	touch   $(PATCH_SRC_PATH)libmbedtls_2.a
+	touch   $(PATCH_SRC_PATH)libmbedcrypto.a
+	touch   $(PATCH_SRC_PATH)libmbedx509.a
+	touch   $(PATCH_SRC_PATH)libbt.a
+	make  $(MBED_LIB_DEST_PATH)libmbedtls.a
+	make  $(MBED_LIB_DEST_PATH)libmbedtls_2.a
+	make  $(MBED_LIB_DEST_PATH)libmbedcrypto.a
+	make  $(MBED_LIB_DEST_PATH)libmbedx509.a
+	make  $(BT_LIB_DEST_PATH)libbt.a
+
+DEBUG_LEVEL=none
+#DEBUG_LEVEL=error
+#DEBUG_LEVEL=warn
+#DEBUG_LEVEL=info
+#DEBUG_LEVEL=debug
+#DEBUG_LEVEL=verbose
+
+ENABLE_DEVELOPER=false
+FIRMWARE_VERSION_MAJOR=99
+FIRMWARE_VERSION_MINOR=99
+POINTPERFECT_TOKEN=
+
+form.h:	$(AP_CONFIG_PATH)/* $(AP_CONFIG_PATH)/src/* $(AP_CONFIG_PATH)/src/fonts/*
+	python ../Tools/index_html_zipper.py $(AP_CONFIG_PATH)/index.html form.h
+	python ../Tools/main_js_zipper.py $(AP_CONFIG_PATH)/src/main.js form.h
+
+$(RTK_BIN_PATH):	$(SKETCH).ino   *.ino   makefile   $(PARTITION_DST_PATH)
+	$(CLEAR)
+	arduino-cli compile --fqbn "esp32:esp32:esp32":DebugLevel=$(DEBUG_LEVEL),PSRAM=enabled $< \
+		--warnings default \
+		--build-property build.partitions=$(PARTITION_CSV_FILE) \
+		--build-property upload.maximum_size=6291456 \
+		--build-property "compiler.cpp.extra_flags=-MMD -c \"-DPOINTPERFECT_TOKEN=$(POINTPERFECT_TOKEN)\" \"-DFIRMWARE_VERSION_MAJOR=$(FIRMWARE_VERSION_MAJOR)\" \"-DFIRMWARE_VERSION_MINOR=$(FIRMWARE_VERSION_MINOR)\" \"-DENABLE_DEVELOPER=$(ENABLE_DEVELOPER)\"" \
+		--export-binaries
+
+RTK:	$(RTK_BIN_PATH)
+
+##########
+# Upload the firmware
+##########
+
+.PHONY: upload
+
+upload:	$(RTK_BIN_PATH)
+	python3 $(ESPTOOL_PATH)esptool.py \
+        --chip   esp32 \
+        --port   $(TERMINAL_PORT) \
+        --baud   921600 \
+        --before   default_reset \
+        --after   hard_reset \
+        write_flash \
+        --flash_mode dio \
+        --flash_freq 80m \
+        --flash_size detect \
+        --compress \
+         0x1000   $(BOOT_LOADER_PATH)RTK_Surveyor.ino.bootloader.bin \
+         0x8000   $(BOOT_LOADER_PATH)RTK_Surveyor_Partitions_16MB.bin \
+         0xe000   $(BOOT_LOADER_PATH)boot_app0.bin \
+        0x10000   $<
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT)   $(TERMINAL_PARAMS)
+
+.PHONY: upload_lg290p
+
+upload_lg290p:	$(RTK_BIN_PATH)
+	python3 $(ESPTOOL_PATH)esptool.py \
+        --chip   esp32 \
+        --port   $(TERMINAL_PORT_LG290P) \
+        --baud   460800 \
+        --before   default_reset \
+        --after   hard_reset \
+        write_flash \
+        --flash_mode dio \
+        --flash_freq 80m \
+        --flash_size detect \
+        --compress \
+         0x1000   $(BOOT_LOADER_PATH)RTK_Surveyor.ino.bootloader.bin \
+         0x8000   $(BOOT_LOADER_PATH)RTK_Everywhere_Partitions_8MB.bin \
+         0xe000   $(BOOT_LOADER_PATH)boot_app0.bin \
+        0x10000   $<
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT_LG290P)   $(TERMINAL_PARAMS)
+
+.PHONY: upload_torch
+
+upload_torch:	$(RTK_BIN_PATH)
+	python3 $(ESPTOOL_PATH)esptool.py \
+        --chip   esp32 \
+        --port   $(TERMINAL_PORT_TORCH) \
+        --baud   460800 \
+        --before   default_reset \
+        --after   hard_reset \
+        write_flash \
+        --flash_mode dio \
+        --flash_freq 80m \
+        --flash_size detect \
+        --compress \
+         0x1000   $(BOOT_LOADER_PATH)RTK_Surveyor.ino.bootloader.bin \
+         0x8000   $(BOOT_LOADER_PATH)RTK_Surveyor_Partitions_16MB.bin \
+         0xe000   $(BOOT_LOADER_PATH)boot_app0.bin \
+        0x10000   $<
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT_TORCH)   $(TERMINAL_PARAMS)
+
+.PHONY:	terminal
+
+terminal:
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT)   $(TERMINAL_PARAMS)
+
+.PHONY:	terminal_lg290p
+
+terminal_lg290p:
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT_LG290P)   $(TERMINAL_PARAMS)
+
+.PHONY:	terminal_torch
+
+terminal_torch:
+	$(TERMINAL_APP)   -D $(TERMINAL_PORT_TORCH)   $(TERMINAL_PARAMS)
+
+########
+# Clean the build directory
+##########
+
+.PHONY: clean
+
+clean:
+	$(DELETE) build


### PR DESCRIPTION
Verify channel switch restrictions and soft AP setup requirements.
* No manual channel switching during WiFi scans
* No channel switching while WiFi station is connected
* No channel switching while user connected to Soft AP
* Soft AP needs to be restarted after WiFi scan

This implies that after WiFi SSID and password are set in WiFi config mode, the connection to the RTK will be disconnected and the user will need to reconnect to the RTK after the RTK connects to the access point or fails.  See  <b>esp_wifi_set_channel</b> retrictions in the [Espressif documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/network/esp_wifi.html).