### PR TITLE
Add GNSS-Specific Configuration. Add LG290P RTK Differential Age and Source Type

### DIFF
--- a/Firmware/Dockerfile
+++ b/Firmware/Dockerfile
@@ -99,8 +99,8 @@ RUN arduino-cli config set library.enable_unsafe_install true
 # Install SparkFun fork of ESP32_BleSerial
 RUN arduino-cli lib install --git-url https://github.com/sparkfun/ESP32_BleSerial.git
 
-# Install new release of SparkFun LG290P Quadband RTK GNSS Arduino Library
-#RUN arduino-cli lib install --git-url https://github.com/sparkfun/.git
+# Install v3.0.2 of SparkFun LG290P Quadband RTK GNSS Arduino Library
+#RUN arduino-cli lib install --git-url https://github.com/sparkfun/SparkFun_LG290P_GNSS_Arduino_Library.git
 
 # The Accessory and Authentication Coprocessor libraries depends=SparkFun Toolkit (>=1.0.6)
 RUN arduino-cli lib install "SparkFun Toolkit"@1.0.6

--- a/Firmware/Dockerfile
+++ b/Firmware/Dockerfile
@@ -99,9 +99,6 @@ RUN arduino-cli config set library.enable_unsafe_install true
 # Install SparkFun fork of ESP32_BleSerial
 RUN arduino-cli lib install --git-url https://github.com/sparkfun/ESP32_BleSerial.git
 
-# Install v3.0.2 of SparkFun LG290P Quadband RTK GNSS Arduino Library
-#RUN arduino-cli lib install --git-url https://github.com/sparkfun/SparkFun_LG290P_GNSS_Arduino_Library.git
-
 # The Accessory and Authentication Coprocessor libraries depends=SparkFun Toolkit (>=1.0.6)
 RUN arduino-cli lib install "SparkFun Toolkit"@1.0.6
 

--- a/Firmware/Dockerfile
+++ b/Firmware/Dockerfile
@@ -80,7 +80,7 @@ RUN arduino-cli lib install "ArduinoMqttClient"@0.1.8
 RUN arduino-cli lib install "SparkFun u-blox PointPerfect Library"@1.11.4
 RUN arduino-cli lib install "SparkFun IM19 IMU Arduino Library"@1.0.2
 RUN arduino-cli lib install "SparkFun UM980 Triband RTK GNSS Arduino Library"@2.0.1
-RUN arduino-cli lib install "SparkFun LG290P Quadband RTK GNSS Arduino Library"@3.0.1
+RUN arduino-cli lib install "SparkFun LG290P Quadband RTK GNSS Arduino Library"@3.0.2
 RUN arduino-cli lib install "SparkFun I2C Expander Arduino Library"@1.0.1
 
 # Install the depends last. See:
@@ -98,6 +98,9 @@ RUN arduino-cli config set library.enable_unsafe_install true
 
 # Install SparkFun fork of ESP32_BleSerial
 RUN arduino-cli lib install --git-url https://github.com/sparkfun/ESP32_BleSerial.git
+
+# Install new release of SparkFun LG290P Quadband RTK GNSS Arduino Library
+#RUN arduino-cli lib install --git-url https://github.com/sparkfun/.git
 
 # The Accessory and Authentication Coprocessor libraries depends=SparkFun Toolkit (>=1.0.6)
 RUN arduino-cli lib install "SparkFun Toolkit"@1.0.6

--- a/Firmware/RTK_Everywhere/AP-Config/index.html
+++ b/Firmware/RTK_Everywhere/AP-Config/index.html
@@ -452,25 +452,25 @@
                             </div>
                         </div>
 
-                        <div class="form-group row" id="rtkDifferentialAgeConfig">
+                        <div class="form-group row" id="lg290pRtkDifferentialAgeConfig">
                             <div class="form-group row">
-                                <label for="rtkDifferentialAge" class="col-sm-4 col-6 col-form-label">RTK Differential Age:
+                                <label for="lg290pRtkDifferentialAge" class="col-sm-4 col-6 col-form-label">RTK Differential Age:
                                     <span class="tt" data-bs-placement="right"
                                         title="Max differential age of RTK fix. Default: 120">
                                         <span class="icon-info-circle text-primary ms-2"></span>
                                     </span>
                                 </label>
                                 <div class="col-sm-4 col-6">
-                                    <input type="number" class="form-control" id="rtkDifferentialAge">
-                                    <p id="rtkDifferentialAgeError" class="inlineError"></p>
+                                    <input type="number" class="form-control" id="lg290pRtkDifferentialAge">
+                                    <p id="lg290pRtkDifferentialAgeError" class="inlineError"></p>
                                 </div>
                             </div>
                         </div>
 
-                        <div class="form-group row" id="rtkDifferentialSourceTypeConfig">
-                            <div id="rtkDifferentialSourceTypeDropdown" class="mb-2">
-                                <label for="rtkDifferentialSourceType">RTK Differential Source Type: </label>
-                                <select name="rtkDifferentialSourceType" id="rtkDifferentialSourceType" class="form-dropdown">
+                        <div class="form-group row" id="lg290pRtkDifferentialSourceTypeConfig">
+                            <div id="lg290pRtkDifferentialSourceTypeDropdown" class="mb-2">
+                                <label for="lg290pRtkDifferentialSourceType">RTK Differential Source Type: </label>
+                                <select name="lg290pRtkDifferentialSourceType" id="lg290pRtkDifferentialSourceType" class="form-dropdown">
                                     <option value="0">Auto</option>
                                     <option value="1">Normal</option>
                                     <option value="2">Wide Lane</option>

