### PR TITLE
Prevent partial loads of a settings file, load all or none

### DIFF
--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -720,7 +720,7 @@ bool loadSystemSettingsFromFileSD(char *fileName, const char *findMe, char *foun
                     if (findMe == nullptr)
                     {
                         // parse each line and load into settings
-                        if (parseLine(line) == false)
+                        if (parseLine(line, &settings) == false)
                         {
                             line[strlen(line) - 1] = 0; // Remove \n for printing
                             systemPrintf("Failed to parse SD file %s line %d: %s\r\n", fileName, lineNumber, line);
@@ -867,7 +867,7 @@ bool loadSystemSettingsFromFileLFS(char *fileName, const char *findMe, char *fou
             if (findMe == nullptr)
             {
                 // parse each line and load into settings
-                if (parseLine(line) == false)
+                if (parseLine(line, &settings) == false)
                 {
                     line[strlen(line) - 1] = 0; // Remove \n for printing
                     systemPrintf("Failed to parse LFS file %s line %d: %s\r\n", fileName, lineNumber, line);
@@ -1005,7 +1005,7 @@ bool printSystemSettingsFromFileLFS(char *fileName)
 // Sets the setting if the name is known
 // The order of variables matches the order found in settings.h
 // Both fgets and getLine leave theLine terminated with \n only (\r is removed)
-bool parseLine(const char *theLine)
+bool parseLine(const char *theLine, struct Settings * tempSettings)
 {
     // Make a copy. Manipulate the copy, not the original
     size_t strLen = strnlen(theLine, 100);
@@ -1164,14 +1164,19 @@ bool parseLine(const char *theLine)
         // Determine if settingName is in the command table
         if (i >= 0)
         {
+            size_t settingsOffset;
             qualifier = rtkSettingsEntries[i].qualifier;
             type = rtkSettingsEntries[i].type;
             var = rtkSettingsEntries[i].var;
+            if (var && (var >= &settings) && (var < &((uint8_t *)&settings)[sizeof(settings)]))
+            {
+                settingsOffset = ((uint8_t *)var) - (uint8_t *)&settings;
+                var = (uint8_t *)tempSettings + settingsOffset;
+            }
 
             // Handle the GNSS specific types
-            if (gnssNewSettingValue(&settings, type, suffix, qualifier, d))
-                knownSetting = true;
-            else
+            knownSetting = gnssNewSettingValue(tempSettings, type, suffix, qualifier, d);
+            if (knownSetting == false)
             {
                 // Handle the generic types
                 switch (type)
@@ -1297,7 +1302,7 @@ bool parseLine(const char *theLine)
                                    &mac[5]) == 6)
                         {
                             for (int i = 0; i < 6; i++)
-                                settings.espnowPeers[suffixNum][i] = mac[i];
+                                tempSettings->espnowPeers[suffixNum][i] = mac[i];
                             knownSetting = true;
                         }
                     }
@@ -1310,8 +1315,8 @@ bool parseLine(const char *theLine)
                     {
                         if (sscanf(suffix, "%dSSID", &network) == 1)
                         {
-                            strncpy(settings.wifiNetworks[network].ssid, settingString,
-                                    sizeof(settings.wifiNetworks[0].ssid));
+                            strncpy(tempSettings->wifiNetworks[network].ssid, settingString,
+                                    sizeof(tempSettings->wifiNetworks[0].ssid));
                             knownSetting = true;
                         }
                     }
@@ -1319,8 +1324,8 @@ bool parseLine(const char *theLine)
                     {
                         if (sscanf(suffix, "%dPassword", &network) == 1)
                         {
-                            strncpy(settings.wifiNetworks[network].password, settingString,
-                                    sizeof(settings.wifiNetworks[0].password));
+                            strncpy(tempSettings->wifiNetworks[network].password, settingString,
+                                    sizeof(tempSettings->wifiNetworks[0].password));
                             knownSetting = true;
                         }
                     }
@@ -1330,7 +1335,7 @@ bool parseLine(const char *theLine)
                     int server;
                     if (sscanf(suffix, "%d", &server) == 1)
                     {
-                        settings.ntripServer_CasterEnabled[server] = d;
+                        tempSettings->ntripServer_CasterEnabled[server] = d;
                         knownSetting = true;
                     }
                 }
@@ -1339,8 +1344,8 @@ bool parseLine(const char *theLine)
                     int server;
                     if (sscanf(suffix, "%d", &server) == 1)
                     {
-                        strncpy(&settings.ntripServer_CasterHost[server][0], settingString,
-                                sizeof(settings.ntripServer_CasterHost[server]));
+                        strncpy(&tempSettings->ntripServer_CasterHost[server][0], settingString,
+                                sizeof(tempSettings->ntripServer_CasterHost[server]));
                         knownSetting = true;
                     }
                 }
@@ -1349,7 +1354,7 @@ bool parseLine(const char *theLine)
                     int server;
                     if (sscanf(suffix, "%d", &server) == 1)
                     {
-                        settings.ntripServer_CasterPort[server] = d;
+                        tempSettings->ntripServer_CasterPort[server] = d;
                         knownSetting = true;
                     }
                 }
@@ -1358,8 +1363,8 @@ bool parseLine(const char *theLine)
                     int server;
                     if (sscanf(suffix, "%d", &server) == 1)
                     {
-                        strncpy(&settings.ntripServer_CasterUser[server][0], settingString,
-                                sizeof(settings.ntripServer_CasterUser[server]));
+                        strncpy(&tempSettings->ntripServer_CasterUser[server][0], settingString,
+                                sizeof(tempSettings->ntripServer_CasterUser[server]));
                         knownSetting = true;
                     }
                 }
@@ -1368,8 +1373,8 @@ bool parseLine(const char *theLine)
                     int server;
                     if (sscanf(suffix, "%d", &server) == 1)
                     {
-                        strncpy(&settings.ntripServer_CasterUserPW[server][0], settingString,
-                                sizeof(settings.ntripServer_CasterUserPW[server]));
+                        strncpy(&tempSettings->ntripServer_CasterUserPW[server][0], settingString,
+                                sizeof(tempSettings->ntripServer_CasterUserPW[server]));
                         knownSetting = true;
                     }
                 }
@@ -1378,8 +1383,8 @@ bool parseLine(const char *theLine)
                     int server;
                     if (sscanf(suffix, "%d", &server) == 1)
                     {
-                        strncpy(&settings.ntripServer_MountPoint[server][0], settingString,
-                                sizeof(settings.ntripServer_MountPoint[server]));
+                        strncpy(&tempSettings->ntripServer_MountPoint[server][0], settingString,
+                                sizeof(tempSettings->ntripServer_MountPoint[server]));
                         knownSetting = true;
                     }
                 }
