### PR TITLE
Soft AP uses previous WiFi channel, WiFi station saves channel in settings

### DIFF
--- a/Firmware/RTK_Everywhere/Network.ino
+++ b/Firmware/RTK_Everywhere/Network.ino
@@ -321,7 +321,7 @@ void menuTcpUdp()
         else if (incoming == 'm')
         {
             settings.mdnsEnable ^= 1;
-            networkMulticastDNSUpdate();
+            networkMulticastDNSUpdate(wifiSoftApOnline);
         }
 
         else if (settings.mdnsEnable && (incoming == 'n'))
@@ -511,7 +511,7 @@ void networkConsumerAdd(NETCONSUMER_t consumer, NetIndex_t network, const char *
                 networkDisplayStatus();
         }
 
-        // When Web Config is started, all consumers are stopped marking the networkPriority as offline. 
+        // When Web Config is started, all consumers are stopped marking the networkPriority as offline.
         // If the ethernet interface is running, mark the network priority so that consumers within Web Config will use it
         if(networkPriority == NETWORK_OFFLINE && ethernetLinkUp() == true)
         {
@@ -526,7 +526,7 @@ void networkConsumerAdd(NETCONSUMER_t consumer, NetIndex_t network, const char *
             if(settings.debugNetworkLayer)
                 systemPrintf("Network: WiFi station interface running, setting WiFi as highest network priority\r\n");
             networkPriority = 1;
-        }        
+        }
     }
     else
     {
@@ -1588,7 +1588,7 @@ bool networkMulticastDNSStart(NetIndex_t index)
         networkMdnsRequests |= bitMask;
 
         // Start mDNS on this interface
-        mdnsStarted = networkMulticastDNSUpdate();
+        mdnsStarted = networkMulticastDNSUpdate(wifiSoftApOnline);
     }
     return mdnsStarted;
 }
@@ -1609,7 +1609,7 @@ bool networkMulticastDNSStop(NetIndex_t index)
         networkMdnsRequests &= ~bitMask;
 
         // Stop mDNS on this interface
-        mdnsStopped = networkMulticastDNSUpdate();
+        mdnsStopped = networkMulticastDNSUpdate(wifiSoftApOnline);
     }
     return mdnsStopped;
 }
@@ -1633,13 +1633,13 @@ bool networkMulticastDNSStop()
     // Restart mDNS on the highest priority network
     if ((startIndex < NETWORK_OFFLINE) && networkInterfaceTable[startIndex].mDNS)
         networkMdnsRequests |= 1 << startIndex;
-    return networkMulticastDNSUpdate();
+    return networkMulticastDNSUpdate(wifiSoftApOnline);
 }
 
 //----------------------------------------
 // Start multicast DNS
 //----------------------------------------