--- a/Firmware/RTK_Everywhere/AP-Config/index.html
+++ b/Firmware/RTK_Everywhere/AP-Config/index.html
@@ -451,6 +451,37 @@
                                 </div>
                             </div>
                         </div>
+
+                        <div class="form-group row" id="rtkDifferentialAgeConfig">
+                            <div class="form-group row">
+                                <label for="rtkDifferentialAge" class="col-sm-4 col-6 col-form-label">RTK Differential Age:
+                                    <span class="tt" data-bs-placement="right"
+                                        title="Max differential age of RTK fix. Default: 120">
+                                        <span class="icon-info-circle text-primary ms-2"></span>
+                                    </span>
+                                </label>
+                                <div class="col-sm-4 col-6">
+                                    <input type="number" class="form-control" id="rtkDifferentialAge">
+                                    <p id="rtkDifferentialAgeError" class="inlineError"></p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="form-group row" id="rtkDifferentialSourceTypeConfig">
+                            <div id="rtkDifferentialSourceTypeDropdown" class="mb-2">
+                                <label for="rtkDifferentialSourceType">RTK Differential Source Type: </label>
+                                <select name="rtkDifferentialSourceType" id="rtkDifferentialSourceType" class="form-dropdown">
+                                    <option value="0">Auto</option>
+                                    <option value="1">Normal</option>
+                                    <option value="2">Wide Lane</option>
+                                </select>
+                                <span class="tt" data-bs-placement="right"
+                                    title="The RTK differential source type. Default: Auto">
+                                    <span class="icon-info-circle text-primary ms-2"></span>
+                                </span>
+                                <br>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="form-check mt-3">

