### PR TITLE
Allow TCP Server in all modes

### DIFF
--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -28,7 +28,7 @@ bool lg290pMessageEnabled(char *nmeaSentence, int sentenceLength)   {return fals
 
 void mosaicVerifyTables() {}
 void nmeaExtractStdDeviations(char *nmeaSentence, int arraySize) {}
-void processNonSBFData(SEMP_PARSE_STATE *parse) {}
+void processNonSBFData(const uint8_t * buffer, size_t length) {}
 void processUart1SBF(SEMP_PARSE_STATE *parse, uint16_t type) {}
 void processUart1SPARTN(SEMP_PARSE_STATE *parse, uint16_t type) {}
 void menuLogMosaic() {}

--- a/Firmware/RTK_Everywhere/TcpServer.ino
+++ b/Firmware/RTK_Everywhere/TcpServer.ino
@@ -105,17 +105,17 @@ const RtkMode_t tcpServerMode = RTK_MODE_ROVER | RTK_MODE_BASE_SURVEY_IN;
 
 const char *const tcpServerModeNames[] = {
     "TCP Server (Uninitialized)",
-    "TCP Server",   // TCP server running in Rover mode (non-Caster Mode)
-    "Base Caster",  // Base caster using soft AP WiFi
-    "NTRIP Caster", // Base Caster using WiFi STN
+    "TCP Server",   // TCP server running in non-Caster Mode
+    "Base Caster AP", // Base Caster using WiFi Soft AP
+    "Base Caster STN", // Base Caster using WiFi Station
 };
 
 enum tcpServerModeIds
 {
     TCP_SERVER_MODE_UNINITIALIZED,
     TCP_SERVER_MODE_SERVER,
-    TCP_SERVER_MODE_BASE_CASTER,
-    TCP_SERVER_MODE_NTRIP_CASTER,
+    TCP_SERVER_MODE_NTRIP_CASTER_AP,
+    TCP_SERVER_MODE_NTRIP_CASTER_STN,
     // Insert new modes here
     TCP_SERVER_MODE_MAX // Last entry
 };
@@ -254,13 +254,13 @@ bool tcpServerEnabled(const char **line)
             if (settings.baseCasterOverride || (settings.tcpOverWiFiStation == false))
             {
                 // Using soft AP
-                name = tcpServerModeNames[TCP_SERVER_MODE_BASE_CASTER];
+                name = tcpServerModeNames[TCP_SERVER_MODE_NTRIP_CASTER_AP];
                 port = 2101;
                 softAP = true;
             }
             else
             {
-                name = tcpServerModeNames[TCP_SERVER_MODE_NTRIP_CASTER];
+                name = tcpServerModeNames[TCP_SERVER_MODE_NTRIP_CASTER_STN];
                 // Using WiFi station
                 port = settings.tcpServerPort;
                 softAP = false;

--- a/Firmware/RTK_Everywhere/TcpServer.ino
+++ b/Firmware/RTK_Everywhere/TcpServer.ino
@@ -240,7 +240,7 @@ bool tcpServerEnabled(const char **line)
             name = tcpServerModeNames[TCP_SERVER_MODE_SERVER];
             casterMode = false;
             port = settings.tcpServerPort;
-            softAP = false;
+            softAP = !settings.tcpOverWiFiStation; // Use soft AP if not using WiFi station
         }
 
         // Determine if the base caster should be running

--- a/Firmware/RTK_Everywhere/TcpServer.ino
+++ b/Firmware/RTK_Everywhere/TcpServer.ino
@@ -101,12 +101,11 @@ const char *const tcpServerClientStateName[] = {
 const int tcpServerClientStateNameEntries = sizeof(tcpServerClientStateName) / sizeof(tcpServerClientStateName[0]);
 
 const RtkMode_t baseCasterMode = RTK_MODE_BASE_FIXED;
-const RtkMode_t tcpServerMode = RTK_MODE_ROVER | RTK_MODE_BASE_SURVEY_IN;
 
 const char *const tcpServerModeNames[] = {
     "TCP Server (Uninitialized)",
-    "TCP Server",   // TCP server running in non-Caster Mode
-    "Base Caster AP", // Base Caster using WiFi Soft AP
+    "TCP Server",      // TCP server running in non-Caster Mode
+    "Base Caster AP",  // Base Caster using WiFi Soft AP
     "Base Caster STN", // Base Caster using WiFi Station
 };
 
@@ -235,7 +234,7 @@ bool tcpServerEnabled(const char **line)
         }
 
         // Determine if the TCP server should be running
-        if ((EQ_RTK_MODE(tcpServerMode) && settings.enableTcpServer))
+        if (settings.enableTcpServer)
         {
             // TCP server running in Rover mode
             name = tcpServerModeNames[TCP_SERVER_MODE_SERVER];


### PR DESCRIPTION
Remove rover requirement. Allow TCP Server over AP.