-bool networkMulticastDNSUpdate()
+bool networkMulticastDNSUpdate(bool wifiRunning)
 {
     NetMask_t deltaMask;
     NetMask_t requests;
@@ -1648,6 +1648,7 @@ bool networkMulticastDNSUpdate()
     // Determine if mDNS needs to restart
     status = true;
     requests = networkMdnsRequests;
+    requests |= wifiRunning ? (1 << NETWORK_WIFI_AP) : 0;
 
     // Update the mDNS state
     if (settings.mdnsEnable == false)
@@ -2157,7 +2158,7 @@ void networkSoftApConsumerAdd(NETCONSUMER_t consumer, const char *fileName, uint
             if (settings.debugNetworkLayer)
                 networkDisplayStatus();
         }
-        
+
         // If the WiFi station interface is running, mark the network priority so that consumers within Soft AP will use it
         if(networkPriority == NETWORK_OFFLINE && wifiStationRunning == true)
         {
@@ -2505,7 +2506,7 @@ void networkUpdate()
 
     // Update the network services
     // Start or stop mDNS
-    networkMulticastDNSUpdate();
+    networkMulticastDNSUpdate(wifiSoftApOnline);
 
     // Update the network services
     DMW_n("mqttClientUpdate");

--- a/Firmware/RTK_Everywhere/WebServer.ino
+++ b/Firmware/RTK_Everywhere/WebServer.ino
@@ -215,21 +215,6 @@ bool webServerAssignResources(int httpPort = 80)
         }
         memset(incomingSettings, 0, AP_CONFIG_SETTING_SIZE);
 
-        // Note: MDNS should probably be begun by networkMulticastDNSUpdate, but that doesn't seem to be happening...
-        //       Is the networkInterface aware that AP needs it? Let's start it manually...
-        if (MDNS.begin(&settings.mdnsHostName[0]) == false)
-        {
-            systemPrintln("Error setting up MDNS responder!");
-        }
-        else
-        {
-            if (settings.debugNetworkLayer)
-                systemPrintf("mDNS started as %s.local\r\n", settings.mdnsHostName);
-        }
-
-        if (settings.mdnsEnable == true)
-            MDNS.addService("http", "tcp", settings.httpPort); // Add service to MDNS
-
         if (settings.debugWebServer == true)
             systemPrintln("Web Server: Started");
         reportHeapNow(false);

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -1331,7 +1331,7 @@ RTK_WIFI::RTK_WIFI(bool verbose)
       _apGatewayAddress{IPAddress("192.168.4.1")}, _apIpAddress{IPAddress("192.168.4.1")},
       _apMacAddress{0, 0, 0, 0, 0, 0}, _apSubnetMask{IPAddress("255.255.255.0")},
       _scanRunning{false}, _staIpAddress{IPAddress((uint32_t)0)}, _staIpType{0}, _staMacAddress{0, 0, 0, 0, 0, 0},
-      _staRemoteApSsid{nullptr}, _staRemoteApPassword{nullptr}, _started{false}, _stationChannel{0},
+      _staRemoteApSsid{nullptr}, _staRemoteApPassword{nullptr}, _started{false},
       _usingDefaultChannel{true}, _verbose{verbose}
 {
     wifiChannel = 0;
@@ -2013,20 +2013,6 @@ bool RTK_WIFI::startAp(bool forceAP)
 }
 
 //*********************************************************************
-// Get the station channel
-WIFI_CHANNEL_t RTK_WIFI::stationChannelGet()
-{
-    return _stationChannel;
-}
-
-//*********************************************************************
-// Set the station channel
-void RTK_WIFI::stationChannelSet(WIFI_CHANNEL_t channel)
-{
-    _stationChannel = channel;
-}
-
-//*********************************************************************
 // Connect the station to a remote AP
 // Return true if the connection was successful and false upon failure.
 bool RTK_WIFI::stationConnectAP()
@@ -2440,9 +2426,8 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
     //
     // The priority order for the channel is:
     //      1. Active channel (not using default channel)
-    //      2. _stationChannel
     //      3. Remote AP channel determined by scan
-    //      6. Channel 1
+    //      6. Use the previous channel (defaults to channel 1)
     //****************************************
 
     // Determine if there is an active channel
@@ -2454,14 +2439,6 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         channel = wifiChannel;
         if (settings.debugWifiState && _verbose)
             systemPrintf("channel: %d, active channel\r\n", channel);
-    }
-
-    // Use the station channel if specified
-    else if (_stationChannel && (starting & WIFI_STA_ONLINE))
-    {
-        channel = _stationChannel;
-        if (settings.debugWifiState && _verbose)
-            systemPrintf("channel: %d, WiFi station channel\r\n", channel);
     }
 
     // Determine if a scan for remote APs is needed
@@ -2476,10 +2453,10 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
             stopping |= WIFI_START_ESP_NOW;
     }
 
