### PR TITLE
Remove duplicate code when setting the profile number

### DIFF
--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -1011,6 +1011,14 @@ int loraFirmwareVersionInt = 0;
 uint8_t bootTimeIndex;
 uint32_t bootTime[MAX_BOOT_TIME_ENTRIES];
 const char *bootTimeString[MAX_BOOT_TIME_ENTRIES];
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+// Foward routine declarations
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+void changeProfileNumber(byte newProfileNumber, bool recordSettings = true);
+
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 // Support to trackdown a system hang.

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -364,23 +364,9 @@ void menuUserProfiles()
                     }
                 }
 
-                gnssConfigureDefaults(); // Set all bits in the request bitfield to cause the GNSS receiver to go
-                                         // through a full (re)configuration
-
-                recordProfileNumber(0); // Move to Profile1
-
-                setSettingsFileName(); // Update file name with new profileNumber. Also updates station coordinates file
-                                       // names
-
-                // We need to load these settings from file so that we can record a profile name change correctly
-                bool responseLFS = loadSystemSettingsFromFileLFS(settingsFileName);
-                bool responseSD = loadSystemSettingsFromFileSD(settingsFileName);
-
-                // If this is an empty/new profile slot, overwrite our current settings with defaults
-                if (responseLFS == false && responseSD == false)
-                {
-                    settingsToDefaults();
-                }
+                // We need to load these settings from file so that we can
+                // record a profile name change correctly
+                changeProfileNumber(0, false);
 
                 // Get bitmask of active profiles
                 activeProfiles = loadProfileNames();

--- a/Firmware/RTK_Everywhere/menuSupport.ino
+++ b/Firmware/RTK_Everywhere/menuSupport.ino
@@ -3,11 +3,12 @@ menuSupport.ino
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
 // Change the active profile number, without unit reset
-void changeProfileNumber(byte newProfileNumber)
+void changeProfileNumber(byte newProfileNumber, bool recordSettings)
 {
     gnssConfigureDefaults(); // Set all bits in the request bitfield to cause the GNSS receiver to go through a full
                              // (re)configuration
-    recordSystemSettings();  // Before switching, we need to record the current settings to LittleFS and SD
+    if (recordSettings)
+        recordSystemSettings();  // Before switching, we need to record the current settings to LittleFS and SD
 
     recordProfileNumber(newProfileNumber);
     setSettingsFileName(); // Load the settings file name into memory (enabled profile name delete)


### PR DESCRIPTION
This PR includes the following commits:
* Add recordSettings parameter to changeProfileNumber
* Use changeProfileNumber instead of duplicating code