--- a/Firmware/RTK_Everywhere/AP-Config/src/main.js
+++ b/Firmware/RTK_Everywhere/AP-Config/src/main.js
@@ -98,6 +98,8 @@ var divTables = {
     tiltConfig: ["enableTiltCompensation"],
     loraConfig: ["enableLora"],
     loraSerialInteractionTimeoutConfig: ["loraSerialInteractionTimeout"],
+    rtkDifferentialAgeConfig: ["rtkDifferentialAge"],
+    rtkDifferentialSourceTypeConfig: ["rtkDifferentialSourceType"],
 };
 
 function showHideDivs() {
@@ -1218,6 +1220,9 @@ function validateFields() {
     checkElementValue("minCN0", 0, 90, "Must be between 0 and 90", "collapseGNSSConfig");
     if (isElementShown("lg290pGnssSettings") == true) {
         checkElementValue("rtcmMinElev", -90, 90, "Must be between -90 and 90", "collapseGNSSConfig");
+    }
+    if (isElementShown("rtkDifferentialAgeConfig") == true) {
+        checkElementValue("rtkDifferentialAge", 1, 600, "Must be between 1 and 600", "collapseGNSSConfig");
     }
 
     if (isElementShown("pppSettings") == true) {

--- a/Firmware/RTK_Everywhere/AP-Config/src/main.js
+++ b/Firmware/RTK_Everywhere/AP-Config/src/main.js
@@ -98,8 +98,8 @@ var divTables = {
     tiltConfig: ["enableTiltCompensation"],
     loraConfig: ["enableLora"],
     loraSerialInteractionTimeoutConfig: ["loraSerialInteractionTimeout"],
-    rtkDifferentialAgeConfig: ["rtkDifferentialAge"],
-    rtkDifferentialSourceTypeConfig: ["rtkDifferentialSourceType"],
+    lg290pRtkDifferentialAgeConfig: ["lg290pRtkDifferentialAge"],
+    lg290pRtkDifferentialSourceTypeConfig: ["lg290pRtkDifferentialSourceType"],
 };
 
 function showHideDivs() {
@@ -1221,8 +1221,8 @@ function validateFields() {
     if (isElementShown("lg290pGnssSettings") == true) {
         checkElementValue("rtcmMinElev", -90, 90, "Must be between -90 and 90", "collapseGNSSConfig");
     }
-    if (isElementShown("rtkDifferentialAgeConfig") == true) {
-        checkElementValue("rtkDifferentialAge", 1, 600, "Must be between 1 and 600", "collapseGNSSConfig");
+    if (isElementShown("lg290pRtkDifferentialAgeConfig") == true) {
+        checkElementValue("lg290pRtkDifferentialAge", 1, 600, "Must be between 1 and 600", "collapseGNSSConfig");
     }
 
     if (isElementShown("pppSettings") == true) {

--- a/Firmware/RTK_Everywhere/GNSS.h
+++ b/Firmware/RTK_Everywhere/GNSS.h
@@ -253,6 +253,10 @@ class GNSS
     virtual bool gnssInBaseSurveyInMode();
     virtual bool gnssInRoverMode();
 
+    // Indicate if there are any additional settings specific to this GNSS
+    // This governs setGnssSpecificConfiguration() and menuGnssSpecificConfiguration()
+    virtual bool hasGnssSpecificConfiguration();
+
     // Antenna Short / Open detection
     virtual bool isAntennaShorted();
     virtual bool isAntennaOpen();
@@ -308,6 +312,9 @@ class GNSS
     // Controls the constellations that are used to generate a fix and logged
     virtual void menuConstellations();
 
+    // Configure any settings specific to this GNSS
+    virtual void menuGnssSpecificConfiguration();
+
     virtual void menuMessageBaseRtcm();
 
     // Control the messages that get broadcast over Bluetooth and logged (if enabled)
@@ -361,6 +368,9 @@ class GNSS
     // Inputs:
     //   elevationDegrees: The elevation value in degrees
     virtual bool setElevation(uint8_t elevationDegrees);
+
+    // Configure any additional settings specific to this GNSS
+    virtual bool setGnssSpecificConfiguration();
 
     virtual bool setPppService();
 

--- a/Firmware/RTK_Everywhere/GNSS.ino
+++ b/Firmware/RTK_Everywhere/GNSS.ino
@@ -154,6 +154,7 @@ enum
     GNSS_CONFIG_LOGGING,         // Enable / disable logging
     GNSS_CONFIG_SAVE,            // Indicates current settings be saved to GNSS receiver NVM
     GNSS_CONFIG_RESET,           // Indicates receiver needs resetting
+    GNSS_CONFIG_GNSS_SPECIFIC,   // Settings specific to this GNSS
 
     // Add new entries above here
     GNSS_CONFIG_MAX,
@@ -184,6 +185,7 @@ static const char *gnssConfigDisplayNames[] = {
     "LOGGING",
     "SAVE",
     "RESET",
+    "GNSS_SPECIFIC",
 };
 
 static const int gnssConfigStateEntries = sizeof(gnssConfigDisplayNames) / sizeof(gnssConfigDisplayNames[0]);
@@ -201,6 +203,15 @@ bool GNSS::comPortRefresh()
 }
 
 //----------------------------------------
+// Indicate if there are any additional settings specific to this GNSS
+// This governs setGnssSpecificConfiguration() and menuGnssSpecificConfiguration()
+//----------------------------------------
+bool GNSS::hasGnssSpecificConfiguration()
+{
+    return false; // Default to false ("no"). GNSS class implementation - if present - return true.
+}
+
+//----------------------------------------
 // Returns true if the antenna is shorted
 //----------------------------------------
 bool GNSS::isAntennaShorted()
@@ -214,6 +225,22 @@ bool GNSS::isAntennaShorted()
 bool GNSS::isAntennaOpen()
 {
     return false;
+}
+
+//----------------------------------------
+// Configure any settings specific to this GNSS
+//----------------------------------------
+void GNSS::menuGnssSpecificConfiguration()
+{
+    ; // Nothing to do here....
+}
+
+//----------------------------------------
+// Configure any additional settings specific to this GNSS
+//----------------------------------------
+bool GNSS::setGnssSpecificConfiguration()
+{
+    return true; // Return true to clear GNSS_CONFIG_GNSS_SPECIFIC
 }
 
 // Antenna Short / Open detection
@@ -471,6 +498,15 @@ void gnssUpdate()
             if (gnss->setLogging() == true)
             {
                 gnssConfigureClear(GNSS_CONFIG_LOGGING);
+                gnssConfigure(GNSS_CONFIG_SAVE); // Request receiver commit this change to NVM
+            }
+        }
+
+        if (gnssConfigureRequested(GNSS_CONFIG_GNSS_SPECIFIC))
+        {
+            if (gnss->setGnssSpecificConfiguration() == true)
+            {
+                gnssConfigureClear(GNSS_CONFIG_GNSS_SPECIFIC);
                 gnssConfigure(GNSS_CONFIG_SAVE); // Request receiver commit this change to NVM
             }
         }

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.h
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.h
@@ -344,6 +344,10 @@ class GNSS_LG290P : GNSS
     bool gnssInBaseSurveyInMode();
     bool gnssInRoverMode();
 
+    // Indicate if there are any additional settings specific to this GNSS
+    // This governs setGnssSpecificConfiguration() and menuGnssSpecificConfiguration()
+    bool hasGnssSpecificConfiguration();
+
     bool isBlocking();
 
     // Date is confirmed once we have GNSS fix
@@ -394,6 +398,9 @@ class GNSS_LG290P : GNSS
 
     // Controls the constellations that are used to generate a fix and logged
     void menuConstellations();
+
+    // Configure any settings specific to this GNSS
+    void menuGnssSpecificConfiguration();
 
     void menuMessageBaseRtcm();
 
@@ -448,6 +455,9 @@ class GNSS_LG290P : GNSS
     // Inputs:
     //   elevationDegrees: The elevation value in degrees
     bool setElevation(uint8_t elevationDegrees);
+
+    // Configure any additional settings specific to this GNSS
+    bool setGnssSpecificConfiguration();
 
     bool setPppService();
 

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -1148,6 +1148,14 @@ bool GNSS_LG290P::gnssInRoverMode()
     return (false);
 }
 
+//----------------------------------------
+// Indicate if there are any additional settings specific to this GNSS
+//----------------------------------------
+bool GNSS_LG290P::hasGnssSpecificConfiguration()
+{
+    return true;
+}
+
 // If we issue a library command that must wait for a response, we don't want
 // the gnssReadTask() gobbling up the data before the library can use it
 // Check to see if the library is expecting a response
@@ -1383,29 +1391,24 @@ void GNSS_LG290P::menuConstellations()
             systemPrintln();
         }
 
-        systemPrintf("%d) RTK Differential Age: %ds\r\n", MAX_LG290P_CONSTELLATIONS + 1, settings.rtkDifferentialAge);
-        systemPrintf("%d) RTK Differential Source Type: %s\r\n", MAX_LG290P_CONSTELLATIONS + 2,
-            settings.rtkDifferentialSourceType == 0 ? "Auto" :
-            settings.rtkDifferentialSourceType == 1 ? "Normal" : "Wide Lane");
-
         if (present.pppCapable)
         {
-            systemPrintf("%d) PPP Mode: %s\r\n", MAX_LG290P_CONSTELLATIONS + 3,
+            systemPrintf("%d) PPP Mode: %s\r\n", MAX_LG290P_CONSTELLATIONS + 1,
                          settings.pppMode == PPP_MODE_DISABLE ? "Disabled"
                          : settings.pppMode == PPP_MODE_HAS   ? "HAS"
                          : settings.pppMode == PPP_MODE_B2B   ? "B2B"
                                                               : "Auto");
             if (settings.pppMode > PPP_MODE_DISABLE)
             {
-                systemPrintf("%d) PPP Datum: %s\r\n", MAX_LG290P_CONSTELLATIONS + 4,
+                systemPrintf("%d) PPP Datum: %s\r\n", MAX_LG290P_CONSTELLATIONS + 2,
                              settings.pppDatum == 1   ? "WGS84"
                              : settings.pppDatum == 2 ? "PPP Original"
                              : settings.pppDatum == 3 ? "CGCS2000"
                                                       : "Unknown");
-                systemPrintf("%d) PPP Timeout: %d\r\n", MAX_LG290P_CONSTELLATIONS + 5, settings.pppTimeout);
-                systemPrintf("%d) PPP Horizontal Convergence Accuracy: %0.2f\r\n", MAX_LG290P_CONSTELLATIONS + 6,
+                systemPrintf("%d) PPP Timeout: %d\r\n", MAX_LG290P_CONSTELLATIONS + 3, settings.pppTimeout);
+                systemPrintf("%d) PPP Horizontal Convergence Accuracy: %0.2f\r\n", MAX_LG290P_CONSTELLATIONS + 4,
                              settings.pppHorizontalConvergence);
-                systemPrintf("%d) PPP Vertical Convergence Accuracy: %0.2f\r\n", MAX_LG290P_CONSTELLATIONS + 7,
+                systemPrintf("%d) PPP Vertical Convergence Accuracy: %0.2f\r\n", MAX_LG290P_CONSTELLATIONS + 5,
                              settings.pppVerticalConvergence);
             }
         }
@@ -1421,22 +1424,7 @@ void GNSS_LG290P::menuConstellations()
             settings.lg290pConstellations[incoming] ^= 1;
             gnssConfigure(GNSS_CONFIG_CONSTELLATION); // Request receiver to use new settings
         }
-        else if (incoming == MAX_LG290P_CONSTELLATIONS + 1)
-        {
-            uint16_t newAge = 120;
-            if (getNewSetting("Enter RTK Differential Age", 1, 600, &newAge) == INPUT_RESPONSE_VALID)
-            {
-                settings.rtkDifferentialAge = newAge;
-                gnssConfigure(GNSS_CONFIG_CONSTELLATION); // Request receiver to use new settings
-            }
-        }
-        else if (incoming == MAX_LG290P_CONSTELLATIONS + 2)
-        {
-            settings.rtkDifferentialSourceType += 1;
-            settings.rtkDifferentialSourceType %= 3;
-            gnssConfigure(GNSS_CONFIG_CONSTELLATION); // Request receiver to use new settings
-        }
-        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 3) && present.pppCapable)
+        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 1) && present.pppCapable)
         {
             int newMode = 0;
             if (getNewSetting("Enter PPP Mode (0 = Disable, 1 = B2b PPP, 2 = E6 HAS, 255 = Auto)", 0, 255, &newMode) ==
@@ -1452,7 +1440,7 @@ void GNSS_LG290P::menuConstellations()
                     systemPrintln("Error: Out of range");
             }
         }
-        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 4) && present.pppCapable)
+        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 2) && present.pppCapable)
         {
             if (getNewSetting("Enter PPP Datum Number (1 = WGS84, 2 = PPP Original, 3 = CGCS2000)", 1, 3,
                               &settings.pppDatum) == INPUT_RESPONSE_VALID)
@@ -1460,7 +1448,7 @@ void GNSS_LG290P::menuConstellations()
                 gnssConfigure(GNSS_CONFIG_PPP); // Request receiver to use new settings
             }
         }