-    // No channel specified and scan not being done, use the default channel
+    // No channel specified and scan not being done, use the previous channel
     else
     {
-        channel = WIFI_DEFAULT_CHANNEL;
+        channel = settings.wifiChannel;
         _usingDefaultChannel = true;
         if (settings.debugWifiState && _verbose)
             systemPrintf("channel: %d, default channel\r\n", channel);

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -390,6 +390,8 @@ void menuWiFi()
         systemPrint("c) Captive Portal: ");
         systemPrintf("%s\r\n", settings.enableCaptivePortal ? "Enabled" : "Disabled");
 
+        systemPrintf("d) Set default WiFi channel: %d\r\n", wifiChannel);
+
         systemPrintln("x) Exit");
 
         byte incoming = getUserInputCharacterNumber();
@@ -423,6 +425,27 @@ void menuWiFi()
         {
             settings.enableCaptivePortal ^= 1;
         }
+
+        // Set the default WiFi channel
+        else if (incoming == 'd')
+        {
+            if (getNewSetting("Enter the default WiFi channel", 1, 14,
+                              &settings.wifiChannel) == INPUT_RESPONSE_VALID)
+            {
+                if (settings.wifiChannel == wifiChannel)
+                    systemPrintf("WiFi is already on channel %d.", settings.wifiChannel);
+                else
+                {
+                    if (wifiSoftApRunning || wifiStationRunning)
+                        systemPrintf("Restart WiFi to use channel %d.", settings.wifiChannel);
+                    else if (wifiEspNowRunning)
+                        systemPrintf("Restart ESP-NOW to use channel %d.", settings.wifiChannel);
+                    else
+                        systemPrintf("Please start ESP-NOW to use channel %d.", settings.wifiChannel);
+                }
+            }
+        }
+
         else if (incoming == 'x')
             break;
         else if (incoming == INPUT_RESPONSE_GETCHARACTERNUMBER_EMPTY)

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -541,6 +541,7 @@ void wifiDisplayNetworkData()
         }
     }
     systemPrintf("%s: %s%s\r\n", wifiSoftApName, status, netif->isDefault() ? ", default" : "");
+    systemPrintf("    Channel: %d\r\n", settings.wifiChannel);
     hostName = netif->getHostname();
     if (hostName)
         systemPrintf("    Host Name: %s\r\n", hostName);

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -683,20 +683,6 @@ void wifiPromiscuousRxHandler(void *buf, wifi_promiscuous_pkt_type_t type)
 }
 
 //*********************************************************************
-// Get the soft AP channel
-WIFI_CHANNEL_t wifiSoftApChannelGet()
-{
-    return wifi.softApChannelGet();
-}
-
-//*********************************************************************
-// Set the soft AP channel
-void wifiSoftApChannelSet(WIFI_CHANNEL_t channel)
-{
-    wifi.softApChannelSet(channel);
-}
-
-//*********************************************************************
 // Get the broadcast IP address being used for the software access point (AP)
 // Outputs:
 //   Returns an IPAddress object containing the IP address used by the
@@ -1341,7 +1327,7 @@ void wifiVerifyTables()
 //   verbose: Set to true to display additional WiFi debug data
 // For AP on RTK Firmware, we set the Gateway to 192.168.4.1, not 0.0.0.0. Let's do the same here.
 RTK_WIFI::RTK_WIFI(bool verbose)
-    : _apChannel{0}, _apCount{0}, _apDnsAddress{IPAddress((uint32_t)0)}, _apFirstDhcpAddress{IPAddress("192.168.4.32")},
+    : _apCount{0}, _apDnsAddress{IPAddress((uint32_t)0)}, _apFirstDhcpAddress{IPAddress("192.168.4.32")},
       _apGatewayAddress{IPAddress("192.168.4.1")}, _apIpAddress{IPAddress("192.168.4.1")},
       _apMacAddress{0, 0, 0, 0, 0, 0}, _apSubnetMask{IPAddress("255.255.255.0")},
       _scanRunning{false}, _staIpAddress{IPAddress((uint32_t)0)}, _staIpType{0}, _staMacAddress{0, 0, 0, 0, 0, 0},
@@ -1777,24 +1763,6 @@ bool RTK_WIFI::setWiFiProtocols(wifi_interface_t interface, bool enableWiFiProto
 
     // Return the final status
     return started;
-}
-
-//*********************************************************************
-// Get the soft AP channel
-// Outputs:
-//   Returns the requested soft AP channel
-WIFI_CHANNEL_t RTK_WIFI::softApChannelGet()
-{
-    return _apChannel;
-}
-
-//*********************************************************************
-// Set the soft AP channel
-// Inputs:
-//   channel: Request the channel for WiFi soft AP
-void RTK_WIFI::softApChannelSet(WIFI_CHANNEL_t channel)
-{
-    _apChannel = channel;
 }
 
 //*********************************************************************
