### PR TITLE
Share UART2 between LoRa and Tilt, one UART, two names

### DIFF
--- a/Firmware/RTK_Everywhere/Begin.ino
+++ b/Firmware/RTK_Everywhere/Begin.ino
@@ -1127,6 +1127,32 @@ void beginGnssUart2()
     serial2GNSS->begin(115200, SERIAL_8N1, pin_GnssUart2_RX, pin_GnssUart2_TX);
 }
 
+//----------------------------------------
+// Configure UART2 serial port shared between LoRa and Tilt
+//----------------------------------------
+bool beginUart2Serial()
+{
+    // Determine if serial port is already configured
+    if (uart2Serial)
+        return true;
+
+    // Allocate the serial port object
+    uart2Serial = new HardwareSerial(2);
+
+    // Determine if the allocation failed
+    if (uart2Serial == nullptr)
+    {
+        systemPrintf("ERROR: Failed to allocate the uart2Serial port!\r\n");
+        return false;
+    }
+
+    // Configure the serial port
+    uart2Serial->setRxBufferSize(settings.uartReceiveBufferSize);
+    uart2Serial->setTimeout(settings.serialTimeoutGNSS); // Requires serial traffic on the UART pins for detection
+    uart2Serial->begin(115200, SERIAL_8N1, pin_IMU_RX, pin_IMU_TX);
+    return true;
+}
+
 void beginFS()
 {
     if (online.fs == false)

--- a/Firmware/RTK_Everywhere/LoRa.ino
+++ b/Firmware/RTK_Everywhere/LoRa.ino
@@ -94,8 +94,6 @@ static volatile uint8_t loraState = LORA_NOT_PRESENT;
 
 int loraBytesSent = 0;
 
-HardwareSerial *SerialForLoRa; // Don't instantiate until we know the platform. May compete with SerialForTilt.
-
 // Called from main loop
 // Control incoming/outgoing RTCM data from STM32 based LoRa radio (if supported by platform)
 void updateLora()
@@ -404,20 +402,7 @@ void beginLora()
         if (present.loraDedicatedUart == true)
         {
             // UART2 of the ESP32 is also used for Tilt module communication on the GNSS
-            // If Tilt is active we will use its serial port
-            if (SerialForTilt != nullptr)
-            {
-                SerialForLoRa = SerialForTilt; // SerialForTilt will be using UART2 (HardwareSerial(2))
-            }
-            else
-            {
-                if (SerialForLoRa == nullptr)
-                {
-                    SerialForLoRa = new HardwareSerial(2); // Use UART2 on the ESP32 to communicate with LoRa radio
-
-                    SerialForLoRa->begin(115200, SERIAL_8N1, pin_IMU_RX, pin_IMU_TX);
-                }
-            }
+            beginUart2Serial();
         }
 
         // Store firmware version in char array
@@ -433,18 +418,6 @@ void loraStop()
             systemPrintln("Stopping LoRa");
 
         loraPowerOff(); // Power down STM32/radio
-
-        if (SerialForLoRa != nullptr)
-        {
-            // UART2 of the ESP32 is also used for Tilt module communication on the GNSS
-            // If Tilt is not active, then release the resources
-            if (SerialForTilt == nullptr)
-            {
-                delete SerialForLoRa;
-
-                SerialForLoRa = nullptr;
-            }
-        }
     }
 }
 
@@ -1303,13 +1276,9 @@ void loraRxDirectConnectFacetFP()
     // Push all data received on ESP32 UART2 out ESP32 UART0
 
     // We must use SerialForLoRa because loraAvailable checks SerialForLoRa->available
+    beginUart2Serial();
     if (SerialForLoRa == nullptr)
-        SerialForLoRa = new HardwareSerial(2); // Use UART2 on the ESP32 for communication with the LoRa radio
-
-    SerialForLoRa->setRxBufferSize(settings.uartReceiveBufferSize);
-    SerialForLoRa->setTimeout(settings.serialTimeoutGNSS); // Requires serial traffic on the UART pins for detection
-
-    SerialForLoRa->begin(115200, SERIAL_8N1, pin_IMU_RX, pin_IMU_TX); // Keep this at 115200
+        return;
 
     loraPowerOn(); // Power STM32/radio
 
