### PR TITLE
Fix crash in gnssReadTask after tasksStopGnssUart is called

### DIFF
--- a/Firmware/RTK_Everywhere/Tasks.ino
+++ b/Firmware/RTK_Everywhere/Tasks.ino
@@ -338,6 +338,7 @@ void gnssReadTask(void *e)
 
     rtkBuffer = nullptr;
     sbfBuffer = nullptr;
+    spartnBuffer = nullptr;
 
     // Start notification
     task.gnssReadTaskRunning = true;


### PR DESCRIPTION
Bug: Attempt to free spartnBuffer when it was never initialized.

Fix: Initialize spartnBuffer to remove the need to free it