### PR TITLE
Remove tcpServerFlush, triggering deprecated function warning

### DIFF
--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -270,7 +270,6 @@ void tcpServerZeroTail() {}
 uint8_t tcpServerDataAvailable() {return 0;}
 uint8_t tcpServerRead() {return 0;}
 int tcpServerWrite(const uint8_t *buffer, int length) {return 0;}
-void tcpServerFlush() {}
 bool tcpServerInRemoteConfig() {return false;}
 void tcpServerDisableEndpoint() {}
 

--- a/Firmware/RTK_Everywhere/TcpServer.ino
+++ b/Firmware/RTK_Everywhere/TcpServer.ino
@@ -921,15 +921,6 @@ int tcpServerWrite(const uint8_t *buffer, int length)
     return (tcpServerClient[tcpServerRemoteClientIndex]->write(buffer, length));
 }
 
-// Flush data to the TCP server client
-void tcpServerFlush()
-{
-    if (tcpServerInRemoteConfig() == false)
-        return; // No client in remote config mode
-
-    tcpServerClient[tcpServerRemoteClientIndex]->flush();
-}
-
 // Returns true if a remote client is in remote config mode
 bool tcpServerInRemoteConfig()
 {

--- a/Firmware/RTK_Everywhere/support.ino
+++ b/Firmware/RTK_Everywhere/support.ino
@@ -125,9 +125,6 @@ void systemFlush()
 
     // Flush active Bluetooth device, does nothing when Bluetooth is off
     bluetoothFlush();
-
-    // Flush active TCP client, does nothing when no client is connected
-    tcpServerFlush();
 }
 
 // Output a byte to the serial port


### PR DESCRIPTION
The implementation of NetworkClient::flush is broken it clears the pending receive input buffers instead of ensuring output is sent to the clients.