### PR TITLE
Switch builds to use ESP32 Core 3.3.7

### DIFF
--- a/Firmware/Dockerfile
+++ b/Firmware/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest AS upstream
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG CORE_VERSION=3.0.7
+ARG CORE_VERSION=3.3.7
 
 ARG FIRMWARE_VERSION_MAJOR=99
 ARG FIRMWARE_VERSION_MINOR=99
@@ -150,13 +150,13 @@ RUN if [ "$COMPILE_AUTHENTICATION" = "false" ] ; \
 
 # Patch libmbedtls and libbt
 RUN cd ./RTK_Everywhere/Patch \
-    && ESP_IDF=$(ls /root/.arduino15/packages/esp32/tools/esp32-arduino-libs | grep idf-release) \
+    && ESP_IDF=$(ls /root/.arduino15/packages/esp32/tools/esp32-libs | grep idf-release) \
     && echo "ESP IDF Version: ${ESP_IDF}" \
-    && cp libmbedtls.a "/root/.arduino15/packages/esp32/tools/esp32-arduino-libs/${ESP_IDF}/esp32/lib/libmbedtls.a" \
-    && cp libmbedtls_2.a "/root/.arduino15/packages/esp32/tools/esp32-arduino-libs/${ESP_IDF}/esp32/lib/libmbedtls_2.a" \
-    && cp libmbedcrypto.a "/root/.arduino15/packages/esp32/tools/esp32-arduino-libs/${ESP_IDF}/esp32/lib/libmbedcrypto.a" \
-    && cp libmbedx509.a "/root/.arduino15/packages/esp32/tools/esp32-arduino-libs/${ESP_IDF}/esp32/lib/libmbedx509.a" \
-    && cp libbt.a "/root/.arduino15/packages/esp32/tools/esp32-arduino-libs/${ESP_IDF}/esp32/lib/libbt.a"
+    && cp libmbedtls.a "/root/.arduino15/packages/esp32/tools/esp32-libs/${ESP_IDF}/lib/libmbedtls.a" \
+    && cp libmbedtls_2.a "/root/.arduino15/packages/esp32/tools/esp32-libs/${ESP_IDF}/lib/libmbedtls_2.a" \
+    && cp libmbedcrypto.a "/root/.arduino15/packages/esp32/tools/esp32-libs/${ESP_IDF}/lib/libmbedcrypto.a" \
+    && cp libmbedx509.a "/root/.arduino15/packages/esp32/tools/esp32-libs/${ESP_IDF}/lib/libmbedx509.a" \
+    && cp libbt.a "/root/.arduino15/packages/esp32/tools/esp32-libs/${ESP_IDF}/lib/libbt.a"
 
 # Update form.h with index_html and main_js
 RUN cd ./Tools \

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -26,15 +26,12 @@ static const char *wifiAuthorizationName[] = {
     "WAPI_PSK",
     "OWE",
     "WPA3_ENT_192",
-
-    // Compatible with ESP32 core v3.2.1, 16 reported, 18 listed here:
-    // https://github.com/espressif/esp-idf/blob/master/components/esp_wifi/include/esp_wifi_types_generic.h#L86
-    //"WPA3_EXT_PSK",
-    //"WPA3_EXT_PSK_MIXED_MODE",
-    //"DPP",
-    //"WPA3_ENTERPRISE",
-    //"WPA2_WPA3_ENTERPRISE",
-    //"WPA_ENTERPRISE",
+    "WPA3_ENT_PSK",
+    "WPA3_EXT_PSK_MIXED_MODE",
+    "DPP",
+    "WPA3_ENTERPRISE",
+    "WPA2_WPA3_ENTERPRISE",
+    "WPA_ENTERPRISE",
 };
 static const int wifiAuthorizationNameEntries = sizeof(wifiAuthorizationName) / sizeof(wifiAuthorizationName[0]);
 

--- a/Firmware/RTK_Everywhere/makefile
+++ b/Firmware/RTK_Everywhere/makefile
@@ -9,8 +9,8 @@
 ##########
 
 SKETCH=RTK_Everywhere.ino
