### PR TITLE
Add CRC to the settings file, validate the CRC when loading the settings file.

### DIFF
--- a/Firmware/RTK_Everywhere/GNSS.h
+++ b/Firmware/RTK_Everywhere/GNSS.h
@@ -455,7 +455,7 @@ typedef bool (*GNSS_GET_SETTING_VALUE)(RTK_Settings_Types type, const char *suff
 typedef bool (*GNSS_NEW_SETTING_VALUE)(struct Settings * tempSettings, RTK_Settings_Types type, const char *suffix, int qualifier, double d);
 
 // Write settings to a file
-typedef bool (*GNSS_SETTING_TO_FILE)(File *settingsFile, RTK_Settings_Types type, int settingsIndex);
+typedef bool (*GNSS_SETTING_TO_FILE)(char * line, size_t lineSize, RTK_Settings_Types type, int settingsIndex);
 
 typedef struct _GNSS_SUPPORT_ROUTINES
 {

--- a/Firmware/RTK_Everywhere/GNSS.ino
+++ b/Firmware/RTK_Everywhere/GNSS.ino
@@ -1091,12 +1091,12 @@ bool gnssNewSettingValue(struct Settings * tempSettings, RTK_Settings_Types type
 //----------------------------------------
 // Called by recordSystemSettingsToFile to save GNSS specific settings
 //----------------------------------------
-bool gnssSettingsToFile(File *settingsFile, RTK_Settings_Types type, int settingsIndex)
+bool gnssSettingsToFile(char * line, size_t lineSize, RTK_Settings_Types type, int settingsIndex)
 {
     for (int index = 0; index < GNSS_SUPPORT_ROUTINES_ENTRIES; index++)
     {
         if (gnssSupportRoutines[index]._settingToFile &&
-            gnssSupportRoutines[index]._settingToFile(settingsFile, type, settingsIndex))
+            gnssSupportRoutines[index]._settingToFile(line, lineSize, type, settingsIndex))
             return true;
     }
     return false;

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.h
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.h
@@ -518,7 +518,7 @@ bool lg290pGetSettingValue(RTK_Settings_Types type, const char *suffix, int qual
 bool lg290pIsPresentOnFacetFP();
 void lg290pNewClass();
 bool lg290pNewSettingValue(struct Settings * tempSettings, RTK_Settings_Types type, const char *suffix, int qualifier, double d);
-bool lg290pSettingsToFile(File *settingsFile, RTK_Settings_Types type, int settingsIndex);
+bool lg290pSettingsToFile(char * line, size_t lineSize, RTK_Settings_Types type, int settingsIndex);
 
 #endif // COMPILE_LG290P
 #endif // __GNSS_LG290P_H__

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -3279,7 +3279,10 @@ bool lg290pNewSettingValue(struct Settings * tempSettings, RTK_Settings_Types ty
 //----------------------------------------
 // Called by gnssSettingsToFile to save LG290P specific settings
 //----------------------------------------
-bool lg290pSettingsToFile(File *settingsFile, RTK_Settings_Types type, int settingsIndex)
+bool lg290pSettingsToFile(char * line,
+                          size_t lineSize,
+                          RTK_Settings_Types type,
+                          int settingsIndex)
 {
     switch (type)
     {
@@ -3290,10 +3293,10 @@ bool lg290pSettingsToFile(File *settingsFile, RTK_Settings_Types type, int setti
         // Record LG290P NMEA rates
         for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
         {
-            char tempString[50]; // lg290pMessageRatesNMEA_GPGGA=2
-            snprintf(tempString, sizeof(tempString), "%s%s=%d", rtkSettingsEntries[settingsIndex].name,
+            // lg290pMessageRatesNMEA_GPGGA=2
+            snprintf(line, lineSize, "%s%s=%d\r\n", rtkSettingsEntries[settingsIndex].name,
                      lgMessagesNMEA[x].msgTextName, settings.lg290pMessageRatesNMEA[x]);
-            settingsFile->println(tempString);
+            nvmRecordStringToFile(line);
         }
     }
     break;
@@ -3301,10 +3304,10 @@ bool lg290pSettingsToFile(File *settingsFile, RTK_Settings_Types type, int setti
         // Record LG290P Rover RTCM rates
         for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
         {
-            char tempString[50]; // lg290pMessageRatesRTCMRover_RTCM1005=2
-            snprintf(tempString, sizeof(tempString), "%s%s=%d", rtkSettingsEntries[settingsIndex].name,
+            // lg290pMessageRatesRTCMRover_RTCM1005=2
+            snprintf(line, lineSize, "%s%s=%d\r\n", rtkSettingsEntries[settingsIndex].name,
                      lgMessagesRTCM[x].msgTextName, settings.lg290pMessageRatesRTCMRover[x]);
-            settingsFile->println(tempString);
+            nvmRecordStringToFile(line);
         }
     }
     break;
@@ -3312,10 +3315,10 @@ bool lg290pSettingsToFile(File *settingsFile, RTK_Settings_Types type, int setti
         // Record LG290P Base RTCM rates
         for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
         {
-            char tempString[50]; // lg290pMessageRatesRTCMBase_RTCM1005=2
-            snprintf(tempString, sizeof(tempString), "%s%s=%d", rtkSettingsEntries[settingsIndex].name,
+            // lg290pMessageRatesRTCMBase_RTCM1005=2
+            snprintf(line, lineSize, "%s%s=%d\r\n", rtkSettingsEntries[settingsIndex].name,
                      lgMessagesRTCM[x].msgTextName, settings.lg290pMessageRatesRTCMBase[x]);
-            settingsFile->println(tempString);
+            nvmRecordStringToFile(line);
         }
     }
     break;
@@ -3323,10 +3326,10 @@ bool lg290pSettingsToFile(File *settingsFile, RTK_Settings_Types type, int setti
         // Record LG290P PQTM rates
         for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
         {
-            char tempString[50]; // lg290pMessageRatesPQTM_EPE=1
-            snprintf(tempString, sizeof(tempString), "%s%s=%d", rtkSettingsEntries[settingsIndex].name,
+            // lg290pMessageRatesPQTM_EPE=1
+            snprintf(line, lineSize, "%s%s=%d\r\n", rtkSettingsEntries[settingsIndex].name,
                      lgMessagesPQTM[x].msgTextName, settings.lg290pMessageRatesPQTM[x]);
-            settingsFile->println(tempString);
+            nvmRecordStringToFile(line);
         }
     }
     break;
@@ -3334,10 +3337,10 @@ bool lg290pSettingsToFile(File *settingsFile, RTK_Settings_Types type, int setti
         // Record LG290P Constellations
         for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
         {
-            char tempString[50]; // lg290pConstellations_GLONASS=1
-            snprintf(tempString, sizeof(tempString), "%s%s=%d", rtkSettingsEntries[settingsIndex].name,
+            // lg290pConstellations_GLONASS=1
+            snprintf(line, lineSize, "%s%s=%d\r\n", rtkSettingsEntries[settingsIndex].name,
                      lg290pConstellationNames[x], settings.lg290pConstellations[x]);
-            settingsFile->println(tempString);
+            nvmRecordStringToFile(line);
         }
     }
     break;

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.h
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.h
@@ -1103,7 +1103,8 @@ bool mosaicNewSettingValue(struct Settings * tempSettings,
                            const char * suffix,
                            int qualifier,
                            double d);
-bool mosaicSettingsToFile(File *settingsFile,
+bool mosaicSettingsToFile(char * line,
+                          size_t lineSize,
                           RTK_Settings_Types type,
                           int settingsIndex);
 

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
@@ -3916,7 +3916,8 @@ bool mosaicNewSettingValue(struct Settings * tempSettings,
 //----------------------------------------
 // Called by gnssSettingsToFile to save mosaic specific settings
 //----------------------------------------
-bool mosaicSettingsToFile(File *settingsFile,
+bool mosaicSettingsToFile(char * line,
+                          size_t lineSize,
                           RTK_Settings_Types type,
                           int settingsIndex)
 {
@@ -3929,10 +3930,10 @@ bool mosaicSettingsToFile(File *settingsFile,
             // Record Mosaic Constellations
             for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
             {
-                char tempString[50]; // constellation_GLONASS=1
-                snprintf(tempString, sizeof(tempString), "%s%s=%0d", rtkSettingsEntries[settingsIndex].name,
+                // constellation_GLONASS=1
+                snprintf(line, lineSize, "%s%s=%0d\r\n", rtkSettingsEntries[settingsIndex].name,
                          mosaicSignalConstellations[x].configName, settings.mosaicConstellations[x]);
-                settingsFile->println(tempString);
+                nvmRecordStringToFile(line);
             }
         }
         break;
@@ -3940,10 +3941,10 @@ bool mosaicSettingsToFile(File *settingsFile,
             // Record Mosaic NMEA message streams
             for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
             {
-                char tempString[50]; // messageStreamNMEA_GGA=1
-                snprintf(tempString, sizeof(tempString), "%s%s=%0d", rtkSettingsEntries[settingsIndex].name,
+                // messageStreamNMEA_GGA=1
+                snprintf(line, lineSize, "%s%s=%0d\r\n", rtkSettingsEntries[settingsIndex].name,
                          mosaicMessagesNMEA[x].msgTextName, settings.mosaicMessageStreamNMEA[x]);
-                settingsFile->println(tempString);
+                nvmRecordStringToFile(line);
             }
         }
         break;
@@ -3951,10 +3952,10 @@ bool mosaicSettingsToFile(File *settingsFile,
             // Record Mosaic NMEA stream intervals
             for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
             {
-                char tempString[50]; // streamIntervalNMEA_1=1
-                snprintf(tempString, sizeof(tempString), "%s%d=%0d", rtkSettingsEntries[settingsIndex].name, x,
+                // streamIntervalNMEA_1=1
+                snprintf(line, lineSize, "%s%d=%0d\r\n", rtkSettingsEntries[settingsIndex].name, x,
                          settings.mosaicStreamIntervalsNMEA[x]);
-                settingsFile->println(tempString);
+                nvmRecordStringToFile(line);
             }
         }
         break;
@@ -3962,10 +3963,10 @@ bool mosaicSettingsToFile(File *settingsFile,
             // Record Mosaic Rover RTCM intervals
             for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
             {
-                char tempString[50]; // messageIntervalRTCMRover_RTCM1001=0.2
-                snprintf(tempString, sizeof(tempString), "%s%s=%0.2f", rtkSettingsEntries[settingsIndex].name,
+                // messageIntervalRTCMRover_RTCM1001=0.2
+                snprintf(line, lineSize, "%s%s=%0.2f\r\n", rtkSettingsEntries[settingsIndex].name,
                          mosaicRTCMv3MsgIntervalGroups[x].name, settings.mosaicMessageIntervalsRTCMv3Rover[x]);
-                settingsFile->println(tempString);
+                nvmRecordStringToFile(line);
             }
         }
         break;
@@ -3973,10 +3974,10 @@ bool mosaicSettingsToFile(File *settingsFile,
             // Record Mosaic Base RTCM intervals
             for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
             {
-                char tempString[50]; // messageIntervalRTCMBase_RTCM1001=0.2
-                snprintf(tempString, sizeof(tempString), "%s%s=%0.2f", rtkSettingsEntries[settingsIndex].name,
+                // messageIntervalRTCMBase_RTCM1001=0.2
+                snprintf(line, lineSize, "%s%s=%0.2f\r\n", rtkSettingsEntries[settingsIndex].name,
                          mosaicRTCMv3MsgIntervalGroups[x].name, settings.mosaicMessageIntervalsRTCMv3Base[x]);
-                settingsFile->println(tempString);
+                nvmRecordStringToFile(line);
             }
         }
         break;
@@ -3984,10 +3985,10 @@ bool mosaicSettingsToFile(File *settingsFile,
             // Record Mosaic Rover RTCM enabled
             for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
             {
-                char tempString[50]; // messageEnabledRTCMRover_RTCM1001=0
-                snprintf(tempString, sizeof(tempString), "%s%s=%0d", rtkSettingsEntries[settingsIndex].name,
+                // messageEnabledRTCMRover_RTCM1001=0
+                snprintf(line, lineSize, "%s%s=%0d\r\n", rtkSettingsEntries[settingsIndex].name,
                          mosaicMessagesRTCMv3[x].name, settings.mosaicMessageEnabledRTCMv3Rover[x]);
-                settingsFile->println(tempString);
+                nvmRecordStringToFile(line);
             }
         }
         break;
@@ -3995,10 +3996,10 @@ bool mosaicSettingsToFile(File *settingsFile,
             // Record Mosaic Base RTCM enabled
             for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
             {
-                char tempString[50]; // messageEnabledRTCMBase_RTCM1001=0
-                snprintf(tempString, sizeof(tempString), "%s%s=%0d", rtkSettingsEntries[settingsIndex].name,
+                // messageEnabledRTCMBase_RTCM1001=0
+                snprintf(line, lineSize, "%s%s=%0d\r\n", rtkSettingsEntries[settingsIndex].name,
                          mosaicMessagesRTCMv3[x].name, settings.mosaicMessageEnabledRTCMv3Base[x]);
-                settingsFile->println(tempString);
+                nvmRecordStringToFile(line);
             }
         }
         break;

--- a/Firmware/RTK_Everywhere/GNSS_UM980.h
+++ b/Firmware/RTK_Everywhere/GNSS_UM980.h
@@ -506,7 +506,7 @@ bool um980CreateString(RTK_Settings_Types type, int settingsIndex, char *newSett
 bool um980GetSettingValue(RTK_Settings_Types type, const char *suffix, int settingsIndex, int qualifier,
                           char *settingValueStr);
 bool um980NewSettingValue(struct Settings * tempSettings, RTK_Settings_Types type, const char *suffix, int qualifier, double d);
-bool um980SettingsToFile(File *settingsFile, RTK_Settings_Types type, int settingsIndex);
+bool um980SettingsToFile(char * line, size_t lineSize, RTK_Settings_Types type, int settingsIndex);
 
 #endif // COMPILE_UM980
 #endif // __GNSS_UM980_H__

--- a/Firmware/RTK_Everywhere/GNSS_UM980.ino
+++ b/Firmware/RTK_Everywhere/GNSS_UM980.ino
@@ -2498,7 +2498,10 @@ bool um980NewSettingValue(struct Settings * tempSettings, RTK_Settings_Types typ
 //----------------------------------------
 // Called by gnssSettingsToFile to save UM980 specific settings
 //----------------------------------------
-bool um980SettingsToFile(File *settingsFile, RTK_Settings_Types type, int settingsIndex)
+bool um980SettingsToFile(char * line,
+                         size_t lineSize,
+                         RTK_Settings_Types type,
+                         int settingsIndex)
 {
     switch (type)
     {
@@ -2509,10 +2512,10 @@ bool um980SettingsToFile(File *settingsFile, RTK_Settings_Types type, int settin
         // Record UM980 NMEA rates
         for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
         {
-            char tempString[50]; // um980MessageRatesNMEA_GPDTM=0.05
-            snprintf(tempString, sizeof(tempString), "%s%s=%0.2f", rtkSettingsEntries[settingsIndex].name,
+            // um980MessageRatesNMEA_GPDTM=0.05
+            snprintf(line, lineSize, "%s%s=%0.2f\r\n", rtkSettingsEntries[settingsIndex].name,
                      umMessagesNMEA[x].msgTextName, settings.um980MessageRatesNMEA[x]);
-            settingsFile->println(tempString);
+            nvmRecordStringToFile(line);
         }
     }
     break;
@@ -2520,10 +2523,10 @@ bool um980SettingsToFile(File *settingsFile, RTK_Settings_Types type, int settin
         // Record UM980 Rover RTCM rates
         for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
         {
-            char tempString[50]; // um980MessageRatesRTCMRover_RTCM1001=0.2
-            snprintf(tempString, sizeof(tempString), "%s%s=%0.2f", rtkSettingsEntries[settingsIndex].name,
+            // um980MessageRatesRTCMRover_RTCM1001=0.2
+            snprintf(line, lineSize, "%s%s=%0.2f\r\n", rtkSettingsEntries[settingsIndex].name,
                      umMessagesRTCM[x].msgTextName, settings.um980MessageRatesRTCMRover[x]);
-            settingsFile->println(tempString);
+            nvmRecordStringToFile(line);
         }
     }
     break;
@@ -2531,10 +2534,10 @@ bool um980SettingsToFile(File *settingsFile, RTK_Settings_Types type, int settin
         // Record UM980 Base RTCM rates
         for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
         {
-            char tempString[50]; // um980MessageRatesRTCMBase_RTCM1001=0.2
-            snprintf(tempString, sizeof(tempString), "%s%s=%0.2f", rtkSettingsEntries[settingsIndex].name,
+            // um980MessageRatesRTCMBase_RTCM1001=0.2
+            snprintf(line, lineSize, "%s%s=%0.2f\r\n", rtkSettingsEntries[settingsIndex].name,
                      umMessagesRTCM[x].msgTextName, settings.um980MessageRatesRTCMBase[x]);
-            settingsFile->println(tempString);
+            nvmRecordStringToFile(line);
         }
     }
     break;
@@ -2542,10 +2545,10 @@ bool um980SettingsToFile(File *settingsFile, RTK_Settings_Types type, int settin
         // Record UM980 Constellations
         for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
         {
-            char tempString[50]; // um980Constellations_GLONASS=1
-            snprintf(tempString, sizeof(tempString), "%s%s=%0d", rtkSettingsEntries[settingsIndex].name,
+            // um980Constellations_GLONASS=1
+            snprintf(line, lineSize, "%s%s=%0d\r\n", rtkSettingsEntries[settingsIndex].name,
                      um980ConstellationCommands[x].textName, settings.um980Constellations[x]);
-            settingsFile->println(tempString);
+            nvmRecordStringToFile(line);
         }
     }
     break;

--- a/Firmware/RTK_Everywhere/GNSS_ZED.h
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.h
@@ -734,7 +734,7 @@ bool zedCreateString(RTK_Settings_Types type, int settingsIndex, char *newSettin
 bool zedGetSettingValue(RTK_Settings_Types type, const char *suffix, int settingsIndex, int qualifier,
                         char *settingValueStr);
 bool zedNewSettingValue(struct Settings * tempSettings, RTK_Settings_Types type, const char *suffix, int qualifier, double d);
-bool zedSettingsToFile(File *settingsFile, RTK_Settings_Types type, int settingsIndex);
+bool zedSettingsToFile(char * line, size_t lineSize, RTK_Settings_Types type, int settingsIndex);
 bool x20pIsPresentOnFacetFP();
 void x20pNewClass();
 bool f9pIsPresentOnFacetFP();

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -3349,7 +3349,10 @@ bool zedNewSettingValue(struct Settings *tempSettings, RTK_Settings_Types type, 
 //----------------------------------------
 // Called by gnssSettingsToFile to save ZED specific settings
 //----------------------------------------
-bool zedSettingsToFile(File *settingsFile, RTK_Settings_Types type, int settingsIndex)
+bool zedSettingsToFile(char * line,
+                       size_t lineSize,
+                       RTK_Settings_Types type,
+                       int settingsIndex)
 {
     switch (type)
     {
@@ -3363,10 +3366,10 @@ bool zedSettingsToFile(File *settingsFile, RTK_Settings_Types type, int settings
             // Only record constellations which are supported on this platform and firmware version
             if (constellationSupported(x) == true)
             {
-                char tempString[50]; // constellation_BeiDou=1
-                snprintf(tempString, sizeof(tempString), "%s%s=%d", rtkSettingsEntries[settingsIndex].name,
+                // constellation_BeiDou=1
+                snprintf(line, lineSize, "%s%s=%d\r\n", rtkSettingsEntries[settingsIndex].name,
                          ubxConstellations[x].textName, settings.ubxConstellationsEnabled[x]);
-                settingsFile->println(tempString);
+                nvmRecordStringToFile(line);
             }
         }
     }
@@ -3375,10 +3378,10 @@ bool zedSettingsToFile(File *settingsFile, RTK_Settings_Types type, int settings
         // Record message settings
         for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
         {
-            char tempString[50]; // ubxMessageRate_UBX_NMEA_DTM=5
-            snprintf(tempString, sizeof(tempString), "%s%s=%d", rtkSettingsEntries[settingsIndex].name,
+            // ubxMessageRate_UBX_NMEA_DTM=5
+            snprintf(line, lineSize, "%s%s=%d\r\n", rtkSettingsEntries[settingsIndex].name,
                      ubxMessages[x].msgTextName, settings.ubxMessageRates[x]);
-            settingsFile->println(tempString);
+            nvmRecordStringToFile(line);
         }
     }
     break;
@@ -3390,10 +3393,10 @@ bool zedSettingsToFile(File *settingsFile, RTK_Settings_Types type, int settings
 
         for (int x = 0; x < rtkSettingsEntries[settingsIndex].qualifier; x++)
         {
-            char tempString[50]; // ubxMessageRateBase_UBX_NMEA_DTM=5
-            snprintf(tempString, sizeof(tempString), "%s%s=%d", rtkSettingsEntries[settingsIndex].name,
+            // ubxMessageRateBase_UBX_NMEA_DTM=5
+            snprintf(line, lineSize, "%s%s=%d\r\n", rtkSettingsEntries[settingsIndex].name,
                      ubxMessages[firstRTCMRecord + x].msgTextName, settings.ubxMessageRatesBase[x]);
-            settingsFile->println(tempString);
+            nvmRecordStringToFile(line);
         }
     }
     break;

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -582,6 +582,7 @@ void nvmRecordStringToFile(const char * string)
 //----------------------------------------
 void recordSystemSettingsToFile(File *settingsFile)
 {
+    char line[256];
     RTK_Settings_Types type;
 
     // Initialize the CRC and save the file pointer
@@ -589,8 +590,8 @@ void recordSystemSettingsToFile(File *settingsFile)
     nvmSettingsFile = settingsFile;
 
     // Write the header (required values) to the file
-    settingsFile->printf("%s=%d\r\n", "sizeOfSettings", settings.sizeOfSettings);
-    settingsFile->printf("%s=%d\r\n", "rtkIdentifier", settings.rtkIdentifier);
+    SETTINGS_FILE_PRINTF_3("%s=%d\r\n", "sizeOfSettings", settings.sizeOfSettings);
+    SETTINGS_FILE_PRINTF_3("%s=%d\r\n", "rtkIdentifier", settings.rtkIdentifier);
 
     if (settings.debugSettings)
         systemPrintf("numRtkSettingsEntries: %d\r\n", numRtkSettingsEntries);
@@ -626,92 +627,92 @@ void recordSystemSettingsToFile(File *settingsFile)
             break;
         case _bool: {
             bool *ptr = (bool *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%d\r\n", rtkSettingsEntries[i].name, *ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%d\r\n", rtkSettingsEntries[i].name, *ptr);
         }
         break;
         case _int: {
             int *ptr = (int *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%d\r\n", rtkSettingsEntries[i].name, *ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%d\r\n", rtkSettingsEntries[i].name, *ptr);
         }
         break;
         case _float: {
             float *ptr = (float *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%0.*f\r\n", rtkSettingsEntries[i].name, rtkSettingsEntries[i].qualifier, *ptr);
+            SETTINGS_FILE_PRINTF_4("%s=%0.*f\r\n", rtkSettingsEntries[i].name, rtkSettingsEntries[i].qualifier, *ptr);
         }
         break;
         case _double: {
             double *ptr = (double *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%0.*f\r\n", rtkSettingsEntries[i].name, rtkSettingsEntries[i].qualifier, *ptr);
+            SETTINGS_FILE_PRINTF_4("%s=%0.*f\r\n", rtkSettingsEntries[i].name, rtkSettingsEntries[i].qualifier, *ptr);
         }
         break;
         case _uint8_t: {
             uint8_t *ptr = (uint8_t *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%d\r\n", rtkSettingsEntries[i].name, *ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%d\r\n", rtkSettingsEntries[i].name, *ptr);
         }
         break;
         case _uint16_t: {
             uint16_t *ptr = (uint16_t *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%d\r\n", rtkSettingsEntries[i].name, *ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%d\r\n", rtkSettingsEntries[i].name, *ptr);
         }
         break;
         case _uint32_t: {
             uint32_t *ptr = (uint32_t *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%lu\r\n", rtkSettingsEntries[i].name, *ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%lu\r\n", rtkSettingsEntries[i].name, *ptr);
         }
         break;
         case _uint64_t: {
             uint64_t *ptr = (uint64_t *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%llu\r\n", rtkSettingsEntries[i].name, *ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%llu\r\n", rtkSettingsEntries[i].name, *ptr);
         }
         break;
         case _int8_t: {
             int8_t *ptr = (int8_t *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%d\r\n", rtkSettingsEntries[i].name, *ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%d\r\n", rtkSettingsEntries[i].name, *ptr);
         }
         break;
         case _int16_t: {
             int16_t *ptr = (int16_t *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%d\r\n", rtkSettingsEntries[i].name, *ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%d\r\n", rtkSettingsEntries[i].name, *ptr);
         }
         break;
         case tMuxConn: {
             muxConnectionType_e *ptr = (muxConnectionType_e *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%d\r\n", rtkSettingsEntries[i].name, (int)*ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%d\r\n", rtkSettingsEntries[i].name, (int)*ptr);
         }
         break;
         case tSysState: {
             SystemState *ptr = (SystemState *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%d\r\n", rtkSettingsEntries[i].name, (int)*ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%d\r\n", rtkSettingsEntries[i].name, (int)*ptr);
         }
         break;
         case tPulseEdg: {
             pulseEdgeType_e *ptr = (pulseEdgeType_e *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%d\r\n", rtkSettingsEntries[i].name, (int)*ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%d\r\n", rtkSettingsEntries[i].name, (int)*ptr);
         }
         break;
         case tBtRadio: {
             BluetoothRadioType_e *ptr = (BluetoothRadioType_e *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%d\r\n", rtkSettingsEntries[i].name, (int)*ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%d\r\n", rtkSettingsEntries[i].name, (int)*ptr);
         }
         break;
         case tPerDisp: {
             PeriodicDisplay_t *ptr = (PeriodicDisplay_t *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%llu\r\n", rtkSettingsEntries[i].name, *ptr); // PeriodicDisplay_t is uint64_t
+            SETTINGS_FILE_PRINTF_3("%s=%llu\r\n", rtkSettingsEntries[i].name, *ptr); // PeriodicDisplay_t is uint64_t
         }
         break;
         case tCoordInp: {
             CoordinateInputType *ptr = (CoordinateInputType *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%d\r\n", rtkSettingsEntries[i].name, (int)*ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%d\r\n", rtkSettingsEntries[i].name, (int)*ptr);
         }
         break;
         case tCharArry: {
             char *ptr = (char *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%s\r\n", rtkSettingsEntries[i].name, ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%s\r\n", rtkSettingsEntries[i].name, ptr);
         }
         break;
         case _IPString: {
             IPAddress *ptr = (IPAddress *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%s\r\n", rtkSettingsEntries[i].name, ptr->toString().c_str());
+            SETTINGS_FILE_PRINTF_3("%s=%s\r\n", rtkSettingsEntries[i].name, ptr->toString().c_str());
             // Note: toString separates the four bytes with dots / periods "192.168.1.1"
         }
         break;
@@ -729,12 +730,11 @@ void recordSystemSettingsToFile(File *settingsFile)
             // Record ESP-NOW peer MAC addresses
             for (int x = 0; x < rtkSettingsEntries[i].qualifier; x++)
             {
-                char tempString[50]; // espnowPeer_1=B4:C1:33:42:DE:01,
-                snprintf(tempString, sizeof(tempString), "%s%d=%02X:%02X:%02X:%02X:%02X:%02X",
+                snprintf(line, sizeof(line), "%s%d=%02X:%02X:%02X:%02X:%02X:%02X\r\n",
                          rtkSettingsEntries[i].name, x, settings.espnowPeers[x][0], settings.espnowPeers[x][1],
                          settings.espnowPeers[x][2], settings.espnowPeers[x][3], settings.espnowPeers[x][4],
                          settings.espnowPeers[x][5]);
-                settingsFile->println(tempString);
+                nvmRecordStringToFile(line);
             }
         }
         break;
@@ -743,21 +743,19 @@ void recordSystemSettingsToFile(File *settingsFile)
             // Record WiFi credential table
             for (int x = 0; x < rtkSettingsEntries[i].qualifier; x++)
             {
-                char tempString[100]; // wifiNetwork_0Password=parachutes
-
-                snprintf(tempString, sizeof(tempString), "%s%dSSID=%s", rtkSettingsEntries[i].name, x,
+                snprintf(line, sizeof(line), "%s%dSSID=%s\r\n", rtkSettingsEntries[i].name, x,
                          settings.wifiNetworks[x].ssid);
-                settingsFile->println(tempString);
-                snprintf(tempString, sizeof(tempString), "%s%dPassword=%s", rtkSettingsEntries[i].name, x,
+                nvmRecordStringToFile(line);
+                snprintf(line, sizeof(line), "%s%dPassword=%s\r\n", rtkSettingsEntries[i].name, x,
                          settings.wifiNetworks[x].password);
-                settingsFile->println(tempString);
+                nvmRecordStringToFile(line);
             }
         }
         break;
         case tNSCEn: {
             for (int x = 0; x < rtkSettingsEntries[i].qualifier; x++)
             {
-                settingsFile->printf("%s%d=%d\r\n", rtkSettingsEntries[i].name, x,
+                SETTINGS_FILE_PRINTF_4("%s%d=%d\r\n", rtkSettingsEntries[i].name, x,
                                      settings.ntripServer_CasterEnabled[x]);
             }
         }
@@ -765,7 +763,7 @@ void recordSystemSettingsToFile(File *settingsFile)
         case tNSCHost: {
             for (int x = 0; x < rtkSettingsEntries[i].qualifier; x++)
             {
-                settingsFile->printf("%s%d=%s\r\n", rtkSettingsEntries[i].name, x,
+                SETTINGS_FILE_PRINTF_4("%s%d=%s\r\n", rtkSettingsEntries[i].name, x,
                                      &settings.ntripServer_CasterHost[x][0]);
             }
         }
@@ -773,14 +771,14 @@ void recordSystemSettingsToFile(File *settingsFile)
         case tNSCPort: {
             for (int x = 0; x < rtkSettingsEntries[i].qualifier; x++)
             {
-                settingsFile->printf("%s%d=%d\r\n", rtkSettingsEntries[i].name, x, settings.ntripServer_CasterPort[x]);
+                SETTINGS_FILE_PRINTF_4("%s%d=%d\r\n", rtkSettingsEntries[i].name, x, settings.ntripServer_CasterPort[x]);
             }
         }
         break;
         case tNSCUser: {
             for (int x = 0; x < rtkSettingsEntries[i].qualifier; x++)
             {
-                settingsFile->printf("%s%d=%s\r\n", rtkSettingsEntries[i].name, x,
+                SETTINGS_FILE_PRINTF_4("%s%d=%s\r\n", rtkSettingsEntries[i].name, x,
                                      &settings.ntripServer_CasterUser[x][0]);
             }
         }
@@ -788,7 +786,7 @@ void recordSystemSettingsToFile(File *settingsFile)
         case tNSCUsrPw: {
             for (int x = 0; x < rtkSettingsEntries[i].qualifier; x++)
             {
-                settingsFile->printf("%s%d=%s\r\n", rtkSettingsEntries[i].name, x,
+                SETTINGS_FILE_PRINTF_4("%s%d=%s\r\n", rtkSettingsEntries[i].name, x,
                                      &settings.ntripServer_CasterUserPW[x][0]);
             }
         }
@@ -796,7 +794,7 @@ void recordSystemSettingsToFile(File *settingsFile)
         case tNSMtPt: {
             for (int x = 0; x < rtkSettingsEntries[i].qualifier; x++)
             {
-                settingsFile->printf("%s%d=%s\r\n", rtkSettingsEntries[i].name, x,
+                SETTINGS_FILE_PRINTF_4("%s%d=%s\r\n", rtkSettingsEntries[i].name, x,
                                      &settings.ntripServer_MountPoint[x][0]);
             }
         }
@@ -804,7 +802,7 @@ void recordSystemSettingsToFile(File *settingsFile)
         case tNSMtPtPw: {
             for (int x = 0; x < rtkSettingsEntries[i].qualifier; x++)
             {
-                settingsFile->printf("%s%d=%s\r\n", rtkSettingsEntries[i].name, x,
+                SETTINGS_FILE_PRINTF_4("%s%d=%s\r\n", rtkSettingsEntries[i].name, x,
                                      &settings.ntripServer_MountPointPW[x][0]);
             }
         }
@@ -815,23 +813,23 @@ void recordSystemSettingsToFile(File *settingsFile)
             for (int x = 0; x < rtkSettingsEntries[i].qualifier; x++)
             {
                 char tempString[80]; // correctionsPriority_Ethernet_IP_(PointPerfect/MQTT)=99
-                snprintf(tempString, sizeof(tempString), "%s%s=%0d", rtkSettingsEntries[i].name, correctionGetName(x),
+                snprintf(line, sizeof(line), "%s%s=%0d\r\n", rtkSettingsEntries[i].name, correctionGetName(x),
                          settings.correctionsSourcesPriority[x]);
-                settingsFile->println(tempString);
+                nvmRecordStringToFile(line);
             }
         }
         break;
         case tRegCorTp: {
             for (int r = 0; r < rtkSettingsEntries[i].qualifier; r++)
             {
-                settingsFile->printf("%s%d=%s\r\n", rtkSettingsEntries[i].name, r,
+                SETTINGS_FILE_PRINTF_4("%s%d=%s\r\n", rtkSettingsEntries[i].name, r,
                                      &settings.regionalCorrectionTopics[r][0]);
             }
         }
         break;
         case tGnssReceiver: {
             gnssReceiverType_e *ptr = (gnssReceiverType_e *)rtkSettingsEntries[i].var;
-            settingsFile->printf("%s=%d\r\n", rtkSettingsEntries[i].name, (int)*ptr);
+            SETTINGS_FILE_PRINTF_3("%s=%d\r\n", rtkSettingsEntries[i].name, (int)*ptr);
         }
         break;
         }
@@ -841,15 +839,15 @@ void recordSystemSettingsToFile(File *settingsFile)
 
     char firmwareVersion[30]; // v1.3 December 31 2021
     firmwareVersionGet(firmwareVersion, sizeof(firmwareVersion), true);
-    settingsFile->printf("%s=%s\r\n", "rtkFirmwareVersion", firmwareVersion);
+    SETTINGS_FILE_PRINTF_3("%s=%s\r\n", "rtkFirmwareVersion", firmwareVersion);
 
-    settingsFile->printf("%s=%s\r\n", "gnssFirmwareVersion", gnssFirmwareVersion);
+    SETTINGS_FILE_PRINTF_3("%s=%s\r\n", "gnssFirmwareVersion", gnssFirmwareVersion);
 
-    settingsFile->printf("%s=%s\r\n", "gnssUniqueId", gnssUniqueId);
+    SETTINGS_FILE_PRINTF_3("%s=%s\r\n", "gnssUniqueId", gnssUniqueId);
 
     // Firmware URLs
-    settingsFile->printf("%s=%s\r\n", "otaRcFirmwareJsonUrl", otaRcFirmwareJsonUrl);
-    settingsFile->printf("%s=%s\r\n", "otaFirmwareJsonUrl", otaFirmwareJsonUrl);
+    SETTINGS_FILE_PRINTF_3("%s=%s\r\n", "otaRcFirmwareJsonUrl", otaRcFirmwareJsonUrl);
+    SETTINGS_FILE_PRINTF_3("%s=%s\r\n", "otaFirmwareJsonUrl", otaFirmwareJsonUrl);
 
     // Forget the file pointer
     nvmSettingsFile = nullptr;

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -418,14 +418,14 @@ void recordSystemSettingsToFileSD(char *fileName)
             if (sd->exists(fileName))
             {
                 if (settings.debugSettings)
-                    systemPrintf("Removing from SD: %s\r\n", fileName);
+                    systemPrintf("Removing from SD:%s\r\n", fileName);
                 sd->remove(fileName);
             }
 
             SdFile settingsFile; // FAT32
             if (settingsFile.open(fileName, O_CREAT | O_APPEND | O_WRITE) == false)
             {
-                systemPrintf("Failed to create SD settings file %s\r\n", fileName);
+                systemPrintf("Failed to create SD:%s\r\n", fileName);
                 break; // /while (online.microSD == true)
             }
 
@@ -438,7 +438,7 @@ void recordSystemSettingsToFileSD(char *fileName)
             settingsFile.close();
 
             if (settings.debugSettings)
-                systemPrintf("Settings recorded to SD: %s\r\n", fileName);
+                systemPrintf("Settings recorded to SD:%s\r\n", fileName);
         }
         else
         {
@@ -470,21 +470,21 @@ void recordSystemSettingsToFileLFS(char *fileName)
         if (LittleFS.exists(fileName))
         {
             if (settings.debugSettings)
-                    systemPrintf("Removing LittleFS: %s\r\n", fileName);
+                    systemPrintf("Removing LFS:%s\r\n", fileName);
             LittleFS.remove(fileName);
         }
 
         File settingsFile = LittleFS.open(fileName, FILE_WRITE);
         if (!settingsFile)
         {
-            systemPrintf("Failed to create LFS settings file %s\r\n", fileName);
+            systemPrintf("Failed to create LFS:%s\r\n", fileName);
         }
         else
         {
             recordSystemSettingsToFile(&settingsFile); // Record all the settings via strings to file
             settingsFile.close();
             if (settings.debugSettings)
-                systemPrintf("Settings recorded to LittleFS: %s\r\n", fileName);
+                systemPrintf("Settings recorded to LFS:%s\r\n", fileName);
         }
     }
 }
@@ -776,7 +776,7 @@ bool loadSystemSettingsFromFileSD(char *fileName,
     if ((findMe != nullptr) && (found != nullptr))
         *found = 0; // If searching, set found to NULL
     else if (settings.debugSettings)
-        systemPrintf("Loading system settings from SD: %s\r\n", fileName);
+        systemPrintf("Loading system settings from SD:%s\r\n", fileName);
 
     bool gotSemaphore = false;
     bool status = false; // Return false - until file is opened
@@ -800,14 +800,14 @@ bool loadSystemSettingsFromFileSD(char *fileName,
             if (!sd->exists(fileName))
             {
                 if (settings.debugSettings)
-                    systemPrintf("SD File %s not found\r\n", fileName);
+                    systemPrintf("SD:%s not found\r\n", fileName);
                 break; // /while (online.microSD == true)
             }
 
             SdFile settingsFile; // FAT32
             if (settingsFile.open(fileName, O_READ) == false)
             {
-                systemPrintf("Failed to open settings SD file %s\r\n", fileName);
+                systemPrintf("Failed to open settings SD:%s\r\n", fileName);
                 break; // /while (online.microSD == true)
             }
 
@@ -824,7 +824,7 @@ bool loadSystemSettingsFromFileSD(char *fileName,
                 // Handle the file error
                 if (n < 0)
                 {
-                    systemPrintf("Hard read error at line %d in SD file %s!\r\n", lineNumber, fileName);
+                    systemPrintf("Hard read error at line %d in SD:%s!\r\n", lineNumber, fileName);
                     if (findMe)
                         strncpy(found, "SD Card Read Error!", len);
                     break;
@@ -833,7 +833,7 @@ bool loadSystemSettingsFromFileSD(char *fileName,
                 // Handle non-printable data in file
                 else if (n == 0)
                 {
-                    systemPrintf("Line %d contains non-printable data in SD file %s!\r\n", lineNumber, fileName);
+                    systemPrintf("Line %d contains non-printable data in SD:%s!\r\n", lineNumber, fileName);
                     if (findMe)
                     {
                         strncpy(found, "SD Card corrupt file!", len);
@@ -843,13 +843,13 @@ bool loadSystemSettingsFromFileSD(char *fileName,
                 else if (line[n - 1] != '\n')
                 {
                     if (n == (sizeof(line) - 1))
-                        systemPrintf("SD settings file %s line %d too long\r\n", fileName, lineNumber);
+                        systemPrintf("SD:%s line %d too long\r\n", fileName, lineNumber);
                     else
-                        systemPrintf("SD settings file %s line %d not LF terminated\r\n", fileName, lineNumber);
+                        systemPrintf("SD:%s line %d not LF terminated\r\n", fileName, lineNumber);
                     if (lineNumber == 0)
                     {
                         // If we can't read the first line of the settings file, give up
-                        systemPrintf("Giving up on SD settings file %s\r\n", fileName);
+                        systemPrintf("Giving up on SD:%s\r\n", fileName);
                         if (findMe)
                             strncpy(found, "SD Card file line too long!", len);
                         status = false;
@@ -864,11 +864,11 @@ bool loadSystemSettingsFromFileSD(char *fileName,
                         if (parseLine(line, tempSettings) == false)
                         {
                             line[strlen(line) - 1] = 0; // Remove \n for printing
-                            systemPrintf("Failed to parse SD file %s line %d: %s\r\n", fileName, lineNumber, line);
+                            systemPrintf("Failed to parse SD:%s line %d: %s\r\n", fileName, lineNumber, line);
                             if (lineNumber == 0)
                             {
                                 // If we can't read the first line of the settings file, give up
-                                systemPrintf("Giving up on SD settings file %s\r\n", fileName);
+                                systemPrintf("Giving up on SD:%s\r\n", fileName);
                                 status = false;
                                 break; // /while (settingsFile.available())
                             }
@@ -898,7 +898,7 @@ bool loadSystemSettingsFromFileSD(char *fileName,
                 lineNumber++;
                 if (lineNumber > 800) // Arbitrary limit. Catch corrupt files.
                 {
-                    systemPrintf("Max line number exceeded. Giving up reading SD file: %s\r\n", fileName);
+                    systemPrintf("Max line number exceeded. Giving up reading SD:%s\r\n", fileName);
                     if (findMe)
                     {
                         strncpy(found, "SD Card file too many lines!", len);
@@ -947,12 +947,12 @@ bool loadSystemSettingsFromFileLFS(char *fileName,
     if ((findMe != nullptr) && (found != nullptr))
         *found = 0; // If searching, set found to NULL
     else if (settings.debugSettings)
-        systemPrintf("Loading system settings from LFS: %s\r\n", fileName);
+        systemPrintf("Loading system settings from LFS:%s\r\n", fileName);
 
     if (!LittleFS.exists(fileName))
     {
         if (settings.debugSettings)
-            systemPrintf("settingsFile %s not found in LittleFS\r\n", fileName);
+            systemPrintf("LFS:%s not found\r\n", fileName);
         return (false);
     }
 
@@ -977,7 +977,7 @@ bool loadSystemSettingsFromFileLFS(char *fileName,
         // Handle the file error
         if (n < 0)
         {
-            systemPrintf("Hard read error at line %d in LFS file %s!\r\n", lineNumber, fileName);
+            systemPrintf("Hard read error at line %d in LFS:%s!\r\n", lineNumber, fileName);
             if (findMe)
                 strncpy(found, "LFS Read Error!", len);
             break;
@@ -986,7 +986,7 @@ bool loadSystemSettingsFromFileLFS(char *fileName,
         // Handle non-printable data in file
         else if (n == 0)
         {
-            systemPrintf("Line %d contains non-printable data in LFS file %s!\r\n", lineNumber, fileName);
+            systemPrintf("Line %d contains non-printable data in LFS:%s!\r\n", lineNumber, fileName);
             if (findMe)
             {
                 strncpy(found, "LFS Bad Character!", len);
@@ -996,13 +996,13 @@ bool loadSystemSettingsFromFileLFS(char *fileName,
         else if (line[n - 1] != '\n')
         {
             if (n == (sizeof(line) - 1))
-                systemPrintf("LFS settings file %s line %d too long\r\n", fileName, lineNumber);
+                systemPrintf("LFS:%s line %d too long\r\n", fileName, lineNumber);
             else
-                systemPrintf("LSF settings file %s line %d not LF terminated\r\n", fileName, lineNumber);
+                systemPrintf("LFS:%s line %d not LF terminated\r\n", fileName, lineNumber);
             if (lineNumber == 0)
             {
                 // If we can't read the first line of the settings file, give up
-                systemPrintf("Giving up on LFS settings file %s\r\n", fileName);
+                systemPrintf("Giving up on LFS:%s\r\n", fileName);
                 if (findMe)
                     strncpy(found, "LFS Line too long!", len);
                 status = false;
@@ -1017,11 +1017,11 @@ bool loadSystemSettingsFromFileLFS(char *fileName,
                 if (parseLine(line, tempSettings) == false)
                 {
                     line[strlen(line) - 1] = 0; // Remove \n for printing
-                    systemPrintf("Failed to parse LFS file %s line %d: %s\r\n", fileName, lineNumber, line);
+                    systemPrintf("Failed to parse LFS:%s line %d: %s\r\n", fileName, lineNumber, line);
                     if (lineNumber == 0)
                     {
                         // If we can't read the first line of the settings file, give up
-                        systemPrintf("Giving up on LFS settings file %s\r\n", fileName);
+                        systemPrintf("Giving up on LFS:%s\r\n", fileName);
                         status = false;
                         break; // /while (settingsFile.available())
                     }
@@ -1051,7 +1051,7 @@ bool loadSystemSettingsFromFileLFS(char *fileName,
         lineNumber++;
         if (lineNumber > 800) // Arbitrary limit. Catch corrupt files.
         {
-            systemPrintf("Max line number exceeded. Giving up reading LFS file: %s\r\n", fileName);
+            systemPrintf("Max line number exceeded. Giving up reading LFS:%s\r\n", fileName);
             if (findMe)
             {
                 strncpy(found, "LFS Too Many Lines!", len);
@@ -1074,19 +1074,19 @@ bool loadSystemSettingsFromFileLFS(char *fileName,
 bool printSystemSettingsFromFileLFS(char *fileName)
 {
     if (settings.debugSettings)
-        systemPrintf("Printing setting fileName: %s\r\n", fileName);
+        systemPrintf("Printing LFS:%s\r\n", fileName);
 
     if (!LittleFS.exists(fileName))
     {
         if (settings.debugSettings)
-            systemPrintf("settingsFile %s not found in LittleFS\r\n", fileName);
+            systemPrintf("LFS:%s not found\r\n", fileName);
         return (false);
     }
 
     File settingsFile = LittleFS.open(fileName, FILE_READ);
     if (!settingsFile)
     {
-        systemPrintln("Failed to open LFS settings file");
+        systemPrintf("Failed to open LFS:%s\r\n", fileName);
         return (false);
     }
 
@@ -1106,14 +1106,14 @@ bool printSystemSettingsFromFileLFS(char *fileName)
         // Handle the file error
         if (n < 0)
         {
-            systemPrintf("Hard read error at line %d in file %s!\r\n", lineNumber, fileName);
+            systemPrintf("Hard read error at line %d in LFS:%s!\r\n", lineNumber, fileName);
             break;
         }
 
         // Handle non-printable data in file
         else if (n == 0)
         {
-            systemPrintf("Line %d contains non-printable data in file %s!\r\n", lineNumber, fileName);
+            systemPrintf("Line %d contains non-printable data in LFS:%s!\r\n", lineNumber, fileName);
 //            break;
         }
         else if (line[n - 1] != '\n')
@@ -1139,7 +1139,7 @@ bool printSystemSettingsFromFileLFS(char *fileName)
         lineNumber++;
         if (lineNumber > 800) // Arbitrary limit. Catch corrupt files.
         {
-            systemPrintf("Max line number exceeded. Giving up reading LFS file: %s\r\n", fileName);
+            systemPrintf("Max line number exceeded. Giving up reading LFS:%s\r\n", fileName);
             // Should we return true or false? Going with true...
             break;
         }
@@ -1885,21 +1885,21 @@ void recordFile(const char *fileID, char *fileContents, uint32_t fileSize)
     {
         LittleFS.remove(fileName);
         if (settings.debugSettings)
-            systemPrintf("Removing LittleFS: %s\r\n", fileName);
+            systemPrintf("Removing LFS:%s\r\n", fileName);
     }
 
     File fileToWrite = LittleFS.open(fileName, FILE_WRITE);
     if (!fileToWrite)
     {
         if (settings.debugSettings)
-            systemPrintf("Failed to write to file %s\r\n", fileName);
+            systemPrintf("Failed to write to LFS:%s\r\n", fileName);
     }
     else
     {
         fileToWrite.write((uint8_t *)fileContents, fileSize); // Store cert into file
         fileToWrite.close();
         if (settings.debugSettings)
-            systemPrintf("File recorded to LittleFS: %s\r\n", fileName);
+            systemPrintf("File recorded to LFS:%s\r\n", fileName);
     }
 }
 
@@ -1914,7 +1914,7 @@ bool loadFile(const char *fileID, char *fileContents, bool debug)
     if (!LittleFS.exists(fileName))
     {
         if (debug)
-            systemPrintf("File %s does not exist on LittleFS\r\n", fileName);
+            systemPrintf("LFS:%s does not exist\r\n", fileName);
         return false;
     }
 
@@ -1927,12 +1927,12 @@ bool loadFile(const char *fileID, char *fileContents, bool debug)
         if (length == bytesRead)
         {
             if (debug)
-                systemPrintf("File loaded from LittleFS: %s\r\n", fileName);
+                systemPrintf("File loaded from LFS:%s\r\n", fileName);
             return true;
         }
     }
     else if (debug)
-        systemPrintf("Failed to read from LittleFS: %s\r\n", fileName);
+        systemPrintf("Failed to read from LFS:%s\r\n", fileName);
     return false;
 }
 
@@ -2012,7 +2012,7 @@ void nvmDumpFile(const char * fileName)
         file = LittleFS.open(fileName, FILE_READ);
         if (! file)
         {
-            systemPrintf("ERROR: Failed to open NVM file %s\r\n", fileName);
+            systemPrintf("ERROR: Failed to open LFS:%s\r\n", fileName);
             break;
         }
 
@@ -2025,7 +2025,7 @@ void nvmDumpFile(const char * fileName)
         }
 
         // Display the file name
-        systemPrintf("NVM file %s dump:\r\n", fileName);
+        systemPrintf("LFS:%s dump:\r\n", fileName);
 
         // Walk the contents of the file
         offset = 0;
@@ -2047,7 +2047,7 @@ void nvmDumpFile(const char * fileName)
             } while ((bytesRead > 0) && (bytesRead < bufferLength));
             if (bytesRead < 0)
             {
-                systemPrintf("ERROR: Hard read error at offset %ld in NVM file %s\r\n",
+                systemPrintf("ERROR: Hard read error at offset %ld in LFS:%s\r\n",
                              offset, fileName);
                 break;
             }

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -62,6 +62,15 @@ bool loadSystemSettingsFromFileSD(char *fileName,
                                   int len = 0); // Header
 
 //----------------------------------------
+// Constants
+//----------------------------------------
+
+// g(x) = x^32 + x^26 + (x^23 + x^22) + x^16 + x^12 + (x^11 + x^10 + x^8)
+//      + (x^5 + x^4) + (x^2 + x^1 + x^0)
+// 1 0000 0100 1100 0001 0001 1101 1011 0111
+const uint32_t nvmCrc32Polynomial = 0x04c11db7;
+
+//----------------------------------------
 // We use the LittleFS library to store user profiles in SPIFFs
 // Move selected user profile from SPIFFs into settings struct (RAM)
 // We originally used EEPROM but it was limited to 4096 bytes. Each settings struct is ~4000 bytes
@@ -487,6 +496,56 @@ void recordSystemSettingsToFileLFS(char *fileName)
                 systemPrintf("Settings recorded to LFS:%s\r\n", fileName);
         }
     }
+}
+
+//----------------------------------------
+// Compute the next byte of CRC32
+// x32 + x26 + x23 + x22 + x16 + x12 + x11 + x10 + x8 + x7 + x5 + x4 + x2 + x + 1
+// Inputs:
+//   crc: Initial or previous CRC value
+//   byte: Data byte to use in the CRC calculation
+//
+// Output:
+//   Returns the updated CRC value
+//----------------------------------------
+uint32_t nvmBitBangCrc32Byte(uint32_t crc, uint8_t byte)
+{
+    uint32_t bit;
+    int bitNumber;
+
+    // XOR byte into the LSB of the CRC
+    crc ^= byte;
+
+    // Compute the updated CRC32 value
+    for (int bitNumber = 0; bitNumber < 8; bitNumber++)
+    {
+        bit = crc & 1;
+        crc >>= 1;
+        if (bit)
+            crc ^= nvmCrc32Polynomial;
+    }
+    return crc;
+}
+
+//----------------------------------------
+// Compute the CRC32 for a range of data
+// Inputs:
+//   crc: Initial or previous CRC value
+//   data: Address of a buffer containing data for the CRC
+//   length: Number of data bytes in the buffer
+//
+// Output:
+//   Returns the updated CRC value
+//----------------------------------------
+uint32_t nvmBitBangCrc32(uint32_t crc, const uint8_t * data, size_t length)
+{
+    const uint8_t * end;
+
+    // Compute the CRC for the data buffer
+    end = &data[length];
+    while (data < end)
+        crc = nvmBitBangCrc32Byte(crc, *data++);
+    return crc;
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -617,7 +617,7 @@ void recordSystemSettingsToFile(File *settingsFile)
 
         // Check for a GNSS receiver specific type
         type = rtkSettingsEntries[i].type;
-        if (gnssSettingsToFile(settingsFile, type, i))
+        if (gnssSettingsToFile(line, sizeof(line), type, i))
             continue;
 
         // Process the generic types

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -413,21 +413,25 @@ void loadSettingsPartial()
 //----------------------------------------
 // Record settings to files in both the Little File System and SD card
 //----------------------------------------
-void recordSystemSettings()
+bool recordSystemSettings()
 {
+    bool status;
+
     settings.sizeOfSettings = sizeof(settings); // Update to current setting size
 
-    recordSystemSettingsToFileSD(settingsFileName);  // Record to SD if available
-    recordSystemSettingsToFileLFS(settingsFileName); // Record to LFS if available
+    status = recordSystemSettingsToFileSD(settingsFileName);  // Record to SD if available
+    status &= recordSystemSettingsToFileLFS(settingsFileName); // Record to LFS if available
+    return status;
 }
 
 //----------------------------------------
 // Export the current settings to a config file on SD
 // We share the recording with LittleFS so this is all the semaphore and SD specific handling
 //----------------------------------------
-void recordSystemSettingsToFileSD(char *fileName)
+bool recordSystemSettingsToFileSD(char *fileName)
 {
     bool gotSemaphore = false;
+    bool status = true;
     bool wasSdCardOnline;
 
     // Try to gain access the SD card
@@ -439,6 +443,7 @@ void recordSystemSettingsToFileSD(char *fileName)
     {
         // Attempt to write to file system. This avoids collisions with file writing from other functions like
         // updateLogs()
+        status = false;
         if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
         {
             markSemaphore(FUNCTION_RECORDSETTINGS);
@@ -463,10 +468,25 @@ void recordSystemSettingsToFileSD(char *fileName)
 
             recordSystemSettingsToFile((File *)&settingsFile); // Record all the settings via strings to file
 
-            sdUpdateFileAccessTimestamp(&settingsFile); // Update the file access time & date
+            // Write the CRC to the file
+            if (settings.debugSettings)
+                systemPrintf("Writing CRC 0x%08x to file SD:%s\r\n", nvmCrc, fileName);
+            status = (settingsFile.write((uint8_t *)&nvmCrc, sizeof(nvmCrc)) == sizeof(nvmCrc));
+            if (status)
+            {
+                if (settings.debugSettings)
+                    systemPrintf("Successfully wrote CRC 0x%08x to file SD:%s\r\n", nvmCrc, fileName);
 
+                // Update the access timestamp
+                sdUpdateFileAccessTimestamp(&settingsFile); // Update the file access time & date
+                if (settings.debugSettings)
+                    systemPrintf("Updated file access timestampon file SD:%s\r\n", fileName);
+            }
+            else
+                systemPrintf("ERROR: Failed to write CRC to file SD:%s\r\n", fileName);
+
+            // Close the file
             settingsFile.close();
-
             if (settings.debugSettings)
                 systemPrintf("Settings recorded to SD:%s\r\n", fileName);
         }
@@ -487,14 +507,17 @@ void recordSystemSettingsToFileSD(char *fileName)
         endSD(gotSemaphore, true);
     else if (gotSemaphore)
         xSemaphoreGive(sdCardSemaphore);
+    return status;
 }
 
 //----------------------------------------
 // Export the current settings to a config file on SD
 // We share the recording with LittleFS so this is all the semaphore and SD specific handling
 //----------------------------------------
-void recordSystemSettingsToFileLFS(char *fileName)
+bool recordSystemSettingsToFileLFS(char *fileName)
 {
+    bool status = false;
+
     if (online.fs == true)
     {
         if (LittleFS.exists(fileName))
@@ -512,11 +535,21 @@ void recordSystemSettingsToFileLFS(char *fileName)
         else
         {
             recordSystemSettingsToFile(&settingsFile); // Record all the settings via strings to file
+
+            // Write the CRC to the file
+            if (settings.debugSettings)
+                systemPrintf("Writing CRC 0x%08x to file LFS:%s\r\n", nvmCrc, fileName);
+            status = (settingsFile.write((uint8_t *)&nvmCrc, sizeof(nvmCrc)) == sizeof(nvmCrc));
+            if (status == false)
+                systemPrintf("ERROR: Failed to write CRC to file LFS:%s\r\n", fileName);
+
+            // Close the file
             settingsFile.close();
             if (settings.debugSettings)
                 systemPrintf("Settings recorded to LFS:%s\r\n", fileName);
         }
     }
+    return status;
 }
 
 //----------------------------------------
@@ -594,7 +627,7 @@ void recordSystemSettingsToFile(File *settingsFile)
     // Write the header (required values) to the file
     SETTINGS_FILE_PRINTF_3("%s=%d\r\n", "sizeOfSettings", settings.sizeOfSettings);
     SETTINGS_FILE_PRINTF_3("%s=%d\r\n", "rtkIdentifier", settings.rtkIdentifier);
-    SETTINGS_FILE_PRINTF_3("%s=%d\r\n", nvmSettingsFileHasCrc, false);
+    SETTINGS_FILE_PRINTF_3("%s=%d\r\n", nvmSettingsFileHasCrc, true);
 
     if (settings.debugSettings)
         systemPrintf("numRtkSettingsEntries: %d\r\n", numRtkSettingsEntries);
@@ -851,6 +884,10 @@ void recordSystemSettingsToFile(File *settingsFile)
     // Firmware URLs
     SETTINGS_FILE_PRINTF_3("%s=%s\r\n", "otaRcFirmwareJsonUrl", otaRcFirmwareJsonUrl);
     SETTINGS_FILE_PRINTF_3("%s=%s\r\n", "otaFirmwareJsonUrl", otaFirmwareJsonUrl);
+
+    //------------------------------------------------------------
+    // Add any new settings above this line!
+    //------------------------------------------------------------
 
     // Forget the file pointer
     nvmSettingsFile = nullptr;

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -2134,6 +2134,54 @@ void nvmDirectoryListing()
 }
 
 //----------------------------------------
+// Fill buffer with LFS file data
+//----------------------------------------
+ssize_t nvmReadLfsFileData(File * file, uint8_t * buffer, size_t bufferLength)
+{
+    ssize_t bytesRead;
+
+    // Read some data
+    bytesRead = 0;
+    do
+    {
+        int data = file->read();
+        if (data < 0)
+        {
+            if (bytesRead == 0)
+                bytesRead = data;
+            break;
+        }
+        buffer[bytesRead] = (uint8_t)data;
+        bytesRead += 1;
+    } while ((bytesRead > 0) && (bytesRead < bufferLength));
+    return bytesRead;
+}
+
+//----------------------------------------
+// Fill buffer with SD file data
+//----------------------------------------
+ssize_t nvmReadSdFileData(SdFile * file, uint8_t * buffer, size_t bufferLength)
+{
+    ssize_t bytesRead;
+
+    // Read some data
+    bytesRead = 0;
+    do
+    {
+        int data = file->read();
+        if (data < 0)
+        {
+            if (bytesRead == 0)
+                bytesRead = data;
+            break;
+        }
+        buffer[bytesRead] = (uint8_t)data;
+        bytesRead += 1;
+    } while ((bytesRead > 0) && (bytesRead < bufferLength));
+    return bytesRead;
+}
+
+//----------------------------------------
 // Dump an NVM file
 //----------------------------------------
 void nvmDumpFile(const char * fileName)
@@ -2170,19 +2218,7 @@ void nvmDumpFile(const char * fileName)
         while (file.available())
         {
             // Read some data
-            bytesRead = 0;
-            do
-            {
-                int data = file.read();
-                if (data < 0)
-                {
-                    if (bytesRead == 0)
-                        bytesRead = data;
-                    break;
-                }
-                buffer[bytesRead] = (uint8_t)data;
-                bytesRead += 1;
-            } while ((bytesRead > 0) && (bytesRead < bufferLength));
+            bytesRead = nvmReadLfsFileData(&file, buffer ,bufferLength);
             if (bytesRead < 0)
             {
                 systemPrintf("ERROR: Hard read error at offset %ld in LFS:%s\r\n",
@@ -2203,4 +2239,436 @@ void nvmDumpFile(const char * fileName)
     // Done with the buffer
     if (buffer)
         rtkFree(buffer, "NVM file dump buffer");
+}
+
+//----------------------------------------
+// Verify LFS file CRC
+//----------------------------------------
+void nvmVerifyLfsFileCrc(const char * fileName)
+{
+    uint8_t * buffer = nullptr;
+    const size_t bufferLength = 8192;
+    ssize_t bytesRead;
+    uint8_t * data;
+    File file;
+    size_t length;
+    size_t offset;
+    size_t remainingBytes;
+    const char * rtkIdentifier = "rtkIdentifier";
+    const char * sizeOfSettings = "sizeOfSettings=";
+
+    do
+    {
+        // Attempt to open the file
+        file = LittleFS.open(fileName, FILE_READ);
+        if (! file)
+        {
+            systemPrintf("ERROR: Failed to open NVM file %s\r\n", fileName);
+            break;
+        }
+        remainingBytes = file.size();
+
+        // Allocate the buffer
+        buffer = (uint8_t *)rtkMalloc(bufferLength, "NVM file dump buffer");
+        if (buffer == nullptr)
+        {
+            systemPrintf("ERROR: Failed to allocate the dump buffer\r\n");
+            break;
+        }
+
+        // Walk the contents of the file
+        bytesRead = 0;
+        length = 0;
+        offset = 0;
+        if (remainingBytes > sizeof(nvmCrc))
+        {
+            // Determine how much data to read
+            length = remainingBytes - sizeof(nvmCrc);
+            if (length > bufferLength)
+                length = bufferLength;
+
+            // Read some data
+            bytesRead = nvmReadLfsFileData(&file, buffer, length);
+            if (bytesRead < 0)
+            {
+                systemPrintf("ERROR: Hard read error at offset %ld in NVM file %s\r\n",
+                             offset, fileName);
+                break;
+            }
+            if (bytesRead < length)
+            {
+                systemPrintf("ERROR: Failed to read all of the bytes!\r\n",
+                             offset, fileName);
+                break;
+            }
+            offset += bytesRead;
+            remainingBytes -= bytesRead;
+        }
+        if ((bytesRead < 0) || (bytesRead < length))
+            break;
+
+        //--------------------
+        // Verify the file header
+        //--------------------
+
+        // Check for sizeOfSettings value
+        length = strlen(sizeOfSettings);
+        if (strncmp((char *)buffer, sizeOfSettings, length) != 0)
+        {
+            systemPrintf("ERROR: Not a settings file, %s missing!\r\n", sizeOfSettings);
+            break;
+        }
+
+        // Skip over value
+        data = &buffer[length];
+        while (*data++ != '\n');
+
+        // Check for rtkIdentifier value
+        length = strlen(rtkIdentifier);
+        if (strncmp((char *)data, rtkIdentifier, length) != 0)
+        {
+            systemPrintf("ERROR: Not a settings file, %s missing!\r\n", rtkIdentifier);
+            break;
+        }
+
+        // Skip over value
+        data = &data[length];
+        while (*data++ != '\n');
+
+        // Check for sizeOfSettings value
+        length = strlen(nvmSettingsFileHasCrc);
+        if ((strncmp((char *)data, nvmSettingsFileHasCrc, length) !=0)
+            || (data[length] != '=') || (data[length + 1] != '1'))
+        {
+            systemPrintf("LFS:%s does not contain a CRC\r\n", fileName);
+            break;
+        }
+
+        //--------------------
+        // Compute the CRC across the setting values
+        //--------------------
+
+        // Compute the CRC across the first buffer of setting values
+        nvmCrc = 0;
+        nvmCrc = nvmBitBangCrc32(nvmCrc, buffer, bytesRead);
+
+        // Compute the CRC across the rest of the setting values
+        length = 0;
+        bytesRead = 0;
+        while (remainingBytes > sizeof(nvmCrc))
+        {
+            // Determine how much data to read
+            length = remainingBytes - sizeof(nvmCrc);
+            if (length > bufferLength)
+                length = bufferLength;
+
+            // Read some data, but not the CRC
+            bytesRead = nvmReadLfsFileData(&file, buffer, length);
+            if (bytesRead < 0)
+            {
+                systemPrintf("ERROR: Hard read error at offset %ld in NVM file %s\r\n",
+                             offset, fileName);
+                break;
+            }
+            if (bytesRead < length)
+            {
+                systemPrintf("ERROR: Failed to read all of the bytes!\r\n",
+                             offset, fileName);
+                break;
+            }
+            offset += bytesRead;
+            remainingBytes -= bytesRead;
+
+            // Compute the CRC across the setting values
+            nvmCrc = nvmBitBangCrc32(nvmCrc, buffer, bytesRead);
+        }
+        if ((bytesRead < 0) || (bytesRead < length))
+            break;
+
+        // Verify that the file contains enough bytes for the CRC
+        if (remainingBytes < sizeof(nvmCrc))
+        {
+            systemPrintf("ERROR: File too short to comtain a CRC value!\r\n");
+            break;
+        }
+
+        //--------------------
+        // Verify the final CRC value
+        //--------------------
+
+        uint32_t expectedCrc;
+
+        // Get the file CRC
+        uint32_t fileCrc;
+
+        bytesRead = nvmReadLfsFileData(&file, (uint8_t *)&fileCrc, sizeof(fileCrc));
+        if (bytesRead < 0)
+        {
+            systemPrintf("ERROR: Hard read error at offset %ld in LFS:%s\r\n",
+                         offset, fileName);
+            break;
+        }
+        if (bytesRead != sizeof(fileCrc))
+        {
+            systemPrintf("ERROR: Failed to read the CRC value from LFS:%s!\r\n", fileName);
+            break;
+        }
+
+        // Verify the file CRC
+        if (fileCrc == nvmCrc)
+            systemPrintf("Correct CRC for LFS:%s!\r\n", fileName);
+        else
+            systemPrintf("ERROR: Bad CRC for LFS:%s, expected: 0x%08x, in file: 0x%08x\r\n",
+                         fileName, nvmCrc, fileCrc);
+
+        // Verify that the CRC across the setting values and the fileCrc
+        // compute a value of zero
+        uint32_t finalCrc = nvmBitBangCrc32(nvmCrc, (uint8_t *)&nvmCrc, sizeof(nvmCrc));
+        if (finalCrc)
+            systemPrintf("ERROR: Bad CRC calculation, expected: 0x00000000, computed: 0x%08x\r\n", finalCrc);
+    } while (0);
+
+    // Done with the file
+    if (file)
+        file.close();
+
+    // Done with the buffer
+    if (buffer)
+        rtkFree(buffer, "NVM file dump buffer");
+}
+
+//----------------------------------------
+// Verify SD file CRC
+//----------------------------------------
+void nvmVerifySdFileCrc(const char * fileName)
+{
+    uint8_t * buffer = nullptr;
+    const size_t bufferLength = 8192;
+    ssize_t bytesRead;
+    uint8_t * data;
+    bool gotSemaphore = false;
+    size_t length;
+    size_t offset;
+    size_t remainingBytes;
+    const char * rtkIdentifier = "rtkIdentifier";
+    SdFile settingsFile; // FAT32
+    const char * sizeOfSettings = "sizeOfSettings=";
+    bool status = false; // Return false - until file is opened
+    bool wasSdCardOnline;
+
+    // Try to gain access the SD card
+    wasSdCardOnline = online.microSD;
+    if (online.microSD != true)
+        beginSD();
+
+    while (online.microSD == true)
+    {
+        // Attempt to access file system. This avoids collisions with file writing from other functions like
+        // recordSystemSettingsToFile() and gnssSerialReadTask()
+        if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
+        {
+            markSemaphore(FUNCTION_LOADSETTINGS);
+
+            gotSemaphore = true;
+
+            if (!sd->exists(fileName))
+            {
+                if (settings.debugSettings)
+                    systemPrintf("SD:%s not found\r\n", fileName);
+                break; // /while (online.microSD == true)
+            }
+
+            // Attempt to open the file
+            if (settingsFile.open(fileName, O_READ) == false)
+            {
+                systemPrintf("Failed to open settings SD:%s\r\n", fileName);
+                break; // /while (online.microSD == true)
+            }
+
+            do
+            {
+                remainingBytes = settingsFile.size();
+
+                // Allocate the buffer
+                buffer = (uint8_t *)rtkMalloc(bufferLength, "NVM file dump buffer");
+                if (buffer == nullptr)
+                {
+                    systemPrintf("ERROR: Failed to allocate the dump buffer\r\n");
+                    break;
+                }
+
+                // Walk the contents of the file
+                bytesRead = 0;
+                length = 0;
+                offset = 0;
+                if (remainingBytes > sizeof(nvmCrc))
+                {
+                    // Determine how much data to read
+                    length = remainingBytes - sizeof(nvmCrc);
+                    if (length > bufferLength)
+                        length = bufferLength;
+
+                    // Read some data
+                    bytesRead = nvmReadSdFileData(&settingsFile, buffer, length);
+                    if (bytesRead < 0)
+                    {
+                        systemPrintf("ERROR: Hard read error at offset %ld in NVM file %s\r\n",
+                                     offset, fileName);
+                        break;
+                    }
+                    if (bytesRead < length)
+                    {
+                        systemPrintf("ERROR: Failed to read all of the bytes!\r\n",
+                                     offset, fileName);
+                        break;
+                    }
+                    offset += bytesRead;
+                    remainingBytes -= bytesRead;
+                }
+                if ((bytesRead < 0) || (bytesRead < length))
+                    break;
+
+                //--------------------
+                // Verify the file header
+                //--------------------
+
+                // Check for sizeOfSettings value
+                length = strlen(sizeOfSettings);
+                if (strncmp((char *)buffer, sizeOfSettings, length) != 0)
+                {
+                    systemPrintf("ERROR: Not a settings file, %s missing!\r\n", sizeOfSettings);
+                    break;
+                }
+
+                // Skip over value
+                data = &buffer[length];
+                while (*data++ != '\n');
+
+                // Check for rtkIdentifier value
+                length = strlen(rtkIdentifier);
+                if (strncmp((char *)data, rtkIdentifier, length) != 0)
+                {
+                    systemPrintf("ERROR: Not a settings file, %s missing!\r\n", rtkIdentifier);
+                    break;
+                }
+
+                // Skip over value
+                data = &data[length];
+                while (*data++ != '\n');
+
+                // Check for sizeOfSettings value
+                length = strlen(nvmSettingsFileHasCrc);
+                if ((strncmp((char *)data, nvmSettingsFileHasCrc, length) !=0)
+                    || (data[length] != '=') || (data[length + 1] != '1'))
+                {
+                    systemPrintf("SD:%s does not contain a CRC\r\n", fileName);
+                    break;
+                }
+
+                //--------------------
+                // Compute the CRC across the setting values
+                //--------------------
+
+                // Compute the CRC across the first buffer of setting values
+                nvmCrc = 0;
+                nvmCrc = nvmBitBangCrc32(nvmCrc, buffer, bytesRead);
+
+                // Compute the CRC across the rest of the setting values
+                length = 0;
+                bytesRead = 0;
+                while (remainingBytes > sizeof(nvmCrc))
+                {
+                    // Determine how much data to read
+                    length = remainingBytes - sizeof(nvmCrc);
+                    if (length > bufferLength)
+                        length = bufferLength;
+
+                    // Read some data, but not the CRC
+                    bytesRead = nvmReadSdFileData(&settingsFile, buffer, length);
+                    if (bytesRead < 0)
+                    {
+                        systemPrintf("ERROR: Hard read error at offset %ld in NVM file %s\r\n",
+                                     offset, fileName);
+                        break;
+                    }
+                    if (bytesRead < length)
+                    {
+                        systemPrintf("ERROR: Failed to read all of the bytes!\r\n",
+                                     offset, fileName);
+                        break;
+                    }
+                    offset += bytesRead;
+                    remainingBytes -= bytesRead;
+
+                    // Compute the CRC across the setting values
+                    nvmCrc = nvmBitBangCrc32(nvmCrc, buffer, bytesRead);
+                }
+                if ((bytesRead < 0) || (bytesRead < length))
+                    break;
+
+                // Verify that the file contains enough bytes for the CRC
+                if (remainingBytes < sizeof(nvmCrc))
+                {
+                    systemPrintf("ERROR: File too short to comtain a CRC value!\r\n");
+                    break;
+                }
+
+                //--------------------
+                // Verify the final CRC value
+                //--------------------
+
+                uint32_t expectedCrc;
+
+                // Get the file CRC
+                uint32_t fileCrc;
+
+                bytesRead = nvmReadSdFileData(&settingsFile, (uint8_t *)&fileCrc, sizeof(fileCrc));
+                if (bytesRead < 0)
+                {
+                    systemPrintf("ERROR: Hard read error at offset %ld in SD:%s\r\n",
+                                 offset, fileName);
+                    break;
+                }
+                if (bytesRead != sizeof(fileCrc))
+                {
+                    systemPrintf("ERROR: Failed to read the CRC value from SD:%s!\r\n", fileName);
+                    break;
+                }
+
+                // Verify the file CRC
+                if (fileCrc == nvmCrc)
+                    systemPrintf("Correct CRC for SD:%s!\r\n", fileName);
+                else
+                    systemPrintf("ERROR: Bad CRC for SD:%s, expected: 0x%08x, in file: 0x%08x\r\n",
+                                 fileName, nvmCrc, fileCrc);
+
+                // Verify that the CRC across the setting values and the fileCrc
+                // compute a value of zero
+                uint32_t finalCrc = nvmBitBangCrc32(nvmCrc, (uint8_t *)&nvmCrc, sizeof(nvmCrc));
+                if (finalCrc)
+                    systemPrintf("ERROR: Bad CRC calculation, expected: 0x00000000, computed: 0x%08x\r\n", finalCrc);
+            } while (0);
+
+            // Done with the file
+            if (settingsFile)
+                settingsFile.close();
+
+            // Done with the buffer
+            if (buffer)
+                rtkFree(buffer, "NVM file dump buffer");
+        } // End Semaphore check
+        else
+        {
+            // This is an error because if the settings exist on the microSD card that
+            // those settings are not overriding the current settings as documented!
+            systemPrintf("sdCardSemaphore failed to yield, NVM.ino line %d\r\n", __LINE__);
+        }
+        break; // /while (online.microSD == true)
+    } // End SD online
+
+    // Release access the SD card
+    if (online.microSD && (!wasSdCardOnline))
+        endSD(gotSemaphore, true);
+    else if (gotSemaphore)
+        xSemaphoreGive(sdCardSemaphore);
 }

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -1128,9 +1128,8 @@ bool loadSystemSettingsFromFileLFS(char *fileName,
     nvmCrc = 0;
     while (settingsFile.available())
     {
-        // Get the next line from the file
-        // getLine will remove the \r - to match SD fgets
-        int n = getLine(&settingsFile, line, sizeof(line));
+        // Get the next line from the file and remove the \r
+        int n = getLfsLine(&settingsFile, line, sizeof(line));
 
         // Handle the file error
         if (n < 0)
@@ -1293,9 +1292,8 @@ bool printSystemSettingsFromFileLFS(char *fileName)
 
     while (settingsFile.available())
     {
-        // Get the next line from the file
-        // getLine will remove the \r - to match SD fgets
-        int n = getLine(&settingsFile, line, sizeof(line));
+        // Get the next line from the file and remove the \r
+        int n = getLfsLine(&settingsFile, line, sizeof(line));
 
         // Handle the file error
         if (n < 0)
@@ -1811,17 +1809,16 @@ bool parseLine(const char *theLine, struct Settings * tempSettings)
 }
 
 //----------------------------------------
-// The SD library doesn't have a fgets function like SD fat so recreate it here
-// Read the current line in the file until we hit a EOL char \r or \n
-// fgets removes the \r leaving only \n. getLine does the same thing
+// Read the current line from the LFS file until we hit a EOL char \r or
+// \n while computing the CRC.  Remove the \r leaving only the \n.
 //----------------------------------------
-int getLine(File *openFile, char *lineChars, int lineSize)
+int getLfsLine(File *lfsFile, char *lineChars, int lineSize)
 {
     int count = 0;
-    while (openFile->available() > 0)
+    while (lfsFile->available() > 0)
     {
         // Read the next byte from the file
-        int data = openFile->read();
+        int data = lfsFile->read();
 
         // Handle any file errors
         if (data < 0)

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -948,6 +948,7 @@ bool loadSystemSettingsFromFileSD(char *fileName,
             int lineNumber = 0;
             status = true; // File is open. Default status to true
 
+            nvmCrc = 0;
             while (settingsFile.available())
             {
                 // Get the next line from the file
@@ -1041,6 +1042,29 @@ bool loadSystemSettingsFromFileSD(char *fileName,
                     // Should we return true or false? Going with true...
                     break; // /while (settingsFile.available())
                 }
+
+                // Read and verify the CRC if present
+                if (tempSettings && tempSettings->settingsFileHasCrc && (settingsFile.available() == 4))
+                {
+                    // Finish computing the CRC
+                    while (settingsFile.available())
+                        nvmCrc = nvmBitBangCrc32Byte(nvmCrc, settingsFile.read());
+
+                    // Check for a bad CRC
+                    if (nvmCrc)
+                    {
+                        // Bad file CRC
+                        if (settings.debugSettings)
+                            systemPrintf("ERROR: Failed CRC check for file; %s!\r\n", fileName);
+                        status = false;
+                        break; // /while (settingsFile.available())
+                    }
+
+                    // Good CRC
+                    if (settings.debugSettings)
+                        systemPrintf("Correct CRC for file; %s!\r\n", fileName);
+                    break;
+                }
             }
 
             // systemPrintln("Config file read complete");
@@ -1097,10 +1121,11 @@ bool loadSystemSettingsFromFileLFS(char *fileName,
         return (false);
     }
 
-    char line[100];
+    char line[256];
     int lineNumber = 0;
     bool status = true; // File is open. Default status to true
 
+    nvmCrc = 0;
     while (settingsFile.available())
     {
         // Get the next line from the file
@@ -1193,6 +1218,42 @@ bool loadSystemSettingsFromFileLFS(char *fileName,
 
             // Should we return true or false? Going with true...
             break; // /while (settingsFile.available())
+        }
+
+        // Read and verify the CRC if present
+        if (tempSettings && tempSettings->settingsFileHasCrc && (settingsFile.available() == 4))
+        {
+            if (settings.debugSettings)
+                Serial.printf("Computed CRC 0x%08x before reading in CRC value from LFS:%s\r\n",
+                              nvmCrc, fileName);
+
+            // Finish computing the CRC
+            if (settings.debugSettings)
+                Serial.printf("Read in CRC 0x");
+            while (settingsFile.available())
+            {
+                uint8_t byte = settingsFile.read();
+                if (settings.debugSettings)
+                    Serial.printf("%02x", byte);
+                nvmCrc = nvmBitBangCrc32Byte(nvmCrc, byte);
+            }
+            if (settings.debugSettings)
+                Serial.printf(" value from LFS:%s\r\n", fileName);
+
+            // Check for a bad CRC
+            if (nvmCrc)
+            {
+                // Bad file CRC
+                systemPrintf("ERROR: Failed CRC (0x%08x) check for LFS:%s!\r\n",
+                             nvmCrc, fileName);
+                status = false;
+                break; // /while (settingsFile.available())
+            }
+
+            // Good CRC
+            if (settings.debugSettings)
+                systemPrintf("Correct CRC for LFS:%s!\r\n", fileName);
+            break;
         }
     }
 
@@ -1768,6 +1829,7 @@ int getLine(File *openFile, char *lineChars, int lineSize)
 
         // Get the data byte
         byte incoming = (byte)data;
+        nvmCrc = nvmBitBangCrc32Byte(nvmCrc, incoming);
         if (incoming == '\0')
         {
             break; // Something bad happened...

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -944,16 +944,15 @@ bool loadSystemSettingsFromFileSD(char *fileName,
                 break; // /while (online.microSD == true)
             }
 
-            char line[100];
+            char line[256];
             int lineNumber = 0;
             status = true; // File is open. Default status to true
 
             nvmCrc = 0;
             while (settingsFile.available())
             {
-                // Get the next line from the file
-                // Note: fgets stripts the \r (if there is one) leaving only \n
-                int n = settingsFile.fgets(line, sizeof(line));
+                // Get the next line from the file, stript the \r leaving just \n
+                int n = getSdLine(&settingsFile, line, sizeof(line));
 
                 // Handle the file error
                 if (n < 0)
@@ -1044,25 +1043,38 @@ bool loadSystemSettingsFromFileSD(char *fileName,
                 }
 
                 // Read and verify the CRC if present
-                if (tempSettings && tempSettings->settingsFileHasCrc && (settingsFile.available() == 4))
+                if (tempSettings && tempSettings->settingsFileHasCrc && (settingsFile.available() == sizeof(nvmCrc)))
                 {
+                    if (settings.debugSettings)
+                        Serial.printf("Computed CRC 0x%08x before reading in CRC value from SD:%s\r\n",
+                                      nvmCrc, fileName);
+
                     // Finish computing the CRC
+                    if (settings.debugSettings)
+                        Serial.printf("Read in CRC 0x");
                     while (settingsFile.available())
-                        nvmCrc = nvmBitBangCrc32Byte(nvmCrc, settingsFile.read());
+                    {
+                        uint8_t byte = settingsFile.read();
+                        if (settings.debugSettings)
+                            Serial.printf("%02x", byte);
+                        nvmCrc = nvmBitBangCrc32Byte(nvmCrc, byte);
+                    }
+                    if (settings.debugSettings)
+                        Serial.printf(" value from SD:%s\r\n", fileName);
 
                     // Check for a bad CRC
                     if (nvmCrc)
                     {
                         // Bad file CRC
-                        if (settings.debugSettings)
-                            systemPrintf("ERROR: Failed CRC check for file; %s!\r\n", fileName);
+                        systemPrintf("ERROR: Failed CRC (0x%08x) check for SD:%s!\r\n",
+                                     nvmCrc, fileName);
                         status = false;
                         break; // /while (settingsFile.available())
                     }
 
                     // Good CRC
                     if (settings.debugSettings)
-                        systemPrintf("Correct CRC for file; %s!\r\n", fileName);
+                        systemPrintf("Correct CRC for SD:%s!\r\n", fileName);
                     break;
                 }
             }
@@ -1819,6 +1831,49 @@ int getLfsLine(File *lfsFile, char *lineChars, int lineSize)
     {
         // Read the next byte from the file
         int data = lfsFile->read();
+
+        // Handle any file errors
+        if (data < 0)
+            return data;
+
+        // Get the data byte
+        byte incoming = (byte)data;
+        nvmCrc = nvmBitBangCrc32Byte(nvmCrc, incoming);
+        if (incoming == '\0')
+        {
+            break; // Something bad happened...
+        }
+        else if (incoming == '\r')
+        {
+            // Skip \r. fgets does the same thing
+        }
+        else if (incoming == '\n')
+        {
+            lineChars[count++] = incoming; // Record the \n. fgets does the same thing
+            break; // We are done
+        }
+        else if ((incoming >= ' ') && (incoming <= '~')) // Reject non-printables
+        {
+            lineChars[count++] = incoming; // Record everything else
+            if (count == lineSize - 1)
+                break; // Stop before overrun of buffer
+        }
+    }
+    lineChars[count] = '\0'; // Terminate string
+    return (count);
+}
+
+//----------------------------------------
+// Read the current line from the LFS file until we hit a EOL char \r or
+// \n while computing the CRC.  Remove the \r leaving only the \n.
+//----------------------------------------
+int getSdLine(SdFile *sdFile, char *lineChars, int lineSize)
+{
+    int count = 0;
+    while (sdFile->available() > 0)
+    {
+        // Read the next byte from the file
+        int data = sdFile->read();
 
         // Handle any file errors
         if (data < 0)

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -70,6 +70,8 @@ bool loadSystemSettingsFromFileSD(char *fileName,
 // 1 0000 0100 1100 0001 0001 1101 1011 0111
 const uint32_t nvmCrc32Polynomial = 0x04c11db7;
 
+const char * nvmSettingsFileHasCrc = "settingsFileHasCrc";
+
 //----------------------------------------
 // Locals
 //----------------------------------------
@@ -592,6 +594,7 @@ void recordSystemSettingsToFile(File *settingsFile)
     // Write the header (required values) to the file
     SETTINGS_FILE_PRINTF_3("%s=%d\r\n", "sizeOfSettings", settings.sizeOfSettings);
     SETTINGS_FILE_PRINTF_3("%s=%d\r\n", "rtkIdentifier", settings.rtkIdentifier);
+    SETTINGS_FILE_PRINTF_3("%s=%d\r\n", nvmSettingsFileHasCrc, false);
 
     if (settings.debugSettings)
         systemPrintf("numRtkSettingsEntries: %d\r\n", numRtkSettingsEntries);
@@ -1379,6 +1382,11 @@ bool parseLine(const char *theLine, struct Settings * tempSettings)
                              (int)d, (int)sizeof(Settings));
         }
 
+        knownSetting = true;
+    }
+    else if (strcmp(settingName, nvmSettingsFileHasCrc) == 0)
+    {
+        tempSettings->settingsFileHasCrc = (bool)d;
         knownSetting = true;
     }
 

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -71,6 +71,25 @@ bool loadSystemSettingsFromFileSD(char *fileName,
 const uint32_t nvmCrc32Polynomial = 0x04c11db7;
 
 //----------------------------------------
+// Locals
+//----------------------------------------
+
+static uint32_t nvmCrc;
+static File * nvmSettingsFile;
+
+//----------------------------------------
+// Macros
+//----------------------------------------
+
+#define SETTINGS_FILE_PRINTF_3(format, name, value)             \
+    snprintf(line, sizeof(line), format, name, value);          \
+    nvmRecordStringToFile(line)
+
+#define SETTINGS_FILE_PRINTF_4(format, name, index, value)      \
+    snprintf(line, sizeof(line), format, name, index, value);   \
+    nvmRecordStringToFile(line)
+
+//----------------------------------------
 // We use the LittleFS library to store user profiles in SPIFFs
 // Move selected user profile from SPIFFs into settings struct (RAM)
 // We originally used EEPROM but it was limited to 4096 bytes. Each settings struct is ~4000 bytes
@@ -549,6 +568,15 @@ uint32_t nvmBitBangCrc32(uint32_t crc, const uint8_t * data, size_t length)
 }
 
 //----------------------------------------
+// Compute the CRC for the line and write the string to the file
+void nvmRecordStringToFile(const char * string)
+//----------------------------------------
+{
+    nvmCrc = nvmBitBangCrc32(nvmCrc, (uint8_t *)string, strlen(string));
+    nvmSettingsFile->printf("%s", string);
+}
+
+//----------------------------------------
 // Write the settings struct to a clear text file
 // The order of variables matches the order found in settings.h
 //----------------------------------------
@@ -556,6 +584,11 @@ void recordSystemSettingsToFile(File *settingsFile)
 {
     RTK_Settings_Types type;
 
+    // Initialize the CRC and save the file pointer
+    nvmCrc = 0;
+    nvmSettingsFile = settingsFile;
+
+    // Write the header (required values) to the file
     settingsFile->printf("%s=%d\r\n", "sizeOfSettings", settings.sizeOfSettings);
     settingsFile->printf("%s=%d\r\n", "rtkIdentifier", settings.rtkIdentifier);
 
@@ -817,6 +850,9 @@ void recordSystemSettingsToFile(File *settingsFile)
     // Firmware URLs
     settingsFile->printf("%s=%s\r\n", "otaRcFirmwareJsonUrl", otaRcFirmwareJsonUrl);
     settingsFile->printf("%s=%s\r\n", "otaFirmwareJsonUrl", otaFirmwareJsonUrl);
+
+    // Forget the file pointer
+    nvmSettingsFile = nullptr;
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/menuSystem.ino
+++ b/Firmware/RTK_Everywhere/menuSystem.ino
@@ -498,7 +498,7 @@ void menuDebugFiles()
         // *** Start of menu ***
         // Support file dumping
         getProfileFileName(profile, fileName, sizeof(fileName));
-        systemPrintf("d) Dump file: %s%s\r\n",
+        systemPrintf("d) Dump file: %s:%s\r\n",
                      sdActive ? "SD" : "NVM", fileName);
 
         // Support directory listings
@@ -507,6 +507,10 @@ void menuDebugFiles()
         // Toggle between NVM and SD card
         if (online.microSD)
             systemPrintf("t) Toggle between NVM and SD\r\n");
+
+        // Verify file CRC
+        systemPrintf("v) Verify %s:%s CRC\r\n",
+                     sdActive ? "SD" : "NVM", fileName);
 
         // Release access the SD card
         if (sdActive)
@@ -559,6 +563,15 @@ void menuDebugFiles()
         // Toggle the selection between NVM and the SD card
         else if (incoming == 't')
             sdActive = ! sdActive;
+
+        // Verify the file CRC
+        else if (incoming == 'v')
+        {
+            if (sdActive)
+                nvmVerifySdFileCrc(fileName);
+            else
+                nvmVerifyLfsFileCrc(fileName);
+        }
 
         // All done with this menu
         else if (incoming == 'x')

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -736,6 +736,9 @@ struct Settings
     int sizeOfSettings = 0;             // sizeOfSettings **must** be the first entry and must be int
     int rtkIdentifier = RTK_IDENTIFIER; // rtkIdentifier **must** be the second entry
 
+    // CRC control, old files missing this value use false, new file write true
+    bool settingsFileHasCrc = false;    // settingsFileHasCrc **must** be the third entry
+
     //Once we detect the platform or receiver, no need to re-detect
     //ProductVariant previouslyDetectedPlatform = RTK_UNKNOWN; //Because LFS is started after deviceID, this is mute
     gnssReceiverType_e detectedGnssReceiver = GNSS_RECEIVER_UNKNOWN;


### PR DESCRIPTION
This pull request includes the following commits:
* NVM: Display device LFS: or SD: before the file name
* NVM: Add CRC calculation routines nvmBitBangCrc32 & nvmBitBangCrc32Byte
* NVM: Add nvmRecordStringToFile to compute CRC and write a setting string
* NVM: Use macros to compute CRC and write setting values to the file
* GNSS: Use nvmRecordStringToFile to write the string to settings file
* settings.h: Add settingsFileHasCrc value
    If a settings file does not contain the settingsFileHasCrc value then
    false is used.  If the settings file has the settingsFileHasCrc value
    then its value is used.  Note that the settingsFileHasCrc is always
    written to the settings file as true!
* NVM: Finish computing the CRC
* File menu: Add -v option to verify the file CRC
* NVM: Compute the CRC while reading the settings file
* NVM: Rename getLine to getLfsLine and parameter from openFile to lfsFile
* NVM: Add getSdLine routine, compute CRC while reading data from SD card