@@ -1479,13 +1448,9 @@ void loraTxDirectConnectFacetFP()
     // Push test data out on ESP32 UART1
 
     // We must use SerialForLoRa because loraAvailable  checks SerialForLoRa->available
+    beginUart2Serial();
     if (SerialForLoRa == nullptr)
-        SerialForLoRa = new HardwareSerial(2); // Use UART2 on the ESP32 for communication with the LoRa radio
-
-    SerialForLoRa->setRxBufferSize(settings.uartReceiveBufferSize);
-    SerialForLoRa->setTimeout(settings.serialTimeoutGNSS); // Requires serial traffic on the UART pins for detection
-
-    SerialForLoRa->begin(115200, SERIAL_8N1, pin_IMU_RX, pin_IMU_TX); // Keep this at 115200
+        return;
 
     loraPowerOn(); // Power STM32/radio
 

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -777,7 +777,6 @@ static NetPriority_t networkPriorityForDisplay = NETWORK_NONE; // Reduce calls t
 #ifdef COMPILE_IM19_IMU
 #include <SparkFun_IM19_IMU_Arduino_Library.h> //http://librarymanager/All#SparkFun_IM19_IMU
 IM19 *tiltSensor;
-HardwareSerial *SerialForTilt; // Don't instantiate until we know the tilt sensor exists
 unsigned long lastTiltCheck;   // Limits polling on IM19 to 1Hz
 bool tiltFailedBegin;          // Goes true if IMU fails beginTilt()
 unsigned long lastTiltBeepMs;  // Emit a beep every 10s if tilt is active
@@ -785,6 +784,12 @@ int imuAppVersionInt;
 char imuFirmwareVersion[32]; // Ex: IM19_H2_B2.2_A11.4.1
 
 #endif                         // COMPILE_IM19_IMU
+
+HardwareSerial * uart2Serial;   // Shared serial port between LoRa and Tilt
+
+#define SerialForLoRa           uart2Serial
+#define SerialForTilt           uart2Serial
+
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
 // PointPerfect Library (PPL)

--- a/Firmware/RTK_Everywhere/Tilt.ino
+++ b/Firmware/RTK_Everywhere/Tilt.ino
@@ -302,15 +302,11 @@ void beginTilt()
 {
     // Use UART2 on the ESP32 to receive IMU corrections
     // Shown as UART2 on these schematics: Torch, Facet FP
-    tiltSensor = new IM19();
+    beginUart2Serial();
     if (SerialForTilt == nullptr)
-        SerialForTilt = new HardwareSerial(2);
+      return;
 
-    SerialForTilt->setRxBufferSize(1024 * 1);
-
-    // We must start the serial port before handing it over to the library
-    SerialForTilt->begin(115200, SERIAL_8N1, pin_IMU_RX, pin_IMU_TX);
-
+    tiltSensor = new IM19();
     if (settings.enableImuDebug == true)
         tiltSensor->enableDebugging(); // Print all debug to Serial
 
@@ -414,12 +410,6 @@ void beginTilt()
 // Stops serial inteface. Marks tilt offline.
 void tiltStop()
 {
-    // Gracefully stop the UART before freeing resources
-    while (SerialForTilt->available())
-        SerialForTilt->read();
-
-    SerialForTilt->end();
-
     // Free the resources
     if (tiltSensor != nullptr)
     {
@@ -427,11 +417,9 @@ void tiltStop()
         tiltSensor = nullptr;
     }
 
-    if (SerialForTilt != nullptr)
-    {
-        delete SerialForTilt;
-        SerialForTilt = nullptr;
-    }
+    // Gracefully stop the UART before freeing resources
+    while (SerialForTilt->available())
+        SerialForTilt->read();
 
     // Beep to indicate we are going offline - but only from tiltRequestStop
     if (tiltState == TILT_REQUEST_STOP)


### PR DESCRIPTION
Common initialization in beginUart2Serial
No need to delete the UART instance