@@ -2474,7 +2442,6 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
     //      1. Active channel (not using default channel)
     //      2. _stationChannel
     //      3. Remote AP channel determined by scan
-    //      5. _apChannel
     //      6. Channel 1
     //****************************************
 
@@ -2507,14 +2474,6 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         // Restart ESP-NOW if necessary
         if (wifiEspNowRunning)
             stopping |= WIFI_START_ESP_NOW;
-    }
-
-    // Determine if the AP channel was specified
-    else if (_apChannel && ((starting | _started) & WIFI_AP_ONLINE))
-    {
-        channel = _apChannel;
-        if (settings.debugWifiState && _verbose)
-            systemPrintf("channel: %d, soft AP channel\r\n", channel);
     }
 
     // No channel specified and scan not being done, use the default channel

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -587,20 +587,6 @@ void wifiDisplayState()
 }
 
 //*********************************************************************
-// Get the ESP-NOW channel
-WIFI_CHANNEL_t wifiEspNowChannelGet()
-{
-    return wifi.espNowChannelGet();
-}
-
-//*********************************************************************
-// Set the ESP-NOW channel
-void wifiEspNowChannelSet(WIFI_CHANNEL_t channel)
-{
-    wifi.espNowChannelSet(channel);
-}
-
-//*********************************************************************
 // Stop ESP-NOW
 // Inputs:
 //   fileName: Name of file calling the enable routine
@@ -1357,7 +1343,7 @@ void wifiVerifyTables()
 RTK_WIFI::RTK_WIFI(bool verbose)
     : _apChannel{0}, _apCount{0}, _apDnsAddress{IPAddress((uint32_t)0)}, _apFirstDhcpAddress{IPAddress("192.168.4.32")},
       _apGatewayAddress{IPAddress("192.168.4.1")}, _apIpAddress{IPAddress("192.168.4.1")},
-      _apMacAddress{0, 0, 0, 0, 0, 0}, _apSubnetMask{IPAddress("255.255.255.0")}, _espNowChannel{0},
+      _apMacAddress{0, 0, 0, 0, 0, 0}, _apSubnetMask{IPAddress("255.255.255.0")},
       _scanRunning{false}, _staIpAddress{IPAddress((uint32_t)0)}, _staIpType{0}, _staMacAddress{0, 0, 0, 0, 0, 0},
       _staRemoteApSsid{nullptr}, _staRemoteApPassword{nullptr}, _started{false}, _stationChannel{0},
       _usingDefaultChannel{true}, _verbose{verbose}
@@ -1551,24 +1537,6 @@ bool RTK_WIFI::enable(bool enableESPNow, bool enableSoftAP, bool enableStation, 
     if (settings.debugWifiState && _verbose)
         systemPrintf("WiFi: RTK_WIFI::enable returning %s\r\n", status ? "true" : "false");
     return status;
-}
-
-//*********************************************************************
-// Get the ESP-NOW channel
-// Outputs:
-//   Returns the requested ESP-NOW channel
-WIFI_CHANNEL_t RTK_WIFI::espNowChannelGet()
-{
-    return _espNowChannel;
-}
-
-//*********************************************************************
-// Set the ESP-NOW channel
-// Inputs:
-//   channel: New ESP-NOW channel number
-void RTK_WIFI::espNowChannelSet(WIFI_CHANNEL_t channel)
-{
-    _espNowChannel = channel;
 }
 
 //*********************************************************************
@@ -2506,7 +2474,6 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
     //      1. Active channel (not using default channel)
     //      2. _stationChannel
     //      3. Remote AP channel determined by scan
-    //      4. _espNowChannel
     //      5. _apChannel
     //      6. Channel 1
     //****************************************
@@ -2540,14 +2507,6 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
         // Restart ESP-NOW if necessary
         if (wifiEspNowRunning)
             stopping |= WIFI_START_ESP_NOW;
