### PR TITLE
Allow WiFi to reconnect when connection is lost

### DIFF
--- a/Firmware/RTK_Everywhere/HTTP_Client.ino
+++ b/Firmware/RTK_Everywhere/HTTP_Client.ino
@@ -114,7 +114,7 @@ bool httpClientConnectLimitReached()
             seconds = httpClientConnectionAttemptTimeout / MILLISECONDS_IN_A_SECOND;
             minutes = seconds / SECONDS_IN_A_MINUTE;
             seconds -= minutes * SECONDS_IN_A_MINUTE;
-            systemPrintf("HTTP Client trying again in %d:%02d seconds.\r\n", minutes, seconds);
+            systemPrintf("HTTP Client trying again in %d:%02d.\r\n", minutes, seconds);
         }
     }
     else

--- a/Firmware/RTK_Everywhere/NtripClient.ino
+++ b/Firmware/RTK_Everywhere/NtripClient.ino
@@ -348,7 +348,7 @@ bool ntripClientConnectLimitReached()
             seconds = ntripClientConnectionAttemptTimeout / MILLISECONDS_IN_A_SECOND;
             minutes = seconds / SECONDS_IN_A_MINUTE;
             seconds -= minutes * SECONDS_IN_A_MINUTE;
-            systemPrintf("NTRIP Client trying again in %d:%02d seconds.\r\n", minutes, seconds);
+            systemPrintf("NTRIP Client trying again in %d:%02d.\r\n", minutes, seconds);
         }
     }
     else

--- a/Firmware/RTK_Everywhere/NtripServer.ino
+++ b/Firmware/RTK_Everywhere/NtripServer.ino
@@ -495,7 +495,7 @@ bool ntripServerConnectLimitReached(int serverIndex)
             seconds = ntripServer->connectionAttemptTimeout / MILLISECONDS_IN_A_SECOND;
             minutes = seconds / SECONDS_IN_A_MINUTE;
             seconds -= minutes * SECONDS_IN_A_MINUTE;
-            systemPrintf("NTRIP Server %d trying again in %d:%02d seconds.\r\n", serverIndex, minutes, seconds);
+            systemPrintf("NTRIP Server %d trying again in %d:%02d.\r\n", serverIndex, minutes, seconds);
         }
     }
     else

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -1092,7 +1092,7 @@ void wifiStationUpdate()
                     uint32_t seconds = startTimeout / MILLISECONDS_IN_A_SECOND;
                     uint32_t minutes = seconds / SECONDS_IN_A_MINUTE;
                     seconds -= minutes * SECONDS_IN_A_MINUTE;
-                    systemPrintf("WiFi: Delaying %2d:%02d before restarting WiFi\r\n", minutes, seconds);
+                    systemPrintf("WiFi: Delaying %01d:%02d before restarting WiFi\r\n", minutes, seconds);
                 }
                 timer = millis();
                 wifiStationSetState(WIFI_STATION_STATE_RESTART_DELAY);

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -1195,10 +1195,46 @@ void wifiStationUpdate()
             startTimeout = 0;
             wifiStationSetState(WIFI_STATION_STATE_STABLE);
         }
+
+        // If WiFi connection is lost while online, restart
+        if (networkInterfaceHasInternet(NETWORK_WIFI_STATION) == false)
+        {
+            if (settings.debugWifiState || settings.debugNetworkLayer)
+            {
+                // Display the delay
+                uint32_t seconds = startTimeout / MILLISECONDS_IN_A_SECOND;
+                uint32_t minutes = seconds / SECONDS_IN_A_MINUTE;
+                seconds -= minutes * SECONDS_IN_A_MINUTE;
+                systemPrintf("WiFi: WiFi station lost internet connection while online, restarting in %01d:%02d\r\n",
+                             minutes, seconds);
+            }
+
+            timer = millis();
+            wifiStationSetState(WIFI_STATION_STATE_WAIT_NO_USERS); // Force reset of state machine
+        }
+
         break;
 
     // WiFi station consumers have internet access
     case WIFI_STATION_STATE_STABLE:
+
+        // If WiFi connection is lost while online, restart
+        if (networkInterfaceHasInternet(NETWORK_WIFI_STATION) == false)
+        {
+            if (settings.debugWifiState || settings.debugNetworkLayer)
+            {
+                // Display the delay
+                uint32_t seconds = startTimeout / MILLISECONDS_IN_A_SECOND;
+                uint32_t minutes = seconds / SECONDS_IN_A_MINUTE;
+                seconds -= minutes * SECONDS_IN_A_MINUTE;
+                systemPrintf("WiFi: WiFi station lost internet connection while stable, restarting in %01d:%02d\r\n",
+                             minutes, seconds);
+            }
+
+            timer = millis();
+            wifiStationSetState(WIFI_STATION_STATE_WAIT_NO_USERS); // Force reset of state machine
+        }
+
         break;
     }
 

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -1205,7 +1205,19 @@ void wifiStationUpdate()
     // Periodically display the WiFi state
     if (PERIODIC_DISPLAY(PD_WIFI_STATE) && !inMainMenu)
     {
-        systemPrintf("WiFi station state: %s%s\r\n", wifiStationStateName[wifiStationState], reason);
+        systemPrintf("WiFi station state: %s%s", wifiStationStateName[wifiStationState], reason);
+
+        if (wifiStationState == WIFI_STATION_STATE_RESTART_DELAY)
+        {
+            // Display the delay
+            uint32_t seconds = (startTimeout - (millis() - timer)) / MILLISECONDS_IN_A_SECOND;
+            uint32_t minutes = seconds / SECONDS_IN_A_MINUTE;
+            seconds -= minutes * SECONDS_IN_A_MINUTE;
+            systemPrintf(" - WiFi Restart in %01d:%02d", minutes, seconds);
+        }
+
+        systemPrintln();
+
         PERIODIC_CLEAR(PD_WIFI_STATE);
     }
 }

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -911,7 +911,7 @@ struct Settings
     };
     char ntripServer_CasterUser[NTRIP_SERVER_MAX][NTRIP_SERVER_STRING_SIZE] =
     {
-        "test@test.com" // Some free casters require auth. User must provide their own email address to use RTK2Go
+        ""
         "",
         "",
         "",


### PR DESCRIPTION
This is a fix for #993.

Previously, if the AP that the device was connected to went down, the device would not try to reconnect because WiFi was stuck in `WIFI_STATION_STATE_ONLINE` or `WIFI_STATION_STATE_STABLE`. This PR resets the wifiStationUpdate state machine if networkInterfaceHasInternet is lost. 