-        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 5) && present.pppCapable)
+        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 3) && present.pppCapable)
         {
             if (getNewSetting("Enter PPP Timeout before fallback (seconds)", 90, 180, &settings.pppTimeout) ==
                 INPUT_RESPONSE_VALID)
@@ -1468,7 +1456,7 @@ void GNSS_LG290P::menuConstellations()
                 gnssConfigure(GNSS_CONFIG_PPP); // Request receiver to use new settings
             }
         }
-        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 6) && present.pppCapable)
+        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 4) && present.pppCapable)
         {
             if (getNewSetting("Enter PPP Horizontal Convergence Accuracy (meters)", 0.0f, 5.0f,
                               &settings.pppHorizontalConvergence) == INPUT_RESPONSE_VALID)
@@ -1476,13 +1464,59 @@ void GNSS_LG290P::menuConstellations()
                 gnssConfigure(GNSS_CONFIG_PPP); // Request receiver to use new settings
             }
         }
-        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 7) && present.pppCapable)
+        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 5) && present.pppCapable)
         {
             if (getNewSetting("Enter PPP Vertical Convergence Accuracy (meters)", 0.0f, 5.0f,
                               &settings.pppVerticalConvergence) == INPUT_RESPONSE_VALID)
             {
                 gnssConfigure(GNSS_CONFIG_PPP); // Request receiver to use new settings
             }
+        }
+
+        else if (incoming == INPUT_RESPONSE_GETNUMBER_EXIT)
+            break;
+        else if (incoming == INPUT_RESPONSE_GETNUMBER_TIMEOUT)
+            break;
+        else
+            printUnknown(incoming);
+    }
+
+    clearBuffer(); // Empty buffer of any newline chars
+}
+
+//----------------------------------------
+// Configure any settings specific to this GNSS
+//----------------------------------------
+void GNSS_LG290P::menuGnssSpecificConfiguration()
+{
+    while (1)
+    {
+        systemPrintln();
+        systemPrintln("Menu: GNSS-Specific Configuration");
+
+        systemPrintf("1) RTK Differential Age: %ds\r\n", settings.lg290pRtkDifferentialAge);
+        systemPrintf("2) RTK Differential Source Type: %s\r\n",
+            settings.lg290pRtkDifferentialSourceType == 0 ? "Auto" :
+            settings.lg290pRtkDifferentialSourceType == 1 ? "Normal" : "Wide Lane");
+
+        systemPrintln("x) Exit");
+
+        int incoming = getUserInputNumber(); // Returns EXIT, TIMEOUT, or long
+
+        if (incoming == 1)
+        {
+            uint16_t newAge = 120;
+            if (getNewSetting("Enter RTK Differential Age", 1, 600, &newAge) == INPUT_RESPONSE_VALID)
+            {
+                settings.lg290pRtkDifferentialAge = newAge;
+                gnssConfigure(GNSS_CONFIG_GNSS_SPECIFIC); // Request receiver to use new settings
+            }
+        }
+        else if (incoming == 2)
+        {
+            settings.lg290pRtkDifferentialSourceType += 1;
+            settings.lg290pRtkDifferentialSourceType %= 3;
+            gnssConfigure(GNSS_CONFIG_GNSS_SPECIFIC); // Request receiver to use new settings
         }
 
         else if (incoming == INPUT_RESPONSE_GETNUMBER_EXIT)
@@ -1977,8 +2011,8 @@ bool GNSS_LG290P::setConstellations()
                                                settings.lg290pConstellations[3],  // BDS
                                                settings.lg290pConstellations[4],  // QZSS
                                                settings.lg290pConstellations[5]); // NavIC
-        response &= _lg290p->setRtkDifferentialAge(settings.rtkDifferentialAge);
-        response &= _lg290p->setRtkDifferentialSourceType(settings.rtkDifferentialSourceType);
+        response &= _lg290p->setRtkDifferentialAge(settings.lg290pRtkDifferentialAge);
+        response &= _lg290p->setRtkDifferentialSourceType(settings.lg290pRtkDifferentialSourceType);
     }
 
     gnssConfigure(GNSS_CONFIG_RESET); // Constellation changes require device save/restart