-    }
-
-    // Determine if the ESP-NOW channel was specified
-    else if (_espNowChannel & ((starting | _started) & WIFI_EN_ESP_NOW_ONLINE))
-    {
-        channel = _espNowChannel;
-        if (settings.debugWifiState && _verbose)
-            systemPrintf("channel: %d, ESP-NOW channel\r\n", channel);
     }
 
     // Determine if the AP channel was specified

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -749,6 +749,9 @@ const char *wifiSoftApGetSsid()
 //   Returns the status of WiFi soft AP stop
 bool wifiSoftApOff(const char *fileName, uint32_t lineNumber)
 {
+    // Disable mDNS
+    networkMulticastDNSUpdate(false);
+
     // Display the call
     if (settings.debugWifiState)
         systemPrintf("wifiSoftApOff called in %s at line %d\r\n", fileName, lineNumber);
@@ -765,6 +768,8 @@ bool wifiSoftApOff(const char *fileName, uint32_t lineNumber)
 //   Returns the status of WiFi soft AP start
 bool wifiSoftApOn(const char *fileName, uint32_t lineNumber)
 {
+    bool status;
+
     // Display the call
     if (settings.debugWifiState)
         systemPrintf("wifiSoftApOn called in %s at line %d\r\n", fileName, lineNumber);
@@ -775,7 +780,11 @@ bool wifiSoftApOn(const char *fileName, uint32_t lineNumber)
     else
         wifiSoftApSsid = "RTK";
 
-    return wifi.enable(wifiEspNowRunning, true, wifiStationRunning, __FILE__, __LINE__);
+    status = wifi.enable(wifiEspNowRunning, true, wifiStationRunning, __FILE__, __LINE__);
+
+    // Enable mDNS
+    networkMulticastDNSUpdate(wifiSoftApOnline);
+    return status;
 }
 
 //*********************************************************************

--- a/Firmware/RTK_Everywhere/WiFi.ino
+++ b/Firmware/RTK_Everywhere/WiFi.ino
@@ -2426,8 +2426,8 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
     //
     // The priority order for the channel is:
     //      1. Active channel (not using default channel)
-    //      3. Remote AP channel determined by scan
-    //      6. Use the previous channel (defaults to channel 1)
+    //      2. Remote AP channel determined by scan
+    //      3. Use the previous saved channel (defaults to channel 1)
     //****************************************
 
     // Determine if there is an active channel
@@ -2836,6 +2836,13 @@ bool RTK_WIFI::stopStart(WIFI_ACTION_t stopping, WIFI_ACTION_t starting)
             if (!channel)
                 channel = WIFI_DEFAULT_CHANNEL;
             wifiChannel = channel;
+
+            // Save the updated channel
+            if (settings.wifiChannel != wifiChannel)
+            {
+                settings.wifiChannel = wifiChannel;
+                recordSystemSettings();
+            }
 
             // Display the selected channel
             if (settings.debugWifiState)

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -469,8 +469,6 @@ void menuRadio()
 
             systemPrintln("3) Forget all radios");
 
-            systemPrintf("4) Current channel: %d\r\n", wifiChannel);
-
             if (settings.debugEspNow == true)
             {
                 systemPrintln("5) Add dummy radio");
@@ -478,6 +476,7 @@ void menuRadio()
                 systemPrintln("7) Broadcast dummy data");
             }
         }
+
 #endif // COMPILE_ESPNOW
 
         if (present.radio_lora == true)
@@ -510,6 +509,8 @@ void menuRadio()
                                  settings.loraSerialInteractionTimeout_s);
             }
         }
+
+        systemPrintf("20) Set default WiFi channel: %d\r\n", wifiChannel);
 
         // Display Bluetooth menu
         mmDisplayBluetoothRadioMenu('b', bluetoothUserChoice);
@@ -579,24 +580,6 @@ void menuRadio()
                 }
                 settings.espnowPeerCount = 0;
                 systemPrintln("Radios forgotten");
