### PR TITLE
Fix for Ext Radio / LoRa corrections on FPL

### DIFF
--- a/Firmware/RTK_Everywhere/GNSS.ino
+++ b/Firmware/RTK_Everywhere/GNSS.ino
@@ -456,7 +456,11 @@ void gnssUpdate()
 
         if (gnssConfigureRequested(GNSS_CONFIG_EXT_CORRECTIONS))
         {
-            if (gnss->setCorrRadioExtPort(settings.enableExtCorrRadio, true) == true) // Force the setting
+            // If settings.enableExtCorrRadio is true, we need RTCM input
+            // On Facet FP, we also need RTCM if LoRa is enabled
+            bool enableExtCorrRadio = settings.enableExtCorrRadio
+                 || ((productVariant == RTK_FACET_FP) && settings.enableLora);
+            if (gnss->setCorrRadioExtPort(enableExtCorrRadio, true) == true) // Force the setting
             {
                 gnssConfigureClear(GNSS_CONFIG_EXT_CORRECTIONS);
                 gnssConfigure(GNSS_CONFIG_SAVE); // Request receiver commit this change to NVM

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -177,6 +177,12 @@ void GNSS_LG290P::begin()
     snprintf(gnssUniqueId, sizeof(gnssUniqueId), "%s", getId());
 
     gnssFirmwareVersionInt = lg290pFirmwareVersionInt; // Tell Web Config what version to use
+
+    // On Facet FP: set UART2 (Radio) protocol(s)
+    // Both Ext Radio and LoRa need RTCM on UART2
+    // Note: this is probably redundant? I only added it because I added it on mosaic...
+    if (productVariant == RTK_FACET_FP)
+        setCorrRadioExtPort((settings.enableExtCorrRadio || settings.enableLora), true); // Force the setting
 }
 
 //----------------------------------------
@@ -1174,7 +1180,12 @@ bool GNSS_LG290P::isConfirmedTime()
 // Returns true if data is arriving on the Radio Ext port
 bool GNSS_LG290P::isCorrRadioExtPortActive()
 {
-    return settings.enableExtCorrRadio;
+    // On LG290P, we don't have access to the UART RX byte counts
+    // We have to assume data is arriving if ext radio is enabled...
+    // And on Facet FP, we also have to fake the arrival of LoRa traffic
+    // to maintain the Radio Ext protocols...
+    return (settings.enableExtCorrRadio
+            || ((productVariant == RTK_FACET_FP) && settings.enableLora));
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
@@ -312,7 +312,9 @@ void GNSS_MOSAIC::begin()
             return;
 
         // Set COM2 (Radio) protocol(s)
-        setCorrRadioExtPort(settings.enableExtCorrRadio, true); // Force the setting
+        // Both Ext Radio and LoRa need RTCM on UART2
+        // Note: this is probably redundant? I'm now not sure why I added it...
+        setCorrRadioExtPort((settings.enableExtCorrRadio || settings.enableLora), true); // Force the setting
 
         updateSD(); // Check card size and free space
 

--- a/Firmware/RTK_Everywhere/GNSS_UM980.h
+++ b/Firmware/RTK_Everywhere/GNSS_UM980.h
@@ -330,7 +330,7 @@ class GNSS_UM980 : GNSS
     // Returns true if data is arriving on the Radio Ext port
     bool isCorrRadioExtPortActive()
     {
-        return false;
+        return false; // Torch has no Radio port...
     }
 
     // Return true if GNSS receiver has a higher quality DGPS fix than 3D

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -223,6 +223,12 @@ void GNSS_ZED::begin()
 
             present.dynamicModel = true; // EVK and FPX ZED modules support dynamic model configuration
 
+            // On Facet FP: set UART2 (Radio) protocol(s)
+            // Both Ext Radio and LoRa need RTCM on UART2
+            // Note: this is probably redundant? I only added it because I added it on mosaic...
+            if (productVariant == RTK_FACET_FP)
+                setCorrRadioExtPort((settings.enableExtCorrRadio || settings.enableLora), true); // Force the setting
+
             return;
         }
     }

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -1664,6 +1664,9 @@ void waitingForMenuInput()
 
     DMW_w("updateLora");
     updateLora(); // Check if we need to finish sending any RTCM over LoRa radio
+
+    DMW_w("correctionUpdateSource");
+    correctionUpdateSource(); // Maintain current sources. Retire expired sources
 }
 
 void loopDelay()

--- a/Firmware/RTK_Everywhere/menuCorrectionsPriorities.ino
+++ b/Firmware/RTK_Everywhere/menuCorrectionsPriorities.ino
@@ -615,6 +615,8 @@ void correctionUpdateSource()
     // The code is the same:
     //   On ZED / mosaic, we can detect if the port is active.
     //   On LG290P, we fake the arrival of data if needed.