-ESP_CORE_VERSION=3.0.7
-ESP_IDF_VERSION=idf-release_v5.1-632e0c2a
+ESP_CORE_VERSION=3.3.7
+ESP_IDF_VERSION=$(ESP_CORE_VERSION)
 
 # Uncomment all five lines for a complete update
 #EXECUTABLES = arduino-config lib-update
@@ -46,7 +46,7 @@ PARTITION_SRC_PATH=$(FIRMWARE_PATH)$(PARTITION_CSV_FILE).csv
 PATCH_SRC_PATH=$(RTK_EVERYWHERE_PATH)Patch\
 
 # Windows NT patch destination paths
-MBED_LIB_DEST_PATH=$(HOME_BOARD_PATH)\tools\esp32-arduino-libs\${{ env.ESP_IDF }}\esp32/lib\
+MBED_LIB_DEST_PATH=$(HOME_BOARD_PATH)\tools\esp32-arduino-libs\${{ env.ESP_IDF }}\lib\
 NET_EVENT_PATCH_PATH=$(HOME_BOARD_PATH)\hardware\esp32\$(ESP_CORE_VERSION)\libraries\Network\src\
 PARTITION_DST_PATH=$(HOME_BOARD_PATH)\hardware\esp32\$(ESP_CORE_VERSION)\tools\partitions\$(PARTITION_CSV_FILE).csv
 
@@ -75,7 +75,7 @@ TERMINAL_PARAMS=-b 115200 -8 < /dev/tty
 USER_DIRECTORY_PATH=~/
 TMP_PATH=/tmp/
 ARDUINO_LIBRARY_PATH=$(USER_DIRECTORY_PATH)Arduino/libraries
-ESP_IDF_PATH=$(HOME_BOARD_PATH)/tools/esp32-arduino-libs
+ESP_IDF_PATH=$(HOME_BOARD_PATH)/tools/esp32-libs
 HOME_BOARD_PATH=$(USER_DIRECTORY_PATH).arduino15/packages/esp32
 
 # Linux patch source paths
@@ -86,8 +86,8 @@ PARTITION_SRC_PATH=$(FIRMWARE_PATH)$(PARTITION_CSV_FILE).csv
 PATCH_SRC_PATH=$(RTK_EVERYWHERE_PATH)Patch/
 
 # Linux patch destination paths
-BT_LIB_DEST_PATH=$(ESP_IDF_PATH)/$(ESP_IDF_VERSION)/esp32/lib/
-MBED_LIB_DEST_PATH=$(ESP_IDF_PATH)/$(ESP_IDF_VERSION)/esp32/lib/
+BT_LIB_DEST_PATH=$(ESP_IDF_PATH)/$(ESP_IDF_VERSION)/lib/
+MBED_LIB_DEST_PATH=$(ESP_IDF_PATH)/$(ESP_IDF_VERSION)/lib/
 NET_EVENT_PATCH_PATH=$(HOME_BOARD_PATH)/hardware/esp32/$(ESP_CORE_VERSION)/libraries/Network/src/
 PARTITION_DST_PATH=$(HOME_BOARD_PATH)/hardware/esp32/$(ESP_CORE_VERSION)/tools/partitions/$(PARTITION_CSV_FILE).csv
 
@@ -149,7 +149,7 @@ lib-install:	index-update
 .PHONY: get-idf-version
 
 get-idf-version:
-	ESP_IDF_VERSION=$(ls ~/.arduino15/packages/esp32/tools/esp32-arduino-libs | grep idf-release)
+	ESP_IDF_VERSION=$(ls ~/.arduino15/packages/esp32/tools/esp32-libs | grep idf-release)
 	echo "ESP IDF Version: ${ESP_IDF_VERSION}"
 
 $(PARTITION_DST_PATH):	$(PARTITION_SRC_PATH)


### PR DESCRIPTION
This PR contains the following commits:
* Switch builds to use ESP32 Core 3.3.7
* Fix wifiAuthorizationName table