### PR TITLE
Correct RTCM logging to accessible SD on Facet FPM(T)

### DIFF
--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.h
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.h
@@ -675,10 +675,7 @@ class GNSS_MOSAIC : GNSS
     uint8_t getActiveMessageCount();
 
     // Return the number of active/enabled RTCM messages
-    uint8_t getActiveRtcmMessageCount()
-    {
-        return (0);
-    }
+    uint8_t getActiveRtcmMessageCount();
 
     // Get the altitude
     // Outputs:

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
@@ -429,7 +429,11 @@ bool GNSS_MOSAIC::checkNMEARates()
 //----------------------------------------
 bool GNSS_MOSAIC::checkPPPRates()
 {
-    return settings.enableLoggingRINEX;
+    if (settings.enableLoggingRINEX)
+        return true;
+
+    // Determine which state we are in
+    return (getActiveRtcmMessageCount() == (inRoverMode() ? 0 : 3));
 }
 
 // Enable / disable RINEX logging
@@ -1068,7 +1072,7 @@ uint8_t GNSS_MOSAIC::getLoggingType()
     LoggingType logType = LOGGING_CUSTOM;
 
     int messageCount = getActiveMessageCount();
-    if (messageCount == 5 || messageCount == 7)
+    if (messageCount == 5 || messageCount == 8) // Default NMEA 5. Default Base RTCM 3
     {
         if (checkNMEARates())
         {

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
@@ -874,6 +874,14 @@ uint8_t GNSS_MOSAIC::getActiveMessageCount()
         if (settings.mosaicMessageStreamNMEA[x] > 0)
             count++;
 
+    count += getActiveRtcmMessageCount();
+
+    return (count);
+}
+uint8_t GNSS_MOSAIC::getActiveRtcmMessageCount()
+{
+    uint8_t count = 0;
+
     // Determine which state we are in
     if (inRoverMode() == true)
     {

--- a/Firmware/RTK_Everywhere/Logging.ino
+++ b/Firmware/RTK_Everywhere/Logging.ino
@@ -391,8 +391,7 @@ bool beginLogging(const char *customFileName)
 
                 // SparkFun RTK Express v1.10-Feb 11 2022
                 char firmwareVersion[30]; // v1.3 December 31 2021
-                firmwareVersion[0] = 'v';
-                firmwareVersionGet(&firmwareVersion[1], sizeof(firmwareVersion) - 1, true);
+                firmwareVersionGet(firmwareVersion, sizeof(firmwareVersion), true);
                 createNMEASentence(CUSTOM_NMEA_TYPE_SYSTEM_VERSION, nmeaMessage, sizeof(nmeaMessage),
                                    firmwareVersion); // textID, buffer, sizeOfBuffer, text
                 logFile->println(nmeaMessage);

--- a/Firmware/RTK_Everywhere/menuFirmware.ino
+++ b/Firmware/RTK_Everywhere/menuFirmware.ino
@@ -142,7 +142,7 @@ void firmwareVersionFormat(uint8_t major, uint8_t minor, char *buffer, int buffe
 
     // Construct the full or release candidate version number
     prefix = (ENABLE_DEVELOPER || (major >= 99)) ? 'd' : 'v';
-    if (enableRCFirmware && (bufferLength >= 21))
+    if (includeDate && (bufferLength >= 21))
         // 123456789012345678901
         // pxxx.yyy-dd-mmm-yyyy0
         snprintf(buffer, bufferLength, "%c%d.%d-%s", prefix, major, minor, __DATE__);


### PR DESCRIPTION
These changes allow RTCM to be logged to the accessible SD on Facet FPM(T)

Please see #1020 for the full details

Also fixes the double v in the custom NMEA GNTXT firmware version message