### PR TITLE
Print Base Caster mode correctly

### DIFF
--- a/Firmware/RTK_Everywhere/States.ino
+++ b/Firmware/RTK_Everywhere/States.ino
@@ -828,7 +828,7 @@ const char *stateToRtkMode(SystemState state)
 
     static char modeName[20];
 
-    strncpy(modeName, "Unknown Mode", sizeof(modeName) - 1); // Always reset to unknown
+    strncpy(modeName, "Unknown Mode", sizeof(modeName) - 1); // Reset to unknown at each function call
 
     // Walk the RTK mode table
     for (int index = 0; index < stateModeTableEntries; index++)


### PR DESCRIPTION
@PaulZC - I don't like this fix, but I don't have a better one. We can't test if we are in Base Caster state because the state is 'Base' 99% of the time. Have you got a better idea? Or is it 'good enough'?