@@ -2052,6 +2086,24 @@ bool GNSS_LG290P::setElevation(uint8_t elevationDegrees)
 
     // Because we call this during module setup we rely on a positive result
     return true;
+}
+
+//----------------------------------------
+// Configure any additional settings specific to this GNSS
+//----------------------------------------
+bool GNSS_LG290P::setGnssSpecificConfiguration()
+{
+    bool response = true;
+
+    if (online.gnss)
+    {
+        response &= _lg290p->setRtkDifferentialAge(settings.lg290pRtkDifferentialAge);
+        response &= _lg290p->setRtkDifferentialSourceType(settings.lg290pRtkDifferentialSourceType);
+    }
+
+    gnssConfigure(GNSS_CONFIG_RESET); // Changes require device save/restart
+
+    return (response);
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -2006,11 +2006,11 @@ bool GNSS_LG290P::setConstellations()
     if (online.gnss)
     {
         response = _lg290p->setConstellations(settings.lg290pConstellations[0],  // GPS
-                                               settings.lg290pConstellations[1],  // GLONASS
-                                               settings.lg290pConstellations[2],  // Galileo
-                                               settings.lg290pConstellations[3],  // BDS
-                                               settings.lg290pConstellations[4],  // QZSS
-                                               settings.lg290pConstellations[5]); // NavIC
+                                              settings.lg290pConstellations[1],  // GLONASS
+                                              settings.lg290pConstellations[2],  // Galileo
+                                              settings.lg290pConstellations[3],  // BDS
+                                              settings.lg290pConstellations[4],  // QZSS
+                                              settings.lg290pConstellations[5]); // NavIC
     }
 
     gnssConfigure(GNSS_CONFIG_RESET); // Constellation changes require device save/restart

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -1383,24 +1383,29 @@ void GNSS_LG290P::menuConstellations()
             systemPrintln();
         }
 