-            }
-        }
-        else if (settings.enableEspNow == true && incoming == 4)
-        {
-            if (getNewSetting("Enter the WiFi channel to use for ESP-NOW communication", 1, 14,
-                              &settings.wifiChannel) == INPUT_RESPONSE_VALID)
-            {
-                if (settings.wifiChannel == wifiChannel)
-                    systemPrintf("WiFi is already on channel %d.", settings.wifiChannel);
-                else
-                {
-                    if (wifiSoftApRunning || wifiStationRunning)
-                        systemPrintf("Restart WiFi to use channel %d.", settings.wifiChannel);
-                    else if (wifiEspNowRunning)
-                        systemPrintf("Restart ESP-NOW to use channel %d.", settings.wifiChannel);
-                    else
-                        systemPrintf("Please start ESP-NOW to use channel %d.", settings.wifiChannel);
-                }
             }
         }
         else if (settings.enableEspNow == true && incoming == 5 && settings.debugEspNow == true)
@@ -674,6 +657,26 @@ void menuRadio()
             getNewSetting("Enter the number of seconds without user serial that must elapse before LoRa radio goes "
                           "into dedicated listening mode",
                           10, 600, &settings.loraSerialInteractionTimeout_s);
+        }
+
+        // Set the default WiFi channel
+        else if (incoming == 20)
+        {
+            if (getNewSetting("Enter the default WiFi channel", 1, 14,
+                              &settings.wifiChannel) == INPUT_RESPONSE_VALID)
+            {
+                if (settings.wifiChannel == wifiChannel)
+                    systemPrintf("WiFi is already on channel %d.", settings.wifiChannel);
+                else
+                {
+                    if (wifiSoftApRunning || wifiStationRunning)
+                        systemPrintf("Restart WiFi to use channel %d.", settings.wifiChannel);
+                    else if (wifiEspNowRunning)
+                        systemPrintf("Restart ESP-NOW to use channel %d.", settings.wifiChannel);
+                    else
+                        systemPrintf("Please start ESP-NOW to use channel %d.", settings.wifiChannel);
+                }
+            }
         }
 
         else if (incoming == 'x')

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -586,20 +586,16 @@ void menuRadio()
             if (getNewSetting("Enter the WiFi channel to use for ESP-NOW communication", 1, 14,
                               &settings.wifiChannel) == INPUT_RESPONSE_VALID)
             {
-                wifiEspNowChannelSet(settings.wifiChannel);
-                if (settings.wifiChannel)
+                if (settings.wifiChannel == wifiChannel)
+                    systemPrintf("WiFi is already on channel %d.", settings.wifiChannel);
+                else
                 {
-                    if (settings.wifiChannel == wifiChannel)
-                        systemPrintf("WiFi is already on channel %d.", settings.wifiChannel);
+                    if (wifiSoftApRunning || wifiStationRunning)
+                        systemPrintf("Restart WiFi to use channel %d.", settings.wifiChannel);
+                    else if (wifiEspNowRunning)
+                        systemPrintf("Restart ESP-NOW to use channel %d.", settings.wifiChannel);
                     else
-                    {
-                        if (wifiSoftApRunning || wifiStationRunning)
-                            systemPrintf("Restart WiFi to use channel %d.", settings.wifiChannel);
-                        else if (wifiEspNowRunning)
-                            systemPrintf("Restart ESP-NOW to use channel %d.", settings.wifiChannel);
-                        else
-                            systemPrintf("Please start ESP-NOW to use channel %d.", settings.wifiChannel);
-                    }
+                        systemPrintf("Please start ESP-NOW to use channel %d.", settings.wifiChannel);
                 }
             }
         }
@@ -672,7 +668,7 @@ void menuRadio()
         }
         else if (present.radio_lora == true && settings.enableLora == true && incoming == 13)
             settings.loraSaveSettingsToFlash ^= 1;
