### PR TITLE
Tasks: Don't set RTCM consumers as a slowConsumer

### DIFF
--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -532,6 +532,7 @@ unsigned long rtcmLastPacketReceived; // Time stamp of RTCM coming in (from BT, 
 
 bool usbSerialIncomingRtcm; // Incoming RTCM over the USB serial port
 #define RTCM_CORRECTION_INPUT_TIMEOUT (2 * 1000)
+#define RTCM_CORRECTION_WRITE_TIMEOUT (5 * 1000)
 
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 

--- a/Firmware/RTK_Everywhere/Tasks.ino
+++ b/Firmware/RTK_Everywhere/Tasks.ino
@@ -1606,8 +1606,13 @@ void handleGnssDataTask(void *e)
 
         sendRTCMToConsumers();
 
-        if ((millis() - startMillis) > settings.networkClientWriteTimeout_ms)
-            slowConsumer = "RTCM Consumers";
+        if ((millis() - startMillis) > RTCM_CORRECTION_WRITE_TIMEOUT)
+        {
+            uint32_t milliseconds = millis() - startMillis;
+            uint32_t seconds = milliseconds / MILLISECONDS_IN_A_SECOND;
+            milliseconds -= seconds * MILLISECONDS_IN_A_SECOND;
+            systemPrintf("\aWARNING: RTCM writes took %d.%03d seconds!\r\n", seconds, milliseconds);
+        }
 
         usedSpace = 0;
 


### PR DESCRIPTION
Only ring buffer data consumers should be delcared as slowConsumers. The slowConsumer value is set in handleGnssDataTask and displayed by processUart1Message which is part of gnssReadTask.

The RTCM consumers use a different ring buffer managed in Base.ino. However some task needs to read the Base.ino ring buffer and send message to the consumers.  This task is currently handleGnssDataTask.

Output a message when the write operation takes too much time to completee.