+        systemPrintf("%d) RTK Differential Age: %ds\r\n", MAX_LG290P_CONSTELLATIONS + 1, settings.rtkDifferentialAge);
+        systemPrintf("%d) RTK Differential Source Type: %s\r\n", MAX_LG290P_CONSTELLATIONS + 2,
+            settings.rtkDifferentialSourceType == 0 ? "Auto" :
+            settings.rtkDifferentialSourceType == 1 ? "Normal" : "Wide Lane");
+
         if (present.pppCapable)
         {
-            systemPrintf("%d) PPP Mode: %s\r\n", MAX_LG290P_CONSTELLATIONS + 1,
+            systemPrintf("%d) PPP Mode: %s\r\n", MAX_LG290P_CONSTELLATIONS + 3,
                          settings.pppMode == PPP_MODE_DISABLE ? "Disabled"
                          : settings.pppMode == PPP_MODE_HAS   ? "HAS"
                          : settings.pppMode == PPP_MODE_B2B   ? "B2B"
                                                               : "Auto");
             if (settings.pppMode > PPP_MODE_DISABLE)
             {
-                systemPrintf("%d) PPP Datum: %s\r\n", MAX_LG290P_CONSTELLATIONS + 2,
+                systemPrintf("%d) PPP Datum: %s\r\n", MAX_LG290P_CONSTELLATIONS + 4,
                              settings.pppDatum == 1   ? "WGS84"
                              : settings.pppDatum == 2 ? "PPP Original"
                              : settings.pppDatum == 3 ? "CGCS2000"
                                                       : "Unknown");
-                systemPrintf("%d) PPP Timeout: %d\r\n", MAX_LG290P_CONSTELLATIONS + 3, settings.pppTimeout);
-                systemPrintf("%d) PPP Horizontal Convergence Accuracy: %0.2f\r\n", MAX_LG290P_CONSTELLATIONS + 4,
+                systemPrintf("%d) PPP Timeout: %d\r\n", MAX_LG290P_CONSTELLATIONS + 5, settings.pppTimeout);
+                systemPrintf("%d) PPP Horizontal Convergence Accuracy: %0.2f\r\n", MAX_LG290P_CONSTELLATIONS + 6,
                              settings.pppHorizontalConvergence);
-                systemPrintf("%d) PPP Vertical Convergence Accuracy: %0.2f\r\n", MAX_LG290P_CONSTELLATIONS + 5,
+                systemPrintf("%d) PPP Vertical Convergence Accuracy: %0.2f\r\n", MAX_LG290P_CONSTELLATIONS + 7,
                              settings.pppVerticalConvergence);
             }
         }
@@ -1416,7 +1421,22 @@ void GNSS_LG290P::menuConstellations()
             settings.lg290pConstellations[incoming] ^= 1;
             gnssConfigure(GNSS_CONFIG_CONSTELLATION); // Request receiver to use new settings
         }
-        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 1) && present.pppCapable)
+        else if (incoming == MAX_LG290P_CONSTELLATIONS + 1)
+        {
+            uint16_t newAge = 120;
+            if (getNewSetting("Enter RTK Differential Age", 1, 600, &newAge) == INPUT_RESPONSE_VALID)
+            {
+                settings.rtkDifferentialAge = newAge;
+                gnssConfigure(GNSS_CONFIG_CONSTELLATION); // Request receiver to use new settings
+            }
+        }
+        else if (incoming == MAX_LG290P_CONSTELLATIONS + 2)
+        {
+            settings.rtkDifferentialSourceType += 1;
+            settings.rtkDifferentialSourceType %= 3;
+            gnssConfigure(GNSS_CONFIG_CONSTELLATION); // Request receiver to use new settings
+        }
+        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 3) && present.pppCapable)
         {
             int newMode = 0;
             if (getNewSetting("Enter PPP Mode (0 = Disable, 1 = B2b PPP, 2 = E6 HAS, 255 = Auto)", 0, 255, &newMode) ==
@@ -1432,7 +1452,7 @@ void GNSS_LG290P::menuConstellations()
                     systemPrintln("Error: Out of range");
             }
         }
-        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 2) && present.pppCapable)
+        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 4) && present.pppCapable)
         {
             if (getNewSetting("Enter PPP Datum Number (1 = WGS84, 2 = PPP Original, 3 = CGCS2000)", 1, 3,
                               &settings.pppDatum) == INPUT_RESPONSE_VALID)
@@ -1440,7 +1460,7 @@ void GNSS_LG290P::menuConstellations()
                 gnssConfigure(GNSS_CONFIG_PPP); // Request receiver to use new settings
             }
         }
