### PR TITLE
Correct LG290P Base ephemeris rates / intervals (RTCM 1019 - 1023)

### DIFF
--- a/Firmware/RTK_Everywhere/AP-Config/src/main.js
+++ b/Firmware/RTK_Everywhere/AP-Config/src/main.js
@@ -2658,10 +2658,10 @@ function getMessageList() {
 
         ge("messageList").innerHTML = "";
         messageText = "";
-        savedMessageNames = [];
-        savedMessageValues = [];
-        savedCheckboxNames = [];
-        savedCheckboxValues = [];
+        savedMessageNames.length = 0;
+        savedMessageValues.length = 0;
+        savedCheckboxNames.length = 0;
+        savedCheckboxValues.length = 0;
 
         var xmlhttp = new XMLHttpRequest();
         xmlhttp.open("GET", "/listMessages", false);

--- a/Firmware/RTK_Everywhere/AP-Config/src/main.js
+++ b/Firmware/RTK_Everywhere/AP-Config/src/main.js
@@ -688,10 +688,6 @@ function parseIncoming(msg) {
             messageText += "<p id='" + messageName + "Error' class='inlineError'></p>";
             messageText += "</div></div>";
 
-            // Save the name and value as we can't set 'checked' yet. messageText has not yet been added to innerHTML
-            savedCheckboxNames.push(messageName);
-            savedCheckboxValues.push(val);
-
             // Add to initialSettings - if it has not been added before. Val will be "true" / "false"
             addInitialSetting(id, val);
         }

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.h
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.h
@@ -62,7 +62,7 @@ const lg290pMsg lgMessagesRTCM[] = {
     {"RTCM3-111X", 0, 1, 1200, false, 0},    //
     {"RTCM3-112X", 0, 1, 1200, false, 0},    //
     {"RTCM3-113X", 0, 1, 1200, false, 0},    //
-    {"RTCM3-1019", -1, 0, 7200, true, 0},      // Ephemeris: CFGRATE must be 0 or 1; CFGRTCM sets the interval 0-7200
+    {"RTCM3-1019", -1, 0, 7200, true, 0},      // Ephemeris: CFGMSGRATE must be 0 or 1; CFGRTCM sets the interval 0-7200
     {"RTCM3-1020", -1, 0, 7200, true, 0},      //
     {"RTCM3-1041", -1, 0, 7200, true, 0},      //
     {"RTCM3-1042", -1, 0, 7200, true, 0},      //

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.h
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.h
@@ -25,72 +25,73 @@ typedef struct
     const char msgTextName[strlen("PQTMGEOFENCESTATUS") + 1]; // Printable/Human readable name
     const int
         msgVersionOffset; // 'MsgVer' or 'Offset' for a given message. Varies depending on the message. -1 of omitted.
-    const int msgDefaultRate;             // Default rate for 'factory' settings
-    const int msgMaxRate;                   // Maximum allowed N message rate
+    const int msgDefaultRate;           // Default rate for 'factory' settings
+    const int msgMaxRate;               // Maximum allowed N message rate
+    const bool msgIsEphemeris;          // True indicates message contains Ephemeris, set by PQTMCFGRTCM
     const int firmwareVersionSupported; // The minimum version this message is supported.
-                                            // 0 = all versions.
-                                            // 104 = Supported in v1.4 and later
+                                        // 0 = all versions.
+                                        // 104 = Supported in v1.4 and later
 } lg290pMsg;
 
 // Static array containing all the compatible messages
 // Rate = Output once every N position fix(es).
 const lg290pMsg lgMessagesNMEA[] = {
     // In order from the LG29xP Series GNSS Protocol Spec v1.2.0 20260109, Table 6
-    {"RMC", -1, 1, 255, 0},   // Firmware v1.0 to v1.6, N = 1. v2.1, N = 0-255
-    {"GGA", -1, 1, 255, 0},   // No message version for NMEA
-    {"GSV", -1, 1, 255, 0},   //
-    {"GSA", -1, 1, 255, 0},   //
-    {"VTG", -1, 1, 255, 0},   //
-    {"GLL", -1, 1, 255, 0},   //
-    {"GBS", -1, 0, 255, 104}, // Added in v1.1.0 spec. Firmware v1.4 and above
-    {"GNS", -1, 0, 255, 104}, // Added in v1.1.0 spec. Firmware v1.4 and above
-    {"GST", -1, 1, 255, 104}, // Added in v1.1.0 spec. Firmware v1.4 and above
-    {"ZDA", -1, 0, 255, 104}, // Added in v1.1.0 spec. Firmware v1.4 and above
-    {"HDT", -1, 0, 255, 104}, // Added in v1.1.0 spec. Firmware v1.4 and above
-    {"THS", -1, 0, 255, 104}, // Added in v1.1.0 spec. Firmware v1.4 and above
+    {"RMC", -1, 1, 255, false, 0},   // Firmware v1.0 to v1.6, N = 1. v2.1, N = 0-255
+    {"GGA", -1, 1, 255, false, 0},   // No message version for NMEA
+    {"GSV", -1, 1, 255, false, 0},   //
+    {"GSA", -1, 1, 255, false, 0},   //
+    {"VTG", -1, 1, 255, false, 0},   //
+    {"GLL", -1, 1, 255, false, 0},   //
+    {"GBS", -1, 0, 255, false, 104}, // Added in v1.1.0 spec. Firmware v1.4 and above
+    {"GNS", -1, 0, 255, false, 104}, // Added in v1.1.0 spec. Firmware v1.4 and above
+    {"GST", -1, 1, 255, false, 104}, // Added in v1.1.0 spec. Firmware v1.4 and above
+    {"ZDA", -1, 0, 255, false, 104}, // Added in v1.1.0 spec. Firmware v1.4 and above
+    {"HDT", -1, 0, 255, false, 104}, // Added in v1.1.0 spec. Firmware v1.4 and above
+    {"THS", -1, 0, 255, false, 104}, // Added in v1.1.0 spec. Firmware v1.4 and above
 };
 
 const lg290pMsg lgMessagesRTCM[] = {
     // In order from the LG29xP Series GNSS Protocol Spec v1.2.0 20260109, Table 6
-    {"RTCM3-1005", -1, 1, 1200, 0},   // RTCM-### must have only the rate (no msgVer/Offset)
-    {"RTCM3-1006", -1, 0, 1200, 0},   //
-    {"RTCM3-1033", -1, 0, 1200, 104}, // Added in v1.1.0 spec. Firmware v1.4 and above
-    {"RTCM3-107X", 0, 1, 1200, 0},    // RTCM3-###X Must have rate and msgVer/Offset = 0.
-    {"RTCM3-108X", 0, 1, 1200, 0},    //
-    {"RTCM3-109X", 0, 1, 1200, 0},    //
-    {"RTCM3-111X", 0, 1, 1200, 0},    //
-    {"RTCM3-112X", 0, 1, 1200, 0},    //
-    {"RTCM3-113X", 0, 1, 1200, 0},    //
-    {"RTCM3-1019", -1, 0, 1, 0},      //
-    {"RTCM3-1020", -1, 0, 1, 0},      //
-    {"RTCM3-1041", -1, 0, 1, 0},      //
-    {"RTCM3-1042", -1, 0, 1, 0},      //
-    {"RTCM3-1044", -1, 0, 1, 0},      //
-    {"RTCM3-1046", -1, 0, 1, 0},      //
-    {"RTCM3-1230", -1, 0, 1, 201},    // Added in v1.2.0 spec. Firmware v2.1 and above.
+    {"RTCM3-1005", -1, 1, 1200, false, 0},   // RTCM-### must have only the rate (no msgVer/Offset)
+    {"RTCM3-1006", -1, 0, 1200, false, 0},   //
+    {"RTCM3-1033", -1, 0, 1200, false, 104}, // Added in v1.1.0 spec. Firmware v1.4 and above
+    {"RTCM3-107X", 0, 1, 1200, false, 0},    // RTCM3-###X Must have rate and msgVer/Offset = 0.
+    {"RTCM3-108X", 0, 1, 1200, false, 0},    //
+    {"RTCM3-109X", 0, 1, 1200, false, 0},    //
+    {"RTCM3-111X", 0, 1, 1200, false, 0},    //
+    {"RTCM3-112X", 0, 1, 1200, false, 0},    //
+    {"RTCM3-113X", 0, 1, 1200, false, 0},    //
+    {"RTCM3-1019", -1, 0, 7200, true, 0},      // Ephemeris: CFGRATE must be 0 or 1; CFGRTCM sets the interval 0-7200
+    {"RTCM3-1020", -1, 0, 7200, true, 0},      //
+    {"RTCM3-1041", -1, 0, 7200, true, 0},      //
+    {"RTCM3-1042", -1, 0, 7200, true, 0},      //
+    {"RTCM3-1044", -1, 0, 7200, true, 0},      //
+    {"RTCM3-1046", -1, 0, 7200, true, 0},      //
+    {"RTCM3-1230", -1, 0, 7200, true, 201},    // Added in v1.2.0 spec. Firmware v2.1 and above.
 };
 
 // Quectel Proprietary messages
 // Any message type not identified here will not be allowed through the lg290pMessageEnabled() filter.
 const lg290pMsg lgMessagesPQTM[] = {
     // In order from the LG29xP Series GNSS Protocol Spec v1.2.0 20260109, Table 6
-    {"PQTMEPE", 2, 0, 255, 0},            // msgVer = 2
-    {"PQTMVEL", 1, 0, 255, 0},            //
-    {"PQTMGEOFENCESTATUS", 1, 0, 255, 0}, //
-    {"PQTMTXT", 1, 0, 255, 0},            //
-    // {"PQTMSVINSTATUS", 1, 0, 255, 0},      // Only available in Base mode
-    {"PQTMPVT", 1, 0, 255, 0}, //
-    {"PQTMDOP", 1, 0, 255, 0}, //
-    {"PQTMPL", 1, 0, 255, 0},  //
-    {"PQTMODO", 1, 0, 255, 0}, //
-    // {"PQTMTAR", 1, 0, 255, 201},           // Only available on LG580P
-    {"PQTMNAV", 1, 0, 255, 201}, // Added in v1.2.0 spec. Firmware v2.1 and above.
-    {"PQTMEOE", 1, 0, 255, 201}, // Added in v1.2.0 spec. Firmware v2.1 and above.
-    // {"PQTMANTENNASTATUS", 1, 0, 255, 201}, // Only supported on LG580P
-    {"PQTMENV", 1, 0, 255, 201},           // Added in v1.2.0 spec. Firmware v2.1 and above.
-    {"PQTMRTCMIS", 1, 0, 1, 201},          // Added in v1.2.0 spec. Firmware v2.1 and above.
-    {"PQTMPPPNAV", 1, 0, 255, 201},        // Added in v1.2.0 spec. Firmware v2.1 and above.
-    {"PQTMJAMMINGSTATUS", 1, 0, 255, 201}, // Added in v1.2.0 spec. Firmware v2.1 and above.
+    {"PQTMEPE", 2, 0, 255, false, 0},            // msgVer = 2
+    {"PQTMVEL", 1, 0, 255, false, 0},            //
+    {"PQTMGEOFENCESTATUS", 1, 0, 255, false, 0}, //
+    {"PQTMTXT", 1, 0, 255, false, 0},            //
+    // {"PQTMSVINSTATUS", 1, 0, 255, false, 0},      // Only available in Base mode
+    {"PQTMPVT", 1, 0, 255, false, 0}, //
+    {"PQTMDOP", 1, 0, 255, false, 0}, //
+    {"PQTMPL", 1, 0, 255, false, 0},  //
+    {"PQTMODO", 1, 0, 255, false, 0}, //
+    // {"PQTMTAR", 1, 0, 255, false, 201},           // Only available on LG580P
+    {"PQTMNAV", 1, 0, 255, false, 201}, // Added in v1.2.0 spec. Firmware v2.1 and above.
+    {"PQTMEOE", 1, 0, 255, false, 201}, // Added in v1.2.0 spec. Firmware v2.1 and above.
+    // {"PQTMANTENNASTATUS", 1, 0, 255, false, 201}, // Only supported on LG580P
+    {"PQTMENV", 1, 0, 255, false, 201},           // Added in v1.2.0 spec. Firmware v2.1 and above.
+    {"PQTMRTCMIS", 1, 0, 1, false, 201},          // Added in v1.2.0 spec. Firmware v2.1 and above.
+    {"PQTMPPPNAV", 1, 0, 255, false, 201},        // Added in v1.2.0 spec. Firmware v2.1 and above.
+    {"PQTMJAMMINGSTATUS", 1, 0, 255, false, 201}, // Added in v1.2.0 spec. Firmware v2.1 and above.
 };
 
 #define MAX_LG290P_NMEA_MSG (sizeof(lgMessagesNMEA) / sizeof(lg290pMsg))

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -1774,7 +1774,7 @@ void GNSS_LG290P::menuMessagesSubtype(int *localMessageRate, const char *message
             // Message rates maxes are set within lgMessagesPQTM
             if (strcmp(messageType, "NMEA") == 0)
             {
-                if (getNewSetting(messageString, 0, lgMessagesPQTM[incoming].msgMaxRate, &newSetting) ==
+                if (getNewSetting(messageString, 0, lgMessagesNMEA[incoming].msgMaxRate, &newSetting) ==
                     INPUT_RESPONSE_VALID)
                 {
                     settings.lg290pMessageRatesNMEA[incoming] = newSetting;
@@ -1783,7 +1783,7 @@ void GNSS_LG290P::menuMessagesSubtype(int *localMessageRate, const char *message
             }
             if (strcmp(messageType, "RTCMRover") == 0)
             {
-                if (getNewSetting(messageString, 0, lgMessagesPQTM[incoming].msgMaxRate, &newSetting) ==
+                if (getNewSetting(messageString, 0, lgMessagesRTCM[incoming].msgMaxRate, &newSetting) ==
                     INPUT_RESPONSE_VALID)
                 {
                     settings.lg290pMessageRatesRTCMRover[incoming] = newSetting;
@@ -1792,7 +1792,7 @@ void GNSS_LG290P::menuMessagesSubtype(int *localMessageRate, const char *message
             }
             if (strcmp(messageType, "RTCMBase") == 0)
             {
-                if (getNewSetting(messageString, 0, lgMessagesPQTM[incoming].msgMaxRate, &newSetting) ==
+                if (getNewSetting(messageString, 0, lgMessagesRTCM[incoming].msgMaxRate, &newSetting) ==
                     INPUT_RESPONSE_VALID)
                 {
                     settings.lg290pMessageRatesRTCMBase[incoming] = newSetting;
@@ -2403,14 +2403,32 @@ bool GNSS_LG290P::setMessagesOther()
 bool GNSS_LG290P::setMessagesRTCMBase()
 {
     bool response = true;
-    bool enableRTCM = false; // Goes true if we need to enable RTCM output reporting
+    bool enableRTCM = false;      // Goes true if we need to enable RTCM output reporting
+    bool enableEphemeris = false; // Goes true if we need to enable ephemeris output
 
     int portNumber = 1;
+
+    int minimumEphemeris = 7200; // Start at 7200. Reduce to minimum non-zero eph rate
 
     while (portNumber < 4)
     {
         for (int messageNumber = 0; messageNumber < MAX_LG290P_RTCM_MSG; messageNumber++)
         {
+            // For ephemeris messages, capture the message with the lowest non-zero rate
+            if (lgMessagesRTCM[messageNumber].msgIsEphemeris)
+                if (settings.lg290pMessageRatesRTCMBase[messageNumber] > 0 &&
+                    settings.lg290pMessageRatesRTCMBase[messageNumber] < minimumEphemeris)
+                    {
+                        minimumEphemeris = settings.lg290pMessageRatesRTCMBase[messageNumber];
+                        enableEphemeris = true;
+                    }
+
+            // Force all ephemeris messages to 1 or 0. See above for reasoning.
+            int rate = settings.lg290pMessageRatesRTCMBase[messageNumber];
+            if (lgMessagesRTCM[messageNumber].msgIsEphemeris)
+                if (rate > 1)
+                    rate = 1;
+
             // Check if this RTCM message is supported by the current LG290P firmware
             if (lg290pFirmwareVersionInt >= lgMessagesRTCM[messageNumber].firmwareVersionSupported)
             {
@@ -2418,13 +2436,12 @@ bool GNSS_LG290P::setMessagesRTCMBase()
                 if (lg290pFirmwareVersionInt >= 104)
                     // Enable this message, at this rate, on this port
                     response &= _lg290p->setMessageRateOnPort(
-                        lgMessagesRTCM[messageNumber].msgTextName, settings.lg290pMessageRatesRTCMBase[messageNumber],
+                        lgMessagesRTCM[messageNumber].msgTextName, rate,
                         portNumber, lgMessagesRTCM[messageNumber].msgVersionOffset);
                 else
                     // Enable this message, at this rate
                     response &= _lg290p->setMessageRate(lgMessagesRTCM[messageNumber].msgTextName,
-                                                        settings.lg290pMessageRatesRTCMBase[messageNumber],
-                                                        lgMessagesRTCM[messageNumber].msgVersionOffset);
+                                                        rate, lgMessagesRTCM[messageNumber].msgVersionOffset);
 
                 if (response == false && settings.debugGnss)
                     systemPrintf("Enable RTCM failed at messageNumber %d %s\r\n", messageNumber,
@@ -2446,11 +2463,17 @@ bool GNSS_LG290P::setMessagesRTCMBase()
     if (enableRTCM == true)
     {
         if (settings.debugGnss)
-            systemPrintln("Enabling Base RTCM output");
+        {
+            if (enableEphemeris)
+                systemPrintf("Enabling Base RTCM MSM output with ephemeris rate of %d\r\n", minimumEphemeris);
+            else
+                systemPrintln("Enabling Base RTCM MSM output");
+        }
 
         // PQTMCFGRTCM fails to respond with OK over UART2 of LG290P, so don't look for it
         char cfgRtcm[40];
-        snprintf(cfgRtcm, sizeof(cfgRtcm), "PQTMCFGRTCM,W,%c,0,-90,07,06,2,1", settings.useMSM7 ? '7' : '4');
+        snprintf(cfgRtcm, sizeof(cfgRtcm), "PQTMCFGRTCM,W,%c,0,-90,07,06,%d,%d", settings.useMSM7 ? '7' : '4',
+                 enableEphemeris ? 2 : 0, enableEphemeris ? minimumEphemeris : 0);
         _lg290p->sendOkCommand(cfgRtcm); // Enable MSM4/7, output regular intervals, interval (seconds)
     }
 
@@ -2469,29 +2492,35 @@ bool GNSS_LG290P::setMessagesRTCMRover()
     bool rtcm1020Enabled = false;
     bool rtcm1042Enabled = false;
     bool rtcm1046Enabled = false;
-    bool enableRTCM = false; // Goes true if we need to enable RTCM output reporting
+    bool enableRTCM = false;      // Goes true if we need to enable RTCM output reporting
+    bool enableEphemeris = false; // Goes true if we need to enable ephemeris output
 
     int portNumber = 1;
 
-    int minimumRtcmRate = 1000;
+    int minimumEphemeris = 7200; // Start at 7200. Reduce to minimum non-zero eph rate
 
     while (portNumber < 4)
     {
         for (int messageNumber = 0; messageNumber < MAX_LG290P_RTCM_MSG; messageNumber++)
         {
-            // 1019 to 1046 can only be set to 1 fix per report
             // 107x to 112x can be set to 1-1200 fixes between reports
-            // So we set all RTCM to 1, and set PQTMCFGRTCM to the lowest value found
+            // 1019 to 1046 can only be set to 1 fix per report
+            // So we set all ephemeris to 1, and set PQTMCFGRTCM to the lowest value found
 
-            // Capture the message with the lowest rate
-            if (settings.lg290pMessageRatesRTCMRover[messageNumber] > 0 &&
-                settings.lg290pMessageRatesRTCMRover[messageNumber] < minimumRtcmRate)
-                minimumRtcmRate = settings.lg290pMessageRatesRTCMRover[messageNumber];
+            // For ephemeris messages, capture the message with the lowest non-zero rate
+            if (lgMessagesRTCM[messageNumber].msgIsEphemeris)
+                if (settings.lg290pMessageRatesRTCMRover[messageNumber] > 0 &&
+                    settings.lg290pMessageRatesRTCMRover[messageNumber] < minimumEphemeris)
+                    {
+                        minimumEphemeris = settings.lg290pMessageRatesRTCMRover[messageNumber];
+                        enableEphemeris = true;
+                    }
 
-            // Force all RTCM messages to 1 or 0. See above for reasoning.
+            // Force all ephemeris messages to 1 or 0. See above for reasoning.
             int rate = settings.lg290pMessageRatesRTCMRover[messageNumber];
-            if (rate > 1)
-                rate = 1;
+            if (lgMessagesRTCM[messageNumber].msgIsEphemeris)
+                if (rate > 1)
+                    rate = 1;
 
             // Check if this RTCM message is supported by the current LG290P firmware
             if (lg290pFirmwareVersionInt >= lgMessagesRTCM[messageNumber].firmwareVersionSupported)
@@ -2546,8 +2575,10 @@ bool GNSS_LG290P::setMessagesRTCMRover()
     if (pointPerfectServiceUsesKeys())
     {
         enableRTCM = true; // Force enable RTCM output
+        enableEphemeris = true;
 
         // Force on any messages that are needed for PPL
+        // Note: a rate/interval of 1 is probably a bit agressive. A lower rate may be better?
         if (rtcm1019Enabled == false)
         {
             if (settings.debugCorrections)
@@ -2579,16 +2610,21 @@ bool GNSS_LG290P::setMessagesRTCMRover()
     // If any RTCM message is enabled, send CFGRTCM
     if (enableRTCM == true)
     {
-        if (settings.debugCorrections)
-            systemPrintf("Enabling Rover RTCM MSM output with rate of %d\r\n", minimumRtcmRate);
+        if (settings.debugGnss || settings.debugGnssConfig)
+        {
+            if (enableEphemeris)
+                systemPrintf("Enabling Rover RTCM MSM output with ephemeris rate of %d\r\n", minimumEphemeris);
+            else
+                systemPrintln("Enabling Rover RTCM MSM output");
+        }
 
         // Enable MSM4/7 (for faster PPP CSRS results), output at a rate equal to the minimum RTCM rate (EPH Mode =
         // 2) PQTMCFGRTCM, W, <MSM_Type>, <MSM_Mode>, <MSM_ElevThd>, <Reserved>, <Reserved>, <EPH_Mode>,
         // <EPH_Interval> Set MSM_ElevThd to 15 degrees from rftop suggestion
 
         char msmCommand[40] = {0};
-        snprintf(msmCommand, sizeof(msmCommand), "PQTMCFGRTCM,W,%c,0,15,07,06,2,%d", settings.useMSM7 ? '7' : '4',
-                 minimumRtcmRate);
+        snprintf(msmCommand, sizeof(msmCommand), "PQTMCFGRTCM,W,%c,0,15,07,06,%d,%d", settings.useMSM7 ? '7' : '4',
+                 enableEphemeris ? 2 : 0, enableEphemeris ? minimumEphemeris : 0);
 
         // PQTMCFGRTCM fails to respond with OK over UART2 of LG290P, so don't look for it
         _lg290p->sendOkCommand(msmCommand);

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -2414,6 +2414,10 @@ bool GNSS_LG290P::setMessagesRTCMBase()
     {
         for (int messageNumber = 0; messageNumber < MAX_LG290P_RTCM_MSG; messageNumber++)
         {
+            // 1005, 1006, 1033, 107x to 113x can be set to 1-1200 fixes between reports
+            // 1019 to 1046, 1230 can only be set to 1 fix per report
+            // So we set all non-zero ephemeris to 1, and set PQTMCFGRTCM to the lowest value found
+
             // For ephemeris messages, capture the message with the lowest non-zero rate
             if (lgMessagesRTCM[messageNumber].msgIsEphemeris)
                 if (settings.lg290pMessageRatesRTCMBase[messageNumber] > 0 &&
@@ -2503,9 +2507,9 @@ bool GNSS_LG290P::setMessagesRTCMRover()
     {
         for (int messageNumber = 0; messageNumber < MAX_LG290P_RTCM_MSG; messageNumber++)
         {
-            // 107x to 112x can be set to 1-1200 fixes between reports
-            // 1019 to 1046 can only be set to 1 fix per report
-            // So we set all ephemeris to 1, and set PQTMCFGRTCM to the lowest value found
+            // 1005, 1006, 1033, 107x to 113x can be set to 1-1200 fixes between reports
+            // 1019 to 1046, 1230 can only be set to 1 fix per report
+            // So we set all non-zero ephemeris to 1, and set PQTMCFGRTCM to the lowest value found
 
             // For ephemeris messages, capture the message with the lowest non-zero rate
             if (lgMessagesRTCM[messageNumber].msgIsEphemeris)


### PR DESCRIPTION
Resolves #1046 and #1047 