-        else if (present.radio_lora == true && settings.enableLora == true 
+        else if (present.radio_lora == true && settings.enableLora == true
                  && present.loraDedicatedUart == false && incoming == 14)
         {
             getNewSetting("Enter the number of seconds without user serial that must elapse before LoRa radio goes "

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2149,7 +2149,6 @@ class RTK_WIFI
     IPAddress _apIpAddress;     // IP address of the soft AP
     uint8_t _apMacAddress[6];   // MAC address of the soft AP
     IPAddress _apSubnetMask;    // Subnet mask for soft AP
-    WIFI_CHANNEL_t _espNowChannel;  // Channel required for ESPNow, zero (0) use wifiChannel
     volatile bool _scanRunning; // Scan running
     int _staAuthType;           // Authorization type for the remote AP
     bool _staConnected;         // True when station is connected
@@ -2329,16 +2328,6 @@ class RTK_WIFI
                 bool enableStation,
                 const char * fileName,
                 int lineNumber);
-
-    // Get the ESP-NOW channel
-    // Outputs:
-    //   Returns the requested ESP-NOW channel
-    WIFI_CHANNEL_t espNowChannelGet();
-
-    // Set the ESP-NOW channel
-    // Inputs:
-    //   channel: New ESP-NOW channel number
-    void espNowChannelSet(WIFI_CHANNEL_t channel);
 
     // Get the ESP-NOW status
     // Outputs:

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2158,7 +2158,6 @@ class RTK_WIFI
     const char * _staRemoteApSsid;      // SSID of remote AP
     const char * _staRemoteApPassword;  // Password of remote AP
     volatile WIFI_ACTION_t _started;    // Components that are started and running
-    WIFI_CHANNEL_t _stationChannel; // Channel required for station, zero (0) use wifiChannel
     bool _usingDefaultChannel;  // Using default WiFi channel
     bool _verbose;              // True causes more debug output to be displayed
 
@@ -2383,16 +2382,6 @@ class RTK_WIFI
     //    Returns true if the soft AP was started successfully and false
     //    otherwise
     bool startAp(bool forceAP);
-
-    // Get the station channel
-    // Outputs:
-    //   Returns the requested station channel
-    WIFI_CHANNEL_t stationChannelGet();
-
-    // Set the station channel
-    // Inputs:
-    //   channel: Request the channel for WiFi station
-    void stationChannelSet(WIFI_CHANNEL_t channel);
 
     // Get the WiFi station IP address
     // Returns the IP address of the WiFi station

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1991,6 +1991,9 @@ enum NetworkTypes
     // Add new networks above this line in default priority order
     NETWORK_ANY,            // 3
     NETWORK_MAX = NETWORK_ANY,
+
+    // Reserved: Only used to manage mDNS
+    NETWORK_WIFI_AP         // 4
 };
 
 #ifdef  COMPILE_NETWORK

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2141,7 +2141,6 @@ class RTK_WIFI
 {
   private:
 
-    WIFI_CHANNEL_t _apChannel;  // Channel required for soft AP, zero (0) use wifiChannel
     int16_t _apCount;           // The number or remote APs detected in the WiFi network
     IPAddress _apDnsAddress;    // DNS IP address to use while translating names into IP addresses
     IPAddress _apFirstDhcpAddress;  // First IP address to use for DHCP
@@ -2346,16 +2345,6 @@ class RTK_WIFI
     // Outputs:
     //   Returns the current WiFi channel number
     WIFI_CHANNEL_t getChannel();
-
-    // Get the soft AP channel
-    // Outputs:
-    //   Returns the requested soft AP channel
-    WIFI_CHANNEL_t softApChannelGet();
-
-    // Set the soft AP channel
-    // Inputs:
-    //   channel: Request the channel for WiFi soft AP
-    void softApChannelSet(WIFI_CHANNEL_t channel);
 
     // Configure the soft AP
     // Inputs:


### PR DESCRIPTION
This PR includes the following commits:
* Remove unused _espNowChannel from RTK_WIFI
* Remove unused _apChannel from RTK_WIFI
* Remove unused _stationChannel from RTK_WIFI
* Use the previous channel when starting without a scan
* Set default WiFi channel in Radio and WiFi menus
* Display the WiFi channel number in system menu header
* Add soft AP into requests that can start/stop mDNS
* Stop and start mDNS when using WiFi Soft AP
* Don't start mDSN in the web server