-        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 3) && present.pppCapable)
+        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 5) && present.pppCapable)
         {
             if (getNewSetting("Enter PPP Timeout before fallback (seconds)", 90, 180, &settings.pppTimeout) ==
                 INPUT_RESPONSE_VALID)
@@ -1448,7 +1468,7 @@ void GNSS_LG290P::menuConstellations()
                 gnssConfigure(GNSS_CONFIG_PPP); // Request receiver to use new settings
             }
         }
-        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 4) && present.pppCapable)
+        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 6) && present.pppCapable)
         {
             if (getNewSetting("Enter PPP Horizontal Convergence Accuracy (meters)", 0.0f, 5.0f,
                               &settings.pppHorizontalConvergence) == INPUT_RESPONSE_VALID)
@@ -1456,7 +1476,7 @@ void GNSS_LG290P::menuConstellations()
                 gnssConfigure(GNSS_CONFIG_PPP); // Request receiver to use new settings
             }
         }
-        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 5) && present.pppCapable)
+        else if ((incoming == MAX_LG290P_CONSTELLATIONS + 7) && present.pppCapable)
         {
             if (getNewSetting("Enter PPP Vertical Convergence Accuracy (meters)", 0.0f, 5.0f,
                               &settings.pppVerticalConvergence) == INPUT_RESPONSE_VALID)
@@ -1951,12 +1971,14 @@ bool GNSS_LG290P::setConstellations()
 
     if (online.gnss)
     {
-        response = _lg290p->setConstellations(settings.lg290pConstellations[0],  // GPS
-                                              settings.lg290pConstellations[1],  // GLONASS
-                                              settings.lg290pConstellations[2],  // Galileo
-                                              settings.lg290pConstellations[3],  // BDS
-                                              settings.lg290pConstellations[4],  // QZSS
-                                              settings.lg290pConstellations[5]); // NavIC
+        response &= _lg290p->setConstellations(settings.lg290pConstellations[0],  // GPS
+                                               settings.lg290pConstellations[1],  // GLONASS
+                                               settings.lg290pConstellations[2],  // Galileo
+                                               settings.lg290pConstellations[3],  // BDS
+                                               settings.lg290pConstellations[4],  // QZSS
+                                               settings.lg290pConstellations[5]); // NavIC
+        response &= _lg290p->setRtkDifferentialAge(settings.rtkDifferentialAge);
+        response &= _lg290p->setRtkDifferentialSourceType(settings.rtkDifferentialSourceType);
     }
 
     gnssConfigure(GNSS_CONFIG_RESET); // Constellation changes require device save/restart
@@ -2078,10 +2100,8 @@ bool GNSS_LG290P::setPppService()
         // Check if a setting has changed
         bool settingsChanged = false;
 
-        if (settings.pppMode)
-
-            if (currentMode != settings.pppMode)
-                settingsChanged = true;
+        if (currentMode != settings.pppMode)
+            settingsChanged = true;
         if (currentDatum != settings.pppDatum)
             settingsChanged = true;
         if (currentTimeout != settings.pppTimeout)

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -2005,14 +2005,12 @@ bool GNSS_LG290P::setConstellations()
 
     if (online.gnss)
     {
-        response &= _lg290p->setConstellations(settings.lg290pConstellations[0],  // GPS
+        response = _lg290p->setConstellations(settings.lg290pConstellations[0],  // GPS
                                                settings.lg290pConstellations[1],  // GLONASS
                                                settings.lg290pConstellations[2],  // Galileo
                                                settings.lg290pConstellations[3],  // BDS
                                                settings.lg290pConstellations[4],  // QZSS
                                                settings.lg290pConstellations[5]); // NavIC
-        response &= _lg290p->setRtkDifferentialAge(settings.lg290pRtkDifferentialAge);
-        response &= _lg290p->setRtkDifferentialSourceType(settings.lg290pRtkDifferentialSourceType);
     }
 
     gnssConfigure(GNSS_CONFIG_RESET); // Constellation changes require device save/restart

--- a/Firmware/RTK_Everywhere/menuGNSS.ino
+++ b/Firmware/RTK_Everywhere/menuGNSS.ino
@@ -220,6 +220,9 @@ void menuGNSS()
                          settings.enableMultipathMitigation ? "Enabled" : "Disabled");
         }
 
+        if (gnss->hasGnssSpecificConfiguration())
+            systemPrintln("16) GNSS-Specific Configuration");
+
         systemPrintln("x) Exit");
 
         int incoming = getUserInputNumber(); // Returns EXIT, TIMEOUT, or long
@@ -416,6 +419,11 @@ void menuGNSS()
         {
             settings.enableMultipathMitigation ^= 1;
             gnssConfigure(GNSS_CONFIG_MULTIPATH); // Request update
+        }
+
+        else if ((incoming == 16) && (gnss->hasGnssSpecificConfiguration()))
+        {
+            gnss->menuGnssSpecificConfiguration();
         }
 
         else if (incoming == INPUT_RESPONSE_GETNUMBER_EXIT)

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1180,6 +1180,8 @@ struct Settings
         254}; // Mark first record with key so defaults will be applied. Int value for each supported message - Report
               // rates for RTCM Base. Default to Quectel recommended rates.
     int lg290pMessageRatesPQTM[MAX_LG290P_PQTM_MSG] = {254}; // Mark first record with key so defaults will be applied.
