### PR TITLE
In Facet FP gnssFirmwareDirectConnectHardware(), hit R to reset the GNSS if needed

### DIFF
--- a/Firmware/RTK_Everywhere/GNSS.ino
+++ b/Firmware/RTK_Everywhere/GNSS.ino
@@ -899,8 +899,12 @@ void gnssFirmwareDirectConnectSoftware()
 }
 
 //----------------------------------------
-void gnssFirmwareDirectConnectHardware() // Facet FP
+void gnssFirmwareDirectConnectHardware() // Facet FP only
 {
+    uint32_t platformGnssCommunicationRate =
+        settings.dataPortBaud;
+    forceGnssCommunicationRate(platformGnssCommunicationRate);
+
     systemPrintln();
     systemPrintln("Entering GNSS direct connect for firmware update and configuration");
     systemPrintf("Use the GNSS manufacturer software to update the firmware via %s\r\n", present.gnssUpdatePort);
@@ -911,9 +915,12 @@ void gnssFirmwareDirectConnectHardware() // Facet FP
         systemPrintln("  Select the .pkg firmware file");
         systemPrintln("  On the top tool bar, click \"Reboot\" (blue circle-back icon)");
         systemPrintln("  Then click the green arrow to start the Firmware Update");
+        systemPrintln("  Hit R to reset the GNSS manually if needed - after starting the Update");
     }
-    systemPrintf("Initial baudrate: %dbps\r\n", settings.dataPortBaud);
-    systemPrintf("Press the %s button or hit any key to return to normal operation\r\n",
+    else
+        systemPrintln("Hit R to reset the GNSS manually if needed");
+    systemPrintf("Initial baudrate: %dbps\r\n", platformGnssCommunicationRate);
+    systemPrintf("Press the %s button or hit any key (except R) to return to normal operation\r\n",
                  present.button_mode ? "mode" : "power");
     systemFlush();
 
@@ -924,15 +931,29 @@ void gnssFirmwareDirectConnectHardware() // Facet FP
 
     // Spin our wheels until the user presses a button or hits a key
     task.endDirectConnectMode = false;
-    while (!task.endDirectConnectMode && !Serial.available())
+    while (1)
     {
         delay(1);
-        // Button task will set task.endDirectConnectMode true
+
+         // Button task will set task.endDirectConnectMode true
+        if (task.endDirectConnectMode)
+            break; // Break on button push
+
+        if (Serial.available())
+        {
+            char c = Serial.read();
+            if ((c == 'r') || (c == 'R'))
+                // If the GNSS is a LG290P, putting it into reset will bring down I2C
+                // So use the fast GNSS-detect routine to do the reset
+                gpioExpanderDetectGnssForced();
+            else
+                break; // Break on any other character
+        }
     }
 
     gpioExpanderConnectGNSSToESP32(); // Redundant...
 
-    if (Serial.available()) // buttonCheckTask has its own print
+    if (!task.endDirectConnectMode) // buttonCheckTask has its own print
     {
         systemPrintln("Exiting GNSS direct connect");
         systemPrintln("Restarting...");

--- a/Firmware/RTK_Everywhere/System.ino
+++ b/Firmware/RTK_Everywhere/System.ino
@@ -1109,9 +1109,17 @@ void gpioExpanderGnssReset()
 // INPUT using a direct write - not the read-modify-write through the library.
 bool gpioExpanderDetectGnss()
 {
+    return gpioExpanderDetectGnssCommon(false);
+}
+bool gpioExpanderDetectGnssForced()
+{
+    return gpioExpanderDetectGnssCommon(true);
+}
+bool gpioExpanderDetectGnssCommon(bool forceDetection)
+{
     if (online.gpioExpanderSwitches == true)
     {
-        if (settings.detectedGnssReceiver == GNSS_RECEIVER_UNKNOWN)
+        if (forceDetection || (settings.detectedGnssReceiver == GNSS_RECEIVER_UNKNOWN))
         {
             // Use 400kHz for speed
             if (present.i2c0BusSpeed_400 == false)
@@ -1119,6 +1127,10 @@ bool gpioExpanderDetectGnss()
             
             // Set GNSS Reset LOW
             gpioExpanderSwitches->digitalWrite(gpioExpanderSwitch_GNSS_Reset, LOW);
+
+            // Flex LG290P with Tilt does not reset unless we delay just a little...
+            if (forceDetection)
+                delayMicroseconds(50); // 250 OK. 100 OK. 50 OK. 25 OK. 10 not OK.
             
             // Clock is ticking! Be quick!
             // Set GNSS Reset to INPUT as fast as possible


### PR DESCRIPTION
On Facet FP with Flex LG290P+Tilt, I wasn't able to start an upgrade using the Reboot (circle-back) icon...

With this PR, hitting R will reset the GNSS. Flex RESET is pulled low for just long enough to reset the LG290P, but without it dragging the I2C bus down.