@@ -1388,8 +1393,8 @@ bool parseLine(const char *theLine)
                     int server;
                     if (sscanf(suffix, "%d", &server) == 1)
                     {
-                        strncpy(&settings.ntripServer_MountPointPW[server][0], settingString,
-                                sizeof(settings.ntripServer_MountPointPW[server]));
+                        strncpy(&tempSettings->ntripServer_MountPointPW[server][0], settingString,
+                                sizeof(tempSettings->ntripServer_MountPointPW[server]));
                         knownSetting = true;
                     }
                 }
@@ -1399,7 +1404,7 @@ bool parseLine(const char *theLine)
                     {
                         if ((suffix[0] == correctionGetName(x)[0]) && (strcmp(suffix, correctionGetName(x)) == 0))
                         {
-                            settings.correctionsSourcesPriority[x] = d;
+                            tempSettings->correctionsSourcesPriority[x] = d;
                             knownSetting = true;
                             break;
                         }
@@ -1410,8 +1415,8 @@ bool parseLine(const char *theLine)
                     int region;
                     if (sscanf(suffix, "%d", &region) == 1)
                     {
-                        strncpy(&settings.regionalCorrectionTopics[region][0], settingString,
-                                sizeof(settings.regionalCorrectionTopics[0]));
+                        strncpy(&tempSettings->regionalCorrectionTopics[region][0], settingString,
+                                sizeof(tempSettings->regionalCorrectionTopics[0]));
                         knownSetting = true;
                     }
                 }

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -149,77 +149,10 @@ bool loadSettingsUsingTempSetting(bool startFromDefault)
 // So we moved again to SPIFFs. It's being replaced by LittleFS so here we are.
 void loadSettings()
 {
-    bool loadSuccessful;
-    bool settingsAllocated;
-    struct Settings * tempSettings;
-
-    // Allocate the tempSettings structure
-    settingsAllocated = false;
-    tempSettings = (struct Settings *)rtkMalloc(sizeof(*tempSettings), "loadSettings tempSettings");
-    if (tempSettings)
-    {
-        settingsAllocated = true;
-        if (settings.debugSettings)
-            systemPrintf("Allocated tempSettings: %p\r\n", (void *)tempSettings);
-
-        // Initialize the temporary settings
-        memcpy(tempSettings, &settings, sizeof(settings));
-    }
-    else
-    {
-        systemPrintf("ERROR: loadSettings failed to allocate tempSettings, using settings!\r\n");
-        reportHeapNow(true);
-        tempSettings = &settings;
-    }
-
-    // If we have a profile in both LFS and SD, the SD settings will overwrite LFS
-    // This will fail if LFS has been erased, a read error occurs or the file is
-    // corrupt.
-    loadSuccessful = loadSystemSettingsFromFileLFS(settingsFileName, tempSettings);
-    if (settingsAllocated)
-    {
-        if (loadSuccessful)
-            // Update the settings
-            memcpy(&settings, tempSettings, sizeof(settings));
-        else
-            // Restore the temporary settings upon load failure
-            memcpy(tempSettings, &settings, sizeof(settings));
-    }
-
-    // Temporarily store any variables from LFS that should override SD
-    int resetCount = tempSettings->resetCount;
-    uint32_t gnssConfigureRequest = tempSettings->gnssConfigureRequest;
-
-    // Load the settings from the SD card
-    // This will fail if no SD is present. That's OK.
-    loadSuccessful = loadSystemSettingsFromFileSD(settingsFileName, tempSettings);
-    if (settingsAllocated)
-    {
-        // Update the settings with the values read from the SD card
-        if (loadSuccessful)
-            memcpy(&settings, tempSettings, sizeof(settings));
-
-        // Done with the tempSettings
-        if (settings.debugSettings)
-            systemPrintf("Freeing tempSettings: %p\r\n", (void *)tempSettings);
-        rtkFree(tempSettings, "loadSettings tempSettings");
-
-        // Restore the LFS settings values that should override SD card values
-        settings.resetCount = resetCount; // resetCount from LFS should override SD
-
-        // Trust gnssConfigureRequest from LittleFS over SD.
-        // LittleFS may have been erased, SD could be stale.
-        settings.gnssConfigureRequest = gnssConfigureRequest;
-    }
-
-    // Change empty profile name to 'Profile1' etc
-    if (strlen(settings.profileName) == 0)
-    {
-        snprintf(settings.profileName, sizeof(settings.profileName), "Profile%d", profileNumber + 1);
-
+    // Load the settings from NVM and SD card
+    if (loadSettingsUsingTempSetting(false))
         // Record these settings to LittleFS and SD file to be sure they are the same
         recordSystemSettings();
-    }
 
     // Get bitmask of active profiles
     activeProfiles = loadProfileNames();

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -63,22 +63,68 @@ bool loadSystemSettingsFromFileSD(char *fileName,
 // So we moved again to SPIFFs. It's being replaced by LittleFS so here we are.
 void loadSettings()
 {
+    bool loadSuccessful;
+    bool settingsAllocated;
+    struct Settings * tempSettings;
+
+    // Allocate the tempSettings structure
+    settingsAllocated = false;
+    tempSettings = (struct Settings *)rtkMalloc(sizeof(*tempSettings), "loadSettings tempSettings");
+    if (tempSettings)
+    {
+        settingsAllocated = true;
+        if (settings.debugSettings)
+            systemPrintf("Allocated tempSettings: %p\r\n", (void *)tempSettings);
+
+        // Initialize the temporary settings
+        memcpy(tempSettings, &settings, sizeof(settings));
+    }
+    else
+    {
+        systemPrintf("ERROR: loadSettings failed to allocate tempSettings, using settings!\r\n");
+        reportHeapNow(true);
+        tempSettings = &settings;
+    }
+
     // If we have a profile in both LFS and SD, the SD settings will overwrite LFS
-    // This will fail if LFS has been erased. That's OK.
-    loadSystemSettingsFromFileLFS(settingsFileName, &settings);
+    // This will fail if LFS has been erased, a read error occurs or the file is
+    // corrupt.
+    loadSuccessful = loadSystemSettingsFromFileLFS(settingsFileName, tempSettings);
+    if (settingsAllocated)
+    {
+        if (loadSuccessful)
+            // Update the settings
+            memcpy(&settings, tempSettings, sizeof(settings));
+        else
+            // Restore the temporary settings upon load failure
+            memcpy(tempSettings, &settings, sizeof(settings));
+    }
 
-    // Temp store any variables from LFS that should override SD
-    int resetCount = settings.resetCount;
-    uint32_t gnssConfigureRequest = settings.gnssConfigureRequest;
+    // Temporarily store any variables from LFS that should override SD
+    int resetCount = tempSettings->resetCount;
+    uint32_t gnssConfigureRequest = tempSettings->gnssConfigureRequest;
 
+    // Load the settings from the SD card
     // This will fail if no SD is present. That's OK.
-    loadSystemSettingsFromFileSD(settingsFileName, &settings);
+    loadSuccessful = loadSystemSettingsFromFileSD(settingsFileName, tempSettings);
+    if (settingsAllocated)
+    {
+        // Update the settings with the values read from the SD card
+        if (loadSuccessful)
+            memcpy(&settings, tempSettings, sizeof(settings));
 
-    settings.resetCount = resetCount; // resetCount from LFS should override SD
+        // Done with the tempSettings
+        if (settings.debugSettings)
+            systemPrintf("Freeing tempSettings: %p\r\n", (void *)tempSettings);
+        rtkFree(tempSettings, "loadSettings tempSettings");
 
-    // Trust gnssConfigureRequest from LittleFS over SD.
-    // LittleFS may have been erased, SD could be stale.
-    settings.gnssConfigureRequest = gnssConfigureRequest;
+        // Restore the LFS settings values that should override SD card values
+        settings.resetCount = resetCount; // resetCount from LFS should override SD
+
+        // Trust gnssConfigureRequest from LittleFS over SD.
+        // LittleFS may have been erased, SD could be stale.
+        settings.gnssConfigureRequest = gnssConfigureRequest;
+    }
 
     // Change empty profile name to 'Profile1' etc
     if (strlen(settings.profileName) == 0)

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -61,6 +61,92 @@ bool loadSystemSettingsFromFileSD(char *fileName,
 // We originally used EEPROM but it was limited to 4096 bytes. Each settings struct is ~4000 bytes
 // so multiple user profiles wouldn't fit. Preferences was limited to a single putBytes of ~3000 bytes.
 // So we moved again to SPIFFs. It's being replaced by LittleFS so here we are.
+//
+// Return true if profile name was updated
+bool loadSettingsUsingTempSetting(bool startFromDefault)
+{
+    bool loadSuccessful;
+    bool profileNameUpdate;
+    bool settingsAllocated;
+    struct Settings * tempSettings;
+
+    // Allocate the tempSettings structure
+    settingsAllocated = false;
+    tempSettings = (struct Settings *)rtkMalloc(sizeof(*tempSettings), "loadSettings tempSettings");
+    if (tempSettings)
+    {
+        settingsAllocated = true;
+        if (settings.debugSettings)
+            systemPrintf("Allocated tempSettings: %p\r\n", (void *)tempSettings);
+
+        // Initialize the temporary settings
+        if (startFromDefault)
+            getDefaultSettings(tempSettings);
+        else
+            memcpy(tempSettings, &settings, sizeof(settings));
+    }
+    else
+    {
+        systemPrintf("ERROR: loadSettings failed to allocate tempSettings, using settings!\r\n");
+        reportHeapNow(true);
+        tempSettings = &settings;
+    }
+
+    // If we have a profile in both LFS and SD, the SD settings will overwrite LFS
+    // This will fail if LFS has been erased, a read error occurs or the file is
+    // corrupt.
+    loadSuccessful = loadSystemSettingsFromFileLFS(settingsFileName, tempSettings);
+    if (settingsAllocated)
+    {
+        if (loadSuccessful)
+            // Update the settings
+            memcpy(&settings, tempSettings, sizeof(settings));
+
+        // Restore the temporary settings upon load failure
+        else if (startFromDefault)
+            getDefaultSettings(tempSettings);
+        else
+            memcpy(tempSettings, &settings, sizeof(settings));
+    }
+
+    // Temporarily store any variables from LFS that should override SD
+    int resetCount = tempSettings->resetCount;
+    uint32_t gnssConfigureRequest = tempSettings->gnssConfigureRequest;
+
+    // Load the settings from the SD card
+    // This will fail if no SD is present. That's OK.
+    loadSuccessful = loadSystemSettingsFromFileSD(settingsFileName, tempSettings);
+    if (settingsAllocated)
+    {
+        // Update the settings with the values read from the SD card
+        if (loadSuccessful)
+            memcpy(&settings, tempSettings, sizeof(settings));
+
+        // Done with the tempSettings
+        if (settings.debugSettings)
+            systemPrintf("Freeing tempSettings: %p\r\n", (void *)tempSettings);
+        rtkFree(tempSettings, "loadSettings tempSettings");
+
+        // Restore the LFS settings values that should override SD card values
+        settings.resetCount = resetCount; // resetCount from LFS should override SD
+
+        // Trust gnssConfigureRequest from LittleFS over SD.
+        // LittleFS may have been erased, SD could be stale.
+        settings.gnssConfigureRequest = gnssConfigureRequest;
+    }
+
+    // Change empty profile name to 'Profile1' etc
+    profileNameUpdate = (strlen(settings.profileName) == 0);
+    if (profileNameUpdate)
+        snprintf(settings.profileName, sizeof(settings.profileName), "Profile%d", profileNumber + 1);
+    return profileNameUpdate;
+}
+
+// We use the LittleFS library to store user profiles in SPIFFs
+// Move selected user profile from SPIFFs into settings struct (RAM)
+// We originally used EEPROM but it was limited to 4096 bytes. Each settings struct is ~4000 bytes
+// so multiple user profiles wouldn't fit. Preferences was limited to a single putBytes of ~3000 bytes.
+// So we moved again to SPIFFs. It's being replaced by LittleFS so here we are.
 void loadSettings()
 {
     bool loadSuccessful;

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -45,7 +45,10 @@ NVM.ino
   edited in the index.html and main.js files.
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
-bool loadSystemSettingsFromFileLFS(char *fileName, const char *findMe = nullptr, char *found = nullptr,
+bool loadSystemSettingsFromFileLFS(char *fileName,
+                                   struct Settings * tempSettings,
+                                   const char *findMe = nullptr,
+                                   char *found = nullptr,
                                    int len = 0); // Header
 bool loadSystemSettingsFromFileSD(char *fileName, const char *findMe = nullptr, char *found = nullptr,
                                   int len = 0); // Header
@@ -59,7 +62,7 @@ void loadSettings()
 {
     // If we have a profile in both LFS and SD, the SD settings will overwrite LFS
     // This will fail if LFS has been erased. That's OK.
-    loadSystemSettingsFromFileLFS(settingsFileName);
+    loadSystemSettingsFromFileLFS(settingsFileName, &settings);
 
     // Temp store any variables from LFS that should override SD
     int resetCount = settings.resetCount;
@@ -251,7 +254,7 @@ void loadSettingsPartial()
     // Set the settingsFileName used in many places
     setSettingsFileName();
 
-    loadSystemSettingsFromFileLFS(settingsFileName);
+    loadSystemSettingsFromFileLFS(settingsFileName, &settings);
 }
 
 void recordSystemSettings()
@@ -795,7 +798,11 @@ bool loadSystemSettingsFromFileSD(char *fileName, const char *findMe, char *foun
 // Returns false if a file was not opened/loaded
 // Optionally search for findMe. If findMe is found, return the remainder of the line in found.
 // Don't update settings when searching.
-bool loadSystemSettingsFromFileLFS(char *fileName, const char *findMe, char *found, int len)
+bool loadSystemSettingsFromFileLFS(char *fileName,
+                                   struct Settings * tempSettings,
+                                   const char *findMe,
+                                   char *found,
+                                   int len)
 {
     if ((findMe != nullptr) && (found != nullptr))
         *found = 0; // If searching, set found to NULL
@@ -867,7 +874,7 @@ bool loadSystemSettingsFromFileLFS(char *fileName, const char *findMe, char *fou
             if (findMe == nullptr)
             {
                 // parse each line and load into settings
-                if (parseLine(line, &settings) == false)
+                if (parseLine(line, tempSettings) == false)
                 {
                     line[strlen(line) - 1] = 0; // Remove \n for printing
                     systemPrintf("Failed to parse LFS file %s line %d: %s\r\n", fileName, lineNumber, line);
@@ -1616,7 +1623,7 @@ void setProfileName(uint8_t ProfileNumber)
 bool getProfileName(char *fileName, char *profileName, uint8_t profileNameLength)
 {
     char profileNameLFS[50];
-    loadSystemSettingsFromFileLFS(fileName, "profileName=", profileNameLFS, sizeof(profileNameLFS));
+    loadSystemSettingsFromFileLFS(fileName, nullptr, "profileName=", profileNameLFS, sizeof(profileNameLFS));
     char profileNameSD[50];
     loadSystemSettingsFromFileSD(fileName, "profileName=", profileNameSD, sizeof(profileNameSD));
 

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -251,13 +251,51 @@ bool nvmCompareSettings(struct Settings * settings1, const char * name1,
 // Used at very first boot to test for resetCounter
 void loadSettingsPartial()
 {
+    bool loadSuccessful;
+    bool settingsAllocated;
+    struct Settings * tempSettings;
+
+    // Allocate the tempSettings structure
+    settingsAllocated = false;
+    loadSuccessful = false;
+    tempSettings = (struct Settings *)rtkMalloc(sizeof(*tempSettings), "loadSettings tempSettings");
+    if (tempSettings)
+    {
+        settingsAllocated = true;
+        if (settings.debugSettings)
+            systemPrintf("Allocated tempSettings: %p\r\n", (void *)tempSettings);
+
+        // Initialize the temporary settings
+        memcpy(tempSettings, &settings, sizeof(settings));
+    }
+    else
+    {
+        systemPrintf("ERROR: loadSettings failed to allocate tempSettings, using settings!\r\n");
+        reportHeapNow(true);
+        tempSettings = &settings;
+    }
+
     // First, look up the last used profile number
     loadProfileNumber();
 
     // Set the settingsFileName used in many places
     setSettingsFileName();
 
-    loadSystemSettingsFromFileLFS(settingsFileName, &settings);
+    // If we have a profile in both LFS and SD, the SD settings will overwrite LFS
+    // This will fail if LFS has been erased, a read error occurs or the file is
+    // corrupt.
+    loadSuccessful = loadSystemSettingsFromFileLFS(settingsFileName, tempSettings);
+    if (settingsAllocated)
+    {
+        // Update the settings with the values read from NVM
+        if (loadSuccessful)
+            memcpy(&settings, tempSettings, sizeof(settings));
+
+        // Done with the tempSettings
+        if (settings.debugSettings)
+            systemPrintf("Freeing tempSettings: %p\r\n", (void *)tempSettings);
+        rtkFree(tempSettings, "loadSettings tempSettings");
+    }
 }
 
 void recordSystemSettings()

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -50,7 +50,10 @@ bool loadSystemSettingsFromFileLFS(char *fileName,
                                    const char *findMe = nullptr,
                                    char *found = nullptr,
                                    int len = 0); // Header
-bool loadSystemSettingsFromFileSD(char *fileName, const char *findMe = nullptr, char *found = nullptr,
+bool loadSystemSettingsFromFileSD(char *fileName,
+                                  struct Settings * tempSettings,
+                                  const char *findMe = nullptr,
+                                  char *found = nullptr,
                                   int len = 0); // Header
 
 // We use the LittleFS library to store user profiles in SPIFFs
@@ -69,7 +72,7 @@ void loadSettings()
     uint32_t gnssConfigureRequest = settings.gnssConfigureRequest;
 
     // This will fail if no SD is present. That's OK.
-    loadSystemSettingsFromFileSD(settingsFileName);
+    loadSystemSettingsFromFileSD(settingsFileName, &settings);
 
     settings.resetCount = resetCount; // resetCount from LFS should override SD
 
@@ -633,7 +636,11 @@ void recordSystemSettingsToFile(File *settingsFile)
 // Returns false if a file was not opened/loaded
 // Optionally search for findMe. If findMe is found, return the remainder of the line in found.
 // Don't update settings when searching.
-bool loadSystemSettingsFromFileSD(char *fileName, const char *findMe, char *found, int len)
+bool loadSystemSettingsFromFileSD(char *fileName,
+                                  struct Settings * tempSettings,
+                                  const char *findMe,
+                                  char *found,
+                                  int len)
 {
     if ((findMe != nullptr) && (found != nullptr))
         *found = 0; // If searching, set found to NULL
@@ -723,7 +730,7 @@ bool loadSystemSettingsFromFileSD(char *fileName, const char *findMe, char *foun
                     if (findMe == nullptr)
                     {
                         // parse each line and load into settings
-                        if (parseLine(line, &settings) == false)
+                        if (parseLine(line, tempSettings) == false)
                         {
                             line[strlen(line) - 1] = 0; // Remove \n for printing
                             systemPrintf("Failed to parse SD file %s line %d: %s\r\n", fileName, lineNumber, line);
@@ -1625,7 +1632,7 @@ bool getProfileName(char *fileName, char *profileName, uint8_t profileNameLength
     char profileNameLFS[50];
     loadSystemSettingsFromFileLFS(fileName, nullptr, "profileName=", profileNameLFS, sizeof(profileNameLFS));
     char profileNameSD[50];
-    loadSystemSettingsFromFileSD(fileName, "profileName=", profileNameSD, sizeof(profileNameSD));
+    loadSystemSettingsFromFileSD(fileName, nullptr, "profileName=", profileNameSD, sizeof(profileNameSD));
 
     // Zero terminate the profile name
     *profileName = 0;

--- a/Firmware/RTK_Everywhere/menuSupport.ino
+++ b/Firmware/RTK_Everywhere/menuSupport.ino
@@ -14,7 +14,7 @@ void changeProfileNumber(byte newProfileNumber, bool recordSettings)
     setSettingsFileName(); // Load the settings file name into memory (enabled profile name delete)
 
     // We need to load these settings from file so that we can record a profile name change correctly
-    bool responseLFS = loadSystemSettingsFromFileLFS(settingsFileName);
+    bool responseLFS = loadSystemSettingsFromFileLFS(settingsFileName, &settings);
     bool responseSD = loadSystemSettingsFromFileSD(settingsFileName);
 
     // If this is an empty/new profile slot, overwrite our current settings with defaults

--- a/Firmware/RTK_Everywhere/menuSupport.ino
+++ b/Firmware/RTK_Everywhere/menuSupport.ino
@@ -14,15 +14,7 @@ void changeProfileNumber(byte newProfileNumber, bool recordSettings)
     setSettingsFileName(); // Load the settings file name into memory (enabled profile name delete)
 
     // We need to load these settings from file so that we can record a profile name change correctly
-    bool responseLFS = loadSystemSettingsFromFileLFS(settingsFileName, &settings);
-    bool responseSD = loadSystemSettingsFromFileSD(settingsFileName, &settings);
-
-    // If this is an empty/new profile slot, overwrite our current settings with defaults
-    if (responseLFS == false && responseSD == false)
-    {
-        systemPrintln("No profile found: Applying default settings");
-        settingsToDefaults();
-    }
+    loadSettingsUsingTempSetting(true);
 }
 
 // Check various setting arrays (message rates, etc) to see if they need to be reset to defaults

--- a/Firmware/RTK_Everywhere/menuSupport.ino
+++ b/Firmware/RTK_Everywhere/menuSupport.ino
@@ -15,7 +15,7 @@ void changeProfileNumber(byte newProfileNumber, bool recordSettings)
 
     // We need to load these settings from file so that we can record a profile name change correctly
     bool responseLFS = loadSystemSettingsFromFileLFS(settingsFileName, &settings);
-    bool responseSD = loadSystemSettingsFromFileSD(settingsFileName);
+    bool responseSD = loadSystemSettingsFromFileSD(settingsFileName, &settings);
 
     // If this is an empty/new profile slot, overwrite our current settings with defaults
     if (responseLFS == false && responseSD == false)


### PR DESCRIPTION
This PR includes the following commits:
* Add tempSettings parameter to parseLine
* Add tempSettings parameter to loadSystemSettingsFromFileLFS
* Add tempSettings parameter to loadSystemSettingsFromFileSD
* Allocate and free tempSettings in loadSettingsPartial
* Allocate and free tempSettings in loadSettings
* Add loadSettingsUsingTempSetting routine
* Use loadSettingsUsingTempSetting