+    uint16_t rtkDifferentialAge = 120; // LG290P only. Sets the max differential age of RTK fix. 1-600s. Default: 120s
+    uint16_t rtkDifferentialSourceType = 0; // LG290P only. 0 = Auto, 1 = Normal, 2 = Wide Lane. Default is Auto.
 #endif // COMPILE_LG290P
 
     bool debugSettings = false;
@@ -1832,6 +1834,8 @@ const RTK_Settings_Entry rtkSettingsEntries[] =
     { 0, 1, 1, 0, 0, 0, 1, L29, 1, tLgMRBaRT, MAX_LG290P_RTCM_MSG, & settings.lg290pMessageRatesRTCMBase, "messageRateRTCMBase_", gnssCmdUpdateMessageRates, },
     { 0, 1, 1, 0, 0, 0, 1, L29, 1, tLgMRRvRT, MAX_LG290P_RTCM_MSG, & settings.lg290pMessageRatesRTCMRover, "messageRateRTCMRover_", gnssCmdUpdateMessageRates, },
     { 0, 1, 1, 0, 0, 0, 1, L29, 1, tLgMRPqtm, MAX_LG290P_PQTM_MSG, & settings.lg290pMessageRatesPQTM, "messageRatePQTM_", gnssCmdUpdateMessageRates, },
+    { 1, 1, 0, 0, 0, 0, 1, L29, 1, _uint16_t, 0, & settings.rtkDifferentialAge, "rtkDifferentialAge", nullptr, },
+    { 1, 1, 0, 0, 0, 0, 1, L29, 1, _uint16_t, 0, & settings.rtkDifferentialSourceType, "rtkDifferentialSourceType", nullptr, },
 #endif  // COMPILE_LG290P
 
     { 0, 0, 0, 1, 1, 1, 1, ALL, 1, _bool,     0, & settings.debugSettings, "debugSettings", nullptr, },

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -1180,8 +1180,8 @@ struct Settings
         254}; // Mark first record with key so defaults will be applied. Int value for each supported message - Report
               // rates for RTCM Base. Default to Quectel recommended rates.
     int lg290pMessageRatesPQTM[MAX_LG290P_PQTM_MSG] = {254}; // Mark first record with key so defaults will be applied.
-    uint16_t rtkDifferentialAge = 120; // LG290P only. Sets the max differential age of RTK fix. 1-600s. Default: 120s
-    uint16_t rtkDifferentialSourceType = 0; // LG290P only. 0 = Auto, 1 = Normal, 2 = Wide Lane. Default is Auto.
+    uint16_t lg290pRtkDifferentialAge = 120; // LG290P only. Sets the max differential age of RTK fix. 1-600s. Default: 120s
+    uint16_t lg290pRtkDifferentialSourceType = 0; // LG290P only. 0 = Auto, 1 = Normal, 2 = Wide Lane. Default is Auto.
 #endif // COMPILE_LG290P
 
     bool debugSettings = false;
@@ -1834,8 +1834,8 @@ const RTK_Settings_Entry rtkSettingsEntries[] =
     { 0, 1, 1, 0, 0, 0, 1, L29, 1, tLgMRBaRT, MAX_LG290P_RTCM_MSG, & settings.lg290pMessageRatesRTCMBase, "messageRateRTCMBase_", gnssCmdUpdateMessageRates, },
     { 0, 1, 1, 0, 0, 0, 1, L29, 1, tLgMRRvRT, MAX_LG290P_RTCM_MSG, & settings.lg290pMessageRatesRTCMRover, "messageRateRTCMRover_", gnssCmdUpdateMessageRates, },
     { 0, 1, 1, 0, 0, 0, 1, L29, 1, tLgMRPqtm, MAX_LG290P_PQTM_MSG, & settings.lg290pMessageRatesPQTM, "messageRatePQTM_", gnssCmdUpdateMessageRates, },
-    { 1, 1, 0, 0, 0, 0, 1, L29, 1, _uint16_t, 0, & settings.rtkDifferentialAge, "rtkDifferentialAge", nullptr, },
-    { 1, 1, 0, 0, 0, 0, 1, L29, 1, _uint16_t, 0, & settings.rtkDifferentialSourceType, "rtkDifferentialSourceType", nullptr, },
+    { 1, 1, 0, 0, 0, 0, 1, L29, 1, _uint16_t, 0, & settings.lg290pRtkDifferentialAge, "lg290pRtkDifferentialAge", nullptr, },
+    { 1, 1, 0, 0, 0, 0, 1, L29, 1, _uint16_t, 0, & settings.lg290pRtkDifferentialSourceType, "lg290pRtkDifferentialSourceType", nullptr, },
 #endif  // COMPILE_LG290P
 
     { 0, 0, 0, 1, 1, 1, 1, ALL, 1, _bool,     0, & settings.debugSettings, "debugSettings", nullptr, },


### PR DESCRIPTION
There is now a GNSS-Specific Configuration menu under the Configure GNSS Receiver menu. It's the correct way to do it...

<img width="606" height="712" alt="Image" src="https://github.com/user-attachments/assets/730bd681-863c-4a68-81d9-ba533ffca6b1" />

<img width="466" height="298" alt="Image" src="https://github.com/user-attachments/assets/fc59db5b-adb2-46b5-843b-e1fab46be9d6" />