+    //   On Facet FPL, we fake the arrival of radio data if LoRa is active
+    //     again to prevent a timeout and maintain the port protocol
     static uint32_t lastRadioExtCheck = millis();
     uint32_t radioCheckIntervalMsec = settings.correctionsSourcesLifetime_s * 500; // Check twice per lifetime
     bool setCorrRadioPort = false;

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -670,6 +670,7 @@ void menuRadio()
         {
             settings.enableLora ^= 1;
             gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_NMEA); // We may need to enable / disable NMEA
+            gnssConfigure(GNSS_CONFIG_EXT_CORRECTIONS); // We may need to enable RTCM input
         }
         else if (present.radio_lora == true && settings.enableLora == true && incoming == 11)
         {

--- a/Firmware/RTK_Everywhere/menuPorts.ino
+++ b/Firmware/RTK_Everywhere/menuPorts.ino
@@ -81,13 +81,13 @@ void menuPortsNoMux()
 
         if (productVariant == RTK_FACET_FP)
         {
-            systemPrintf("4) Allow incoming corrections on GNSS UART2: %s\r\n",
+            systemPrintf("4) Allow incoming corrections on Ext Radio: %s\r\n",
                          settings.enableExtCorrRadio ? "Enabled" : "Disabled");
 
             // X20P / F9P UART2 is limited to RTCM. No need to change settings.enableNmeaOnRadio
             if (present.gnss_lg290p || present.gnss_mosaicX5)
             {
-                systemPrintf("5) Limit GNSS UART2 output to RTCM: %s\r\n",
+                systemPrintf("5) Limit Ext Radio and LoRa output to RTCM: %s\r\n",
                             settings.enableNmeaOnRadio ? "Disabled"
                                                         : "Enabled"); // Reverse disabled/enabled to align with prompt
             }
@@ -157,6 +157,7 @@ void menuPortsNoMux()
         {
             // Toggle the enable for the external corrections radio
             settings.enableExtCorrRadio ^= 1;
+            gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_NMEA); // We may need to enable / disable NMEA
             gnssConfigure(GNSS_CONFIG_EXT_CORRECTIONS); // Request receiver to use new settings
         }
 
@@ -294,6 +295,7 @@ void menuPortsMultiplexed()
         {
             // Toggle the enable for the external corrections radio
             settings.enableExtCorrRadio ^= 1;
+            gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_NMEA); // We may need to enable / disable NMEA
             gnssConfigure(GNSS_CONFIG_EXT_CORRECTIONS); // Request receiver to use new settings
         }
         else if ((incoming == 5) && (productVariant == RTK_FACET_MOSAIC))

--- a/Firmware/RTK_Everywhere/menuSupport.ino
+++ b/Firmware/RTK_Everywhere/menuSupport.ino
@@ -41,6 +41,8 @@ void checkGNSSArrayDefaults()
         if (settings.enableExtCorrRadio == 254)
         {
             defaultsApplied = true;
+            // On F9P/X20P and mosaic, we do have access to the UART2 byte counts so we
+            // can safely default to enabled
             settings.enableExtCorrRadio = true;
         }
 
@@ -159,6 +161,8 @@ void checkGNSSArrayDefaults()
         if (settings.enableExtCorrRadio == 254)
         {
             defaultsApplied = true;
+            // On X20P and mosaic, we do have access to the UART2 byte counts so we
+            // can safely default to enabled
             settings.enableExtCorrRadio = true;
         }
 
@@ -221,9 +225,17 @@ void checkGNSSArrayDefaults()
         {
             defaultsApplied = true;
             if (productVariant == RTK_POSTCARD)
-                settings.enableExtCorrRadio = false; // User has to enable UART3 (JST) manually
+                // User has to enable UART3 (JST) manually for the same reason as LG290P on FP
+                settings.enableExtCorrRadio = false;
             else if (productVariant == RTK_FACET_FP)
-                settings.enableExtCorrRadio = true; // On Facet FP, default to enabled (for LoRa)
+            {
+                // With LG290P on Facet FP:
+                // We do not know if ext radio / LoRa corrections are arriving
+                // because we don't have access to the UART2 byte counts. We have to assume
+                // that corrections are arriving. See GNSS_LG290P::isCorrRadioExtPortActive()
+                // We must set settings.enableExtCorrRadio to false to prevent this.
+                settings.enableExtCorrRadio = false;
+            }
             else if (productVariant == RTK_TORCH_X2)
                 settings.enableExtCorrRadio = false; // GNSS UART1 isn't really accessible
             else


### PR DESCRIPTION
On Facet FPL: default Ext Corr Radio to disabled, to prevent faked radio corrections from taking priority

On Facet FPL: the trick is to fake arrival of Ext Radio data when Ext Radio is enabled and also when LoRa is enabled...

