### PR TITLE
Device_Update: Minor changes

### DIFF
--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -1003,7 +1003,8 @@ void deviceFirmwareReadFillBuffer(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMse
     if (deviceFirmwareRead(ctx, currentMsec, DFUS_DEVICE_CLOSE))
     {
         deviceFirmwareStopTasks(ctx);
-        ctx->_reboot = true;
+        if (ctx->_doAll == false)
+            ctx->_reboot = true;
         deviceFirmwareStateSet(ctx, DFUS_DEVICE_RESET);
     }
 }

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -232,6 +232,15 @@ void deviceFirmwareClose(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
     if (ctx->_complete)
         systemPrintf("CRC: 0x%08x\r\n", ctx->_crc);
 
+    // Display complete
+    systemPrintf("%s\r\n", dfuEqualSigns);
+    systemPrintf("%s %s %s!\r\n", ctx->_deviceInfo->_deviceName,
+                 (ctx->_outputDeviceType == DFU_ODT_DEVICE) ?
+                 "firmware update" : "file copy",
+                 (ctx->_bytesWritten == ctx->_fileBytes) ?
+                 "complete" : "failed");
+    systemPrintf("%s\r\n", dfuEqualSigns);
+
     // Close the output file
     deviceFirmwareCloseOutput(ctx);
 

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -1031,7 +1031,8 @@ void deviceFirmwareReadFillBuffer(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMse
 {
     if (deviceFirmwareRead(ctx, currentMsec, DFUS_DEVICE_CLOSE))
     {
-        deviceFirmwareStopTasks(ctx);
+        if (ctx->_outputDeviceType == DFU_ODT_DEVICE)
+            deviceFirmwareStopTasks(ctx);
         if (ctx->_doAll == false)
             ctx->_reboot = true;
         deviceFirmwareStateSet(ctx, DFUS_DEVICE_RESET);

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -1290,6 +1290,37 @@ nextDevice:
                 }
             }
 
+            // Allocate the device specific context
+            length = ctx->_deviceInfo->_devContextBytes;
+            if (length)
+            {
+                // Allocate the device specific context
+                ctx->_devCtx = (uint8_t *)rtkMalloc(length, "Device specific firmware update context");
+                if (ctx->_devCtx == nullptr)
+                {
+                    systemPrintf("ERROR: Failed to allocate the device specific context of %d bytes\r\n", length);
+                    reportHeapNow(true);
+                    if (ctx->_doAll)
+                        ctx->_reboot = false;
+                    deviceFirmwareStateSet(ctx, DFUS_NEXT_DEVICE);
+                    break;
+                }
+
+                // Initialize the device specific context
+                memset(ctx->_devCtx, 0, length);
+                if (ctx->_deviceInfo->_initDevCtx)
+                {
+                    if (ctx->_deviceInfo->_initDevCtx(ctx) == false)
+                    {
+                        systemPrintf("ERROR: Failed to initialize the %s device specific context\r\n",
+                                     ctx->_deviceInfo->_deviceName);
+                        if (ctx->_doAll)
+                            ctx->_reboot = false;
+                        deviceFirmwareStateSet(ctx, DFUS_NEXT_DEVICE);
+                    }
+                }
+            }
+
             // Determine maximum bytes to write at a time
             ctx->_bytesMax = ctx->_deviceInfo->_maxWriteBytes
                            ? ctx->_deviceInfo->_maxWriteBytes : ctx->_bufferLength;

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -66,7 +66,7 @@ void deviceFirmwareActionMenu(DEVICE_FIRMWARE_CTX * ctx)
         // Display the menu
         if ((ctx->_inputDeviceType == DFU_IDT_NVM) || (ctx->_inputDeviceType == DFU_IDT_SD))
             systemPrintf("d) Delete the file\r\n");
-        if (ctx->_deviceInfo->_useNvm)
+        if (ctx->_deviceInfo->_useNvm && (ctx->_inputDeviceType != DFU_IDT_NVM))
             systemPrintf("n) Copy file to NVM\r\n");
         if (present.microSd)
             systemPrintf("s) Copy file to SD card\r\n");
@@ -1220,7 +1220,8 @@ void deviceFirmwareSelectAction(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
             // Display the file list again
             deviceFirmwareFileListReload(ctx);
         }
-        else if ((action == 'n') && ctx->_deviceInfo->_useNvm)
+        else if ((action == 'n') && ctx->_deviceInfo->_useNvm
+            && (ctx->_inputDeviceType != DFU_IDT_NVM))
         {
             // Display the menu choice
             if (settings.debugFirmwareUpdate)

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -68,7 +68,7 @@ void deviceFirmwareActionMenu(DEVICE_FIRMWARE_CTX * ctx)
             systemPrintf("d) Delete the file\r\n");
         if (ctx->_deviceInfo->_useNvm && (ctx->_inputDeviceType != DFU_IDT_NVM))
             systemPrintf("n) Copy file to NVM\r\n");
-        if (present.microSd)
+        if (present.microSd && (ctx->_inputDeviceType != DFU_IDT_SD))
             systemPrintf("s) Copy file to SD card\r\n");
         systemPrintf("u) Update device firmware\r\n");
         systemPrintf("x) Exit\r\n");
@@ -1231,7 +1231,8 @@ void deviceFirmwareSelectAction(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
             ctx->_outputDeviceType = DFU_ODT_NVM;
             deviceFirmwareStateSet(ctx, DFUS_DEVICE_OPEN_INPUT);
         }
-        else if ((action == 's') && present.microSd)
+        else if ((action == 's') && present.microSd
+            && (ctx->_inputDeviceType != DFU_IDT_SD))
         {
             // Display the menu choice
             if (settings.debugFirmwareUpdate)

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -201,6 +201,14 @@ void deviceFirmwareCleanup(DEVICE_FIRMWARE_CTX * ctx)
         networkConsumerRemove(NETCONSUMER_DEVICE_OTA, NETWORK_ANY, __FILE__, __LINE__);
     }
 
+    // Done with the save data buffer
+    if (ctx->_saveData)
+    {
+        if (settings.debugFirmwareUpdate)
+            systemPrintf("Freeing ctx->_saveData, %d bytes\r\n", ctx->_saveDataLength);
+        rtkFree(ctx->_saveData, "DFU: ctx->_saveData");
+    }
+
     // Done with the context
     if (settings.debugFirmwareUpdate)
         systemPrintf("Freeing device firmware update context, %d bytes\r\n", sizeof(*ctx));
@@ -1592,7 +1600,9 @@ bool deviceFirmwareUpdate(uint32_t currentMsec)
 //----------------------------------------
 // State machine to perform the device firmware update
 //----------------------------------------
-bool deviceFirmwareUpdateBegin(bool doAll, bool debugVerbose)
+bool deviceFirmwareUpdateBegin(bool doAll,
+                               bool debugVerbose,
+                               size_t saveDataLength)
 {
     DEVICE_FIRMWARE_CTX * ctx;
     uint32_t currentMsec;
@@ -1633,6 +1643,23 @@ bool deviceFirmwareUpdateBegin(bool doAll, bool debugVerbose)
         {
             ctx->_outputDeviceType = DFU_ODT_DEVICE;
             ctx->_reboot = true;
+        }
+
+        // Allocate the save data buffer
+        if (debugVerbose && saveDataLength)
+        {
+            length = saveDataLength;
+            if (settings.debugFirmwareUpdate)
+                systemPrintf("Allocating %d bytes for _saveData\r\n", length);
+            ctx->_saveData = (uint8_t *)rtkMalloc(length, "DFU: ctx->_saveData");
+            if (ctx->_saveData == nullptr)
+            {
+                systemPrintf("ERROR: Failed to allocate ctx->_saveData of %d bytes\r\n", length);
+                rtkFree(ctx, "Device firmware context");
+                reportHeapNow(true);
+                break;
+            }
+            ctx->_saveDataLength = length;
         }
 
         // Set the initial state

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -48,6 +48,12 @@ const int dfuStateNameCount = sizeof(dfuStateName) / sizeof(dfuStateName[0]);
 const char * dfuEqualSigns = "==================================================";
 
 //----------------------------------------
+// Constants
+//----------------------------------------
+
+static bool dfuLoopInUpdate;    // Loop in deviceFirmwareUpdate while set
+
+//----------------------------------------
 // Display the action menu
 //----------------------------------------
 void deviceFirmwareActionMenu(DEVICE_FIRMWARE_CTX * ctx)
@@ -234,6 +240,7 @@ void deviceFirmwareClose(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
     deviceFirmwareCloseInput(ctx);
 
     // Determine if all firmware was written
+    dfuLoopInUpdate = false;
     if (ctx->_doAll)
     {
         if (ctx->_complete == false)
@@ -1063,29 +1070,84 @@ void deviceFirmwareReduceBufferSize(DEVICE_FIRMWARE_CTX * ctx)
 
 //----------------------------------------
 // Reset the device before doing the firmware update
+//
+//    file copy          firmware update
+//        |                     |
+//        |                     V
+//        |         .-----------------------.  Error
+//        '-------->|   DFUS_DEVICE_RESET   |-------------------.
+//                  '-----------------------'                   |
+//                              |  if (DFU_ODT_DEVICE)          |
+//                              |      true -> loopInUpdate     |
+//                              V                               |
+//               .-----------------------------.  Error         |
+//               |   DFUS_DEVICE_OPEN_OUTPUT   |------------.   |
+//               '-----------------------------'            |   |
+//                              |                           |   |
+//                              V                           |   |
+//        Done  .-------------------------------.           |   |
+//      .-------| DFUS_DEVICE_PROGRAM_FIRMWARE  |<------.   |   |
+//      |       '-------------------------------'       |   |   |
+//      |                       |  Need more data       |   |   |
+//      |                       V                       |   |   |
+//      |        .-----------------------------.  More  |   |   |
+//      |        |   DFUS_READ_FIRMWARE_DATA   |--------'   |   |
+//      |        '-----------------------------'  data      |   |
+//      |                       |  Error                    |   |
+//      |                       V                           |   |
+//      |           .-----------------------.               |   |
+//      '---------->|   DFUS_DEVICE_CLOSE   |<--------------'   |
+//                  '-----------------------'                   |
+//                              |  false -> loopInUpdate        |
+//         if (doAll == false)  |                               |
+//      .-----------------------+                               |
+//      |                       |  if (doAll == true)           |
+//      |                       V                               |
+//      |           .-----------------------.                   |
+//      |           |   DFUS_NEXT_DEVICE    |<------------------'
+//      |           '-----------------------'
+//      |
+//      |  if (reboot == true)   .-----------------------.
+//      +----------------------->|      DFUS_REBOOT      |
+//      |                        '-----------------------'
+//      |
+//      |  if (reboot == false)  .-----------------------.
+//      '----------------------->|       DFUS_DONE       |
+//                               '-----------------------'
+//
 //----------------------------------------
 void deviceFirmwareReset(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
 {
     const char * deviceName;
 
     deviceName = ctx->_deviceInfo->_deviceName;
-    if (ctx->_deviceInfo->_reset)
-    {
-        if (settings.debugFirmwareUpdate)
-            systemPrintf("Resetting %s for firmware update\r\n", deviceName);
-        if (ctx->_deviceInfo->_reset(ctx, currentMsec))
-            deviceFirmwareStateSet(ctx, DFUS_DEVICE_OPEN_OUTPUT);
-        else
-        {
-            systemPrintf("ERROR: %s firmware reset failed!\r\n", deviceName);
-            deviceFirmwareStateSet(ctx, DFUS_NEXT_DEVICE);
-        }
-        return;
-    }
 
-    if (settings.debugFirmwareUpdate)
-        systemPrintf("NOT IMPLEMENTED: %s firmware update reset routine!\r\n",
-                     deviceName);
+    // Enable looping in update when programming a device
+    dfuLoopInUpdate = (ctx->_outputDeviceType == DFU_ODT_DEVICE);
+
+    // Reset is not necessary when copying files
+    if (dfuLoopInUpdate)
+    {
+        // Get the reset routine
+        if (ctx->_deviceInfo->_reset)
+        {
+            if (settings.debugFirmwareUpdate)
+                systemPrintf("Resetting %s for firmware update\r\n", deviceName);
+            if (ctx->_deviceInfo->_reset(ctx, currentMsec))
+                deviceFirmwareStateSet(ctx, DFUS_DEVICE_OPEN_OUTPUT);
+            else
+            {
+                systemPrintf("ERROR: %s firmware reset failed!\r\n", deviceName);
+                deviceFirmwareStateSet(ctx, DFUS_NEXT_DEVICE);
+            }
+            return;
+        }
+
+        // Testing or device does not require reset
+        if (settings.debugFirmwareUpdate)
+            systemPrintf("NOT IMPLEMENTED: %s firmware update reset routine!\r\n",
+                         deviceName);
+    }
     deviceFirmwareStateSet(ctx, DFUS_DEVICE_OPEN_OUTPUT);
 }
 
@@ -1593,7 +1655,7 @@ bool deviceFirmwareUpdate(uint32_t currentMsec)
             deviceFirmwareStateSet(ctx, DFUS_DONE);
             break;
         }
-    } while (0);
+    } while (dfuLoopInUpdate);
     return running;
 }
 

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -441,10 +441,14 @@ void deviceFirmwareFileListMenu(DEVICE_FIRMWARE_CTX * ctx)
     if (ctx->_doAll == false)
     {
         inMainMenu = true;
-        systemPrintf("\r\nFile List:\r\n");
+
+        // Display the firmware version
+        if (ctx->_deviceInfo->_version)
+            systemPrintf("\r\nCurrent firmware version: %s\r\n", ctx->_deviceInfo->_version(ctx).c_str());
 
         // Display the files
         offset = 0;
+        systemPrintf("\r\nFile List:\r\n");
         deviceFirmwareFileList(bufferGetIndex(&dfuFirmwareFileNamesNet),
                                ctx->_fileCountNet,
                                deviceFirmwareGetDevicePrefix(DFU_IDT_NETWORK),
@@ -1232,6 +1236,10 @@ void deviceFirmwareSelectDevice(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
                         if (deviceFirmwareBufferAllocate(ctx) == false)
                             reportFatalError("Failed buffer allocation!");
                     }
+
+                    // Display the firmware version
+                    if (ctx->_deviceInfo->_version)
+                        systemPrintf("Current firmware version: %s\r\n", ctx->_deviceInfo->_version(ctx).c_str());
 
                     // Program the next device
                     goto nextDevice;

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -228,7 +228,6 @@ void deviceFirmwareCleanup(DEVICE_FIRMWARE_CTX * ctx)
 //----------------------------------------
 void deviceFirmwareClose(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
 {
-    systemPrintf("deviceFirmwareClose entered\r\n");
     // Display the CRC
     if (ctx->_complete)
         systemPrintf("CRC: 0x%08x\r\n", ctx->_crc);
@@ -258,7 +257,6 @@ void deviceFirmwareClose(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
         else
             deviceFirmwareStateSet(ctx, ctx->_reboot ? DFUS_REBOOT : DFUS_DONE);
     }
-    systemPrintf("deviceFirmwareClose exiting\r\n");
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -261,8 +261,11 @@ void deviceFirmwareClose(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
         if ((ctx->_outputDeviceType == DFU_ODT_NVM)
             || (ctx->_outputDeviceType == DFU_ODT_SD))
         {
+            // File copy
             deviceFirmwareFileListReload(ctx);
         }
+
+        // Programming a device
         else
             deviceFirmwareStateSet(ctx, ctx->_reboot ? DFUS_REBOOT : DFUS_DONE);
     }

--- a/Firmware/RTK_Everywhere/Device_Update.h
+++ b/Firmware/RTK_Everywhere/Device_Update.h
@@ -109,6 +109,10 @@ typedef struct _DEVICE_FIRMWARE_CTX
     size_t _bytesWritten;               // Number of bytes written to the output device
     uint32_t _packetNumber;             // Current firmware packet number
 
+    // Verbose debug buffer
+    uint8_t * _saveData;                // Buffer to receive input data from device
+    size_t _saveDataLength;             // Size in bytes of the save buffer
+
     // Status values
     uint32_t _attemptNumber;            // Number of attempts
     uint32_t _lastBlinkMsec;            // Blinking LED to indicate activity
@@ -277,7 +281,7 @@ const int dfuBufferInfoCount = sizeof(dfuBufferInfo) / sizeof(dfuBufferInfo[0]);
 #endif  //COMPILE_LG290P
 
 //----------------------------------------
-// Declare the device support routines
+// Declare the forward device support routines
 //----------------------------------------
 
 // Get firmware version
@@ -302,6 +306,11 @@ ssize_t dfuLg290pWrite(DEVICE_FIRMWARE_CTX * ctx,
 // Device close, finalize the firmware update
 void dfuEsp32Close(DEVICE_FIRMWARE_CTX * ctx);
 void dfuLg290pClose(DEVICE_FIRMWARE_CTX * ctx);
+
+// Declare the begin routine
+bool deviceFirmwareUpdateBegin(bool doAll,
+                               bool debugVerbose,
+                               size_t saveDataLength = 8 * 1024);
 
 //----------------------------------------
 // Describe the devices that support firmware update

--- a/Firmware/RTK_Everywhere/Device_Update.h
+++ b/Firmware/RTK_Everywhere/Device_Update.h
@@ -189,6 +189,7 @@ typedef ssize_t (* DEVICE_WRITE)(DEVICE_FIRMWARE_CTX * ctx,
                                  uint8_t * buffer,
                                  size_t bytesToWrite);
 typedef String (* GET_FIRMWARE_VERSION)(DEVICE_FIRMWARE_CTX * ctx);
+typedef bool (* INIT_DEV_CTX)(DEVICE_FIRMWARE_CTX * ctx);
 
 //----------------------------------------
 // Describe a device that needs firmware updates
@@ -206,6 +207,7 @@ typedef struct _DEVICE_FIRMWARE_INFO
     DEVICE_OPEN _open;          // Prepare for firmware updates
     DEVICE_WRITE _write;        // Perform the firmware writes
     DEVICE_CLOSE _close;        // Perform firmware write cleanup
+    INIT_DEV_CTX _initDevCtx;   // Initialize the device specific context
     bool _crcNeeded;            // Is file CRC needed to do firmware update
     bool _useNvm;               // Allow copy to NVM
     size_t _devContextBytes;    // Size of device specific context buffer
@@ -308,13 +310,13 @@ void dfuLg290pClose(struct _DEVICE_FIRMWARE_CTX * ctx);
 // Note: Use the JSON based OTA to get a new ESP32 image when the
 // parsing fails due to website changes on the servers below!
 const DEVICE_FIRMWARE_INFO deviceFirmwareInfo[] =
-{//  Name           present                 Directory                   NameData        Extension  Firmware version             Reset               Open                Write               Close           CRC     useNvm  Context Bytes           Buffer Bytes        Max Write Bytes                 Server     Branch      dPrefix1     dPrefix2  dirEnd      nPrefix  nameEnd     Raw Branch
-    {"ESP32",       nullptr,                nullptr,                    "Firmware_v",      ".bin", dfuEsp32GetFirmwareVersion,  nullptr,            dfuEsp32Open,       dfuEsp32Write,      dfuEsp32Close,  false,  false,  0,                      0,                  0,                              dfuGithub, nullptr,    dfuTree,     dfuItems, dfuListEnd, dfuName, dfuNameEnd, dfuRawHead},
+{//  Name           present                 Directory                   NameData        Extension  Firmware version             Reset               Open                Write               Close           InitDevCtx          CRC     useNvm  Context Bytes           Buffer Bytes        Max Write Bytes                 Server     Branch      dPrefix1     dPrefix2  dirEnd      nPrefix  nameEnd     Raw Branch
+    {"ESP32",       nullptr,                nullptr,                    "Firmware_v",      ".bin", dfuEsp32GetFirmwareVersion,  nullptr,            dfuEsp32Open,       dfuEsp32Write,      dfuEsp32Close,  nullptr,            false,  false,  0,                      0,                  0,                              dfuGithub, nullptr,    dfuTree,     dfuItems, dfuListEnd, dfuName, dfuNameEnd, dfuRawHead},
     // ESP32 must be the first entry in the list, p command does list in reverse
 
     // GNSS devices
 #ifdef  COMPILE_LG290P
-    {"LG290P",      &present.gnss_lg290p,   "/gnss/lg290p",             "LG290P",          ".pkg", dfuGnssGetFirmwareVersion,   dfuLg290pReset,     dfuLg290pOpen,      dfuLg290pWrite,     dfuLg290pClose, true,   false,  0,                      DFU_LG290P_BYTES,   DFU_LG290P_MAX_PAYLOAD_SIZE,    dfuGithub, dfuRawHead, dfuFileTree, dfuItems, dfuListEnd, dfuName, dfuNameEnd, dfuRawHead},
+    {"LG290P",      &present.gnss_lg290p,   "/gnss/lg290p",             "LG290P",          ".pkg", dfuGnssGetFirmwareVersion,   dfuLg290pReset,     dfuLg290pOpen,      dfuLg290pWrite,     dfuLg290pClose, nullptr,            true,   false,  0,                      DFU_LG290P_BYTES,   DFU_LG290P_MAX_PAYLOAD_SIZE,    dfuGithub, dfuRawHead, dfuFileTree, dfuItems, dfuListEnd, dfuName, dfuNameEnd, dfuRawHead},
 #endif  // COMPILE_LG290P
 };
 const int deviceFirmwareInfoCount = sizeof(deviceFirmwareInfo) / sizeof(deviceFirmwareInfo[0]);

--- a/Firmware/RTK_Everywhere/Device_Update.h
+++ b/Firmware/RTK_Everywhere/Device_Update.h
@@ -188,7 +188,7 @@ typedef bool (* DEVICE_RESET)(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec);
 typedef ssize_t (* DEVICE_WRITE)(DEVICE_FIRMWARE_CTX * ctx,
                                  uint8_t * buffer,
                                  size_t bytesToWrite);
-typedef String (* GET_FIRMWARE_VERSION)();
+typedef String (* GET_FIRMWARE_VERSION)(DEVICE_FIRMWARE_CTX * ctx);
 
 //----------------------------------------
 // Describe a device that needs firmware updates
@@ -279,8 +279,8 @@ const int dfuBufferInfoCount = sizeof(dfuBufferInfo) / sizeof(dfuBufferInfo[0]);
 //----------------------------------------
 
 // Get firmware version
-String dfuEsp32FirmwareVersion();
-String dfuGnssGetFirmwareVersion();
+String dfuEsp32GetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx);
+String dfuGnssGetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx);
 
 // Device reset
 bool dfuLg290pReset(struct _DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec);
@@ -309,7 +309,7 @@ void dfuLg290pClose(struct _DEVICE_FIRMWARE_CTX * ctx);
 // parsing fails due to website changes on the servers below!
 const DEVICE_FIRMWARE_INFO deviceFirmwareInfo[] =
 {//  Name           present                 Directory                   NameData        Extension  Firmware version             Reset               Open                Write               Close           CRC     useNvm  Context Bytes           Buffer Bytes        Max Write Bytes                 Server     Branch      dPrefix1     dPrefix2  dirEnd      nPrefix  nameEnd     Raw Branch
-    {"ESP32",       nullptr,                nullptr,                    "Firmware_v",      ".bin", dfuEsp32FirmwareVersion,     nullptr,            dfuEsp32Open,       dfuEsp32Write,      dfuEsp32Close,  false,  false,  0,                      0,                  0,                              dfuGithub, nullptr,    dfuTree,     dfuItems, dfuListEnd, dfuName, dfuNameEnd, dfuRawHead},
+    {"ESP32",       nullptr,                nullptr,                    "Firmware_v",      ".bin", dfuEsp32GetFirmwareVersion,  nullptr,            dfuEsp32Open,       dfuEsp32Write,      dfuEsp32Close,  false,  false,  0,                      0,                  0,                              dfuGithub, nullptr,    dfuTree,     dfuItems, dfuListEnd, dfuName, dfuNameEnd, dfuRawHead},
     // ESP32 must be the first entry in the list, p command does list in reverse
 
     // GNSS devices

--- a/Firmware/RTK_Everywhere/Device_Update.h
+++ b/Firmware/RTK_Everywhere/Device_Update.h
@@ -285,23 +285,23 @@ String dfuEsp32GetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx);
 String dfuGnssGetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx);
 
 // Device reset
-bool dfuLg290pReset(struct _DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec);
+bool dfuLg290pReset(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec);
 
 // Device open, prepare for writing firmware
-bool dfuEsp32Open(struct _DEVICE_FIRMWARE_CTX * ctx);
-bool dfuLg290pOpen(struct _DEVICE_FIRMWARE_CTX * ctx);
+bool dfuEsp32Open(DEVICE_FIRMWARE_CTX * ctx);
+bool dfuLg290pOpen(DEVICE_FIRMWARE_CTX * ctx);
 
 // Device write, perform the firmware update
-ssize_t dfuEsp32Write(struct _DEVICE_FIRMWARE_CTX * ctx,
+ssize_t dfuEsp32Write(DEVICE_FIRMWARE_CTX * ctx,
                       uint8_t * buffer,
                       size_t bytesToWrite);
-ssize_t dfuLg290pWrite(struct _DEVICE_FIRMWARE_CTX * ctx,
+ssize_t dfuLg290pWrite(DEVICE_FIRMWARE_CTX * ctx,
                        uint8_t * buffer,
                        size_t bytesToWrite);
 
 // Device close, finalize the firmware update
-void dfuEsp32Close(struct _DEVICE_FIRMWARE_CTX * ctx);
-void dfuLg290pClose(struct _DEVICE_FIRMWARE_CTX * ctx);
+void dfuEsp32Close(DEVICE_FIRMWARE_CTX * ctx);
+void dfuLg290pClose(DEVICE_FIRMWARE_CTX * ctx);
 
 //----------------------------------------
 // Describe the devices that support firmware update

--- a/Firmware/RTK_Everywhere/Device_Update_ESP32.ino
+++ b/Firmware/RTK_Everywhere/Device_Update_ESP32.ino
@@ -66,7 +66,7 @@ void dfuEsp32Close(DEVICE_FIRMWARE_CTX * ctx)
 //----------------------------------------
 // Get the current ESP32 firmware version
 //----------------------------------------
-String dfuEsp32FirmwareVersion()
+String dfuEsp32GetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx)
 {
     char version[128];
     firmwareVersionGet(version, sizeof(version), true);

--- a/Firmware/RTK_Everywhere/Device_Update_GNSS.ino
+++ b/Firmware/RTK_Everywhere/Device_Update_GNSS.ino
@@ -7,7 +7,7 @@ Device_Update_GNSS.ino
 //----------------------------------------
 // Get the GNSS firmware version
 //----------------------------------------
-String dfuGnssGetFirmwareVersion()
+String dfuGnssGetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx)
 {
     return String(gnssFirmwareVersion);
 }

--- a/Firmware/RTK_Everywhere/Device_Update_Network.ino
+++ b/Firmware/RTK_Everywhere/Device_Update_Network.ino
@@ -191,6 +191,24 @@ void dfuNetworkFileListGetFileName(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMs
 }
 
 //----------------------------------------
+// Display the error message and exit
+//----------------------------------------
+void dfuNetworkFileListError(DEVICE_FIRMWARE_CTX * ctx, const char * message)
+{
+    DFU_BUFFER_DATA * bufferData;
+
+    // Display the error message
+    systemPrintf("ERROR: %s\r\n", message);
+
+    // Restore access to the data buffer
+    bufferData = &dfuFirmwareFileNamesNet;
+    dfuNetworkCleanup(ctx, bufferData);
+
+    // No files available
+    deviceFirmwareStateSet(ctx, DFUS_GET_NVM_FILE_LIST);
+}
+
+//----------------------------------------
 // Request the web page containing the file specifications
 //----------------------------------------
 void dfuNetworkFileListHtmlRequest(DEVICE_FIRMWARE_CTX * ctx,
@@ -203,40 +221,42 @@ void dfuNetworkFileListHtmlRequest(DEVICE_FIRMWARE_CTX * ctx,
     const char * fileListPrefix;
     int httpResponseCode;
 
-    // Connect to the remote web page
-    ctx->_startMsec = currentMsec;
-    ctx->_https = new HTTPClient;
-    ctx->_https->begin(ctx->_url);
-    ctx->_https->setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
-
-    // Send HTTP GET request
-    httpResponseCode = ctx->_https->GET();
-
-    // Display the error
-    if (httpResponseCode != 200)
+    do
     {
-        // Display the response
-        if (settings.debugFirmwareUpdate)
-            systemPrintf("HTTP Response code: %d (%s)\r\n",
-                         httpResponseCode,
-                         ctx->_https->errorToString(httpResponseCode));
+        // Connect to the remote web page
+        ctx->_startMsec = currentMsec;
+        ctx->_https = new HTTPClient;
+        ctx->_https->begin(ctx->_url);
+        ctx->_https->setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
 
-        // Done with the HTTP link
-        dfuNetworkCleanup(ctx, nullptr);
+        // Send HTTP GET request
+        httpResponseCode = ctx->_https->GET();
 
-        // Stop with known error or too many retries
-        if ((httpResponseCode != -1) || (ctx->_attemptNumber++ >= 3))
+        // Display the error
+        if (httpResponseCode != 200)
         {
-            systemPrintf("Failed to open url: %s\r\n", ctx->_url.c_str());
-            deviceFirmwareStateSet(ctx, DFUS_GET_NVM_FILE_LIST);
+            // Display the response
+            if (settings.debugFirmwareUpdate)
+                systemPrintf("HTTP Response code: %d (%s)\r\n",
+                             httpResponseCode,
+                             ctx->_https->errorToString(httpResponseCode));
+
+            // Done with the HTTP link
+            dfuNetworkCleanup(ctx, nullptr);
+
+            // Stop with known error or too many retries
+            if ((httpResponseCode != -1) || (ctx->_attemptNumber++ >= 3))
+            {
+                systemPrintf("Failed to open url: %s\r\n", ctx->_url.c_str());
+                deviceFirmwareStateSet(ctx, DFUS_GET_NVM_FILE_LIST);
+            }
+            else
+            {
+                // Retry accessing the web server
+            }
+            break;
         }
-        else
-        {
-            // Retry accessing the web server
-        }
-    }
-    else
-    {
+
         // Get TCP stream
         ctx->_networkClient = ctx->_https->getStreamPtr();
 
@@ -246,34 +266,35 @@ void dfuNetworkFileListHtmlRequest(DEVICE_FIRMWARE_CTX * ctx,
         ctx->_bufferLength = bufferData->_length;
         ctx->_validDataBytes = 0;
 
-        // Locate the beginning of the directory listing
+        // Get the parsing strings
         dirPrefix = ctx->_deviceInfo->_dirPrefix;
         dirSuffix = ctx->_deviceInfo->_dirSuffix;
         fileListPrefix = ctx->_deviceInfo->_dirPrefix2;
         filePrefix = ctx->_deviceInfo->_entryPrefix;
-        if ((dirPrefix && (ctx->_networkClient->find(dirPrefix) == false))
-            || (fileListPrefix && (ctx->_networkClient->find(fileListPrefix) == false)))
-        {
-            systemPrintf("ERROR: Directory listing not found!\r\n");
-            dfuNetworkCleanup(ctx, bufferData);
-            deviceFirmwareStateSet(ctx, DFUS_GET_NVM_FILE_LIST);
-        }
-        else
-        {
-            // Locate the first file name
-            if (ctx->_networkClient->findUntil(filePrefix, dirSuffix))
-                // Get the list of names
-                deviceFirmwareStateSet(ctx, DFUS_GET_NETWORK_FILE_LIST);
-            else
-            {
-                // Restore access to the data buffer
-                dfuNetworkCleanup(ctx, bufferData);
 
-                // No files available
-                deviceFirmwareStateSet(ctx, DFUS_GET_NVM_FILE_LIST);
-            }
+        // Locate the beginning of the directory listing
+        if (dirPrefix && (ctx->_networkClient->find(dirPrefix) == false))
+        {
+            dfuNetworkFileListError(ctx, "Directory prefix not found!");
+            break;
         }
-    }
+
+        if (fileListPrefix && (ctx->_networkClient->find(fileListPrefix) == false))
+        {
+            dfuNetworkFileListError(ctx, "File list prefix not found!");
+            break;
+        }
+
+        // Locate the first file name
+        if (ctx->_networkClient->findUntil(filePrefix, dirSuffix) == false)
+        {
+            dfuNetworkFileListError(ctx, "File not found!");
+            break;
+        }
+
+        // Get the list of files
+        deviceFirmwareStateSet(ctx, DFUS_GET_NETWORK_FILE_LIST);
+    } while (0);
 }
 
 //----------------------------------------

--- a/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
+++ b/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
@@ -1003,7 +1003,8 @@ void deviceFirmwareReadFillBuffer(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMse
     if (deviceFirmwareRead(ctx, currentMsec, DFUS_DEVICE_CLOSE))
     {
         deviceFirmwareStopTasks(ctx);
-        ctx->_reboot = true;
+        if (ctx->_doAll == false)
+            ctx->_reboot = true;
         deviceFirmwareStateSet(ctx, DFUS_DEVICE_RESET);
     }
 }

--- a/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
+++ b/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
@@ -232,6 +232,15 @@ void deviceFirmwareClose(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
     if (ctx->_complete)
         systemPrintf("CRC: 0x%08x\r\n", ctx->_crc);
 
+    // Display complete
+    systemPrintf("%s\r\n", dfuEqualSigns);
+    systemPrintf("%s %s %s!\r\n", ctx->_deviceInfo->_deviceName,
+                 (ctx->_outputDeviceType == DFU_ODT_DEVICE) ?
+                 "firmware update" : "file copy",
+                 (ctx->_bytesWritten == ctx->_fileBytes) ?
+                 "complete" : "failed");
+    systemPrintf("%s\r\n", dfuEqualSigns);
+
     // Close the output file
     deviceFirmwareCloseOutput(ctx);
 

--- a/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
+++ b/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
@@ -1031,7 +1031,8 @@ void deviceFirmwareReadFillBuffer(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMse
 {
     if (deviceFirmwareRead(ctx, currentMsec, DFUS_DEVICE_CLOSE))
     {
-        deviceFirmwareStopTasks(ctx);
+        if (ctx->_outputDeviceType == DFU_ODT_DEVICE)
+            deviceFirmwareStopTasks(ctx);
         if (ctx->_doAll == false)
             ctx->_reboot = true;
         deviceFirmwareStateSet(ctx, DFUS_DEVICE_RESET);

--- a/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
+++ b/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
@@ -1290,6 +1290,37 @@ nextDevice:
                 }
             }
 
+            // Allocate the device specific context
+            length = ctx->_deviceInfo->_devContextBytes;
+            if (length)
+            {
+                // Allocate the device specific context
+                ctx->_devCtx = (uint8_t *)rtkMalloc(length, "Device specific firmware update context");
+                if (ctx->_devCtx == nullptr)
+                {
+                    systemPrintf("ERROR: Failed to allocate the device specific context of %d bytes\r\n", length);
+                    reportHeapNow(true);
+                    if (ctx->_doAll)
+                        ctx->_reboot = false;
+                    deviceFirmwareStateSet(ctx, DFUS_NEXT_DEVICE);
+                    break;
+                }
+
+                // Initialize the device specific context
+                memset(ctx->_devCtx, 0, length);
+                if (ctx->_deviceInfo->_initDevCtx)
+                {
+                    if (ctx->_deviceInfo->_initDevCtx(ctx) == false)
+                    {
+                        systemPrintf("ERROR: Failed to initialize the %s device specific context\r\n",
+                                     ctx->_deviceInfo->_deviceName);
+                        if (ctx->_doAll)
+                            ctx->_reboot = false;
+                        deviceFirmwareStateSet(ctx, DFUS_NEXT_DEVICE);
+                    }
+                }
+            }
+
             // Determine maximum bytes to write at a time
             ctx->_bytesMax = ctx->_deviceInfo->_maxWriteBytes
                            ? ctx->_deviceInfo->_maxWriteBytes : ctx->_bufferLength;

--- a/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
+++ b/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
@@ -66,7 +66,7 @@ void deviceFirmwareActionMenu(DEVICE_FIRMWARE_CTX * ctx)
         // Display the menu
         if ((ctx->_inputDeviceType == DFU_IDT_NVM) || (ctx->_inputDeviceType == DFU_IDT_SD))
             systemPrintf("d) Delete the file\r\n");
-        if (ctx->_deviceInfo->_useNvm)
+        if (ctx->_deviceInfo->_useNvm && (ctx->_inputDeviceType != DFU_IDT_NVM))
             systemPrintf("n) Copy file to NVM\r\n");
         if (present.microSd)
             systemPrintf("s) Copy file to SD card\r\n");
@@ -1220,7 +1220,8 @@ void deviceFirmwareSelectAction(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
             // Display the file list again
             deviceFirmwareFileListReload(ctx);
         }
-        else if ((action == 'n') && ctx->_deviceInfo->_useNvm)
+        else if ((action == 'n') && ctx->_deviceInfo->_useNvm
+            && (ctx->_inputDeviceType != DFU_IDT_NVM))
         {
             // Display the menu choice
             if (settings.debugFirmwareUpdate)

--- a/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
+++ b/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
@@ -68,7 +68,7 @@ void deviceFirmwareActionMenu(DEVICE_FIRMWARE_CTX * ctx)
             systemPrintf("d) Delete the file\r\n");
         if (ctx->_deviceInfo->_useNvm && (ctx->_inputDeviceType != DFU_IDT_NVM))
             systemPrintf("n) Copy file to NVM\r\n");
-        if (present.microSd)
+        if (present.microSd && (ctx->_inputDeviceType != DFU_IDT_SD))
             systemPrintf("s) Copy file to SD card\r\n");
         systemPrintf("u) Update device firmware\r\n");
         systemPrintf("x) Exit\r\n");
@@ -1231,7 +1231,8 @@ void deviceFirmwareSelectAction(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
             ctx->_outputDeviceType = DFU_ODT_NVM;
             deviceFirmwareStateSet(ctx, DFUS_DEVICE_OPEN_INPUT);
         }
-        else if ((action == 's') && present.microSd)
+        else if ((action == 's') && present.microSd
+            && (ctx->_inputDeviceType != DFU_IDT_SD))
         {
             // Display the menu choice
             if (settings.debugFirmwareUpdate)

--- a/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
+++ b/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
@@ -201,6 +201,14 @@ void deviceFirmwareCleanup(DEVICE_FIRMWARE_CTX * ctx)
         networkConsumerRemove(NETCONSUMER_DEVICE_OTA, NETWORK_ANY, __FILE__, __LINE__);
     }
 
+    // Done with the save data buffer
+    if (ctx->_saveData)
+    {
+        if (settings.debugFirmwareUpdate)
+            systemPrintf("Freeing ctx->_saveData, %d bytes\r\n", ctx->_saveDataLength);
+        rtkFree(ctx->_saveData, "DFU: ctx->_saveData");
+    }
+
     // Done with the context
     if (settings.debugFirmwareUpdate)
         systemPrintf("Freeing device firmware update context, %d bytes\r\n", sizeof(*ctx));
@@ -1592,7 +1600,9 @@ bool deviceFirmwareUpdate(uint32_t currentMsec)
 //----------------------------------------
 // State machine to perform the device firmware update
 //----------------------------------------
-bool deviceFirmwareUpdateBegin(bool doAll, bool debugVerbose)
+bool deviceFirmwareUpdateBegin(bool doAll,
+                               bool debugVerbose,
+                               size_t saveDataLength)
 {
     DEVICE_FIRMWARE_CTX * ctx;
     uint32_t currentMsec;
@@ -1633,6 +1643,23 @@ bool deviceFirmwareUpdateBegin(bool doAll, bool debugVerbose)
         {
             ctx->_outputDeviceType = DFU_ODT_DEVICE;
             ctx->_reboot = true;
+        }
+
+        // Allocate the save data buffer
+        if (debugVerbose && saveDataLength)
+        {
+            length = saveDataLength;
+            if (settings.debugFirmwareUpdate)
+                systemPrintf("Allocating %d bytes for _saveData\r\n", length);
+            ctx->_saveData = (uint8_t *)rtkMalloc(length, "DFU: ctx->_saveData");
+            if (ctx->_saveData == nullptr)
+            {
+                systemPrintf("ERROR: Failed to allocate ctx->_saveData of %d bytes\r\n", length);
+                rtkFree(ctx, "Device firmware context");
+                reportHeapNow(true);
+                break;
+            }
+            ctx->_saveDataLength = length;
         }
 
         // Set the initial state

--- a/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
+++ b/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
@@ -48,6 +48,12 @@ const int dfuStateNameCount = sizeof(dfuStateName) / sizeof(dfuStateName[0]);
 const char * dfuEqualSigns = "==================================================";
 
 //----------------------------------------
+// Constants
+//----------------------------------------
+
+static bool dfuLoopInUpdate;    // Loop in deviceFirmwareUpdate while set
+
+//----------------------------------------
 // Display the action menu
 //----------------------------------------
 void deviceFirmwareActionMenu(DEVICE_FIRMWARE_CTX * ctx)
@@ -234,6 +240,7 @@ void deviceFirmwareClose(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
     deviceFirmwareCloseInput(ctx);
 
     // Determine if all firmware was written
+    dfuLoopInUpdate = false;
     if (ctx->_doAll)
     {
         if (ctx->_complete == false)
@@ -1063,29 +1070,84 @@ void deviceFirmwareReduceBufferSize(DEVICE_FIRMWARE_CTX * ctx)
 
 //----------------------------------------
 // Reset the device before doing the firmware update
+//
+//    file copy          firmware update
+//        |                     |
+//        |                     V
+//        |         .-----------------------.  Error
+//        '-------->|   DFUS_DEVICE_RESET   |-------------------.
+//                  '-----------------------'                   |
+//                              |  if (DFU_ODT_DEVICE)          |
+//                              |      true -> loopInUpdate     |
+//                              V                               |
+//               .-----------------------------.  Error         |
+//               |   DFUS_DEVICE_OPEN_OUTPUT   |------------.   |
+//               '-----------------------------'            |   |
+//                              |                           |   |
+//                              V                           |   |
+//        Done  .-------------------------------.           |   |
+//      .-------| DFUS_DEVICE_PROGRAM_FIRMWARE  |<------.   |   |
+//      |       '-------------------------------'       |   |   |
+//      |                       |  Need more data       |   |   |
+//      |                       V                       |   |   |
+//      |        .-----------------------------.  More  |   |   |
+//      |        |   DFUS_READ_FIRMWARE_DATA   |--------'   |   |
+//      |        '-----------------------------'  data      |   |
+//      |                       |  Error                    |   |
+//      |                       V                           |   |
+//      |           .-----------------------.               |   |
+//      '---------->|   DFUS_DEVICE_CLOSE   |<--------------'   |
+//                  '-----------------------'                   |
+//                              |  false -> loopInUpdate        |
+//         if (doAll == false)  |                               |
+//      .-----------------------+                               |
+//      |                       |  if (doAll == true)           |
+//      |                       V                               |
+//      |           .-----------------------.                   |
+//      |           |   DFUS_NEXT_DEVICE    |<------------------'
+//      |           '-----------------------'
+//      |
+//      |  if (reboot == true)   .-----------------------.
+//      +----------------------->|      DFUS_REBOOT      |
+//      |                        '-----------------------'
+//      |
+//      |  if (reboot == false)  .-----------------------.
+//      '----------------------->|       DFUS_DONE       |
+//                               '-----------------------'
+//
 //----------------------------------------
 void deviceFirmwareReset(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
 {
     const char * deviceName;
 
     deviceName = ctx->_deviceInfo->_deviceName;
-    if (ctx->_deviceInfo->_reset)
-    {
-        if (settings.debugFirmwareUpdate)
-            systemPrintf("Resetting %s for firmware update\r\n", deviceName);
-        if (ctx->_deviceInfo->_reset(ctx, currentMsec))
-            deviceFirmwareStateSet(ctx, DFUS_DEVICE_OPEN_OUTPUT);
-        else
-        {
-            systemPrintf("ERROR: %s firmware reset failed!\r\n", deviceName);
-            deviceFirmwareStateSet(ctx, DFUS_NEXT_DEVICE);
-        }
-        return;
-    }
 
-    if (settings.debugFirmwareUpdate)
-        systemPrintf("NOT IMPLEMENTED: %s firmware update reset routine!\r\n",
-                     deviceName);
+    // Enable looping in update when programming a device
+    dfuLoopInUpdate = (ctx->_outputDeviceType == DFU_ODT_DEVICE);
+
+    // Reset is not necessary when copying files
+    if (dfuLoopInUpdate)
+    {
+        // Get the reset routine
+        if (ctx->_deviceInfo->_reset)
+        {
+            if (settings.debugFirmwareUpdate)
+                systemPrintf("Resetting %s for firmware update\r\n", deviceName);
+            if (ctx->_deviceInfo->_reset(ctx, currentMsec))
+                deviceFirmwareStateSet(ctx, DFUS_DEVICE_OPEN_OUTPUT);
+            else
+            {
+                systemPrintf("ERROR: %s firmware reset failed!\r\n", deviceName);
+                deviceFirmwareStateSet(ctx, DFUS_NEXT_DEVICE);
+            }
+            return;
+        }
+
+        // Testing or device does not require reset
+        if (settings.debugFirmwareUpdate)
+            systemPrintf("NOT IMPLEMENTED: %s firmware update reset routine!\r\n",
+                         deviceName);
+    }
     deviceFirmwareStateSet(ctx, DFUS_DEVICE_OPEN_OUTPUT);
 }
 
@@ -1593,7 +1655,7 @@ bool deviceFirmwareUpdate(uint32_t currentMsec)
             deviceFirmwareStateSet(ctx, DFUS_DONE);
             break;
         }
-    } while (0);
+    } while (dfuLoopInUpdate);
     return running;
 }
 

--- a/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
+++ b/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
@@ -441,10 +441,14 @@ void deviceFirmwareFileListMenu(DEVICE_FIRMWARE_CTX * ctx)
     if (ctx->_doAll == false)
     {
         inMainMenu = true;
-        systemPrintf("\r\nFile List:\r\n");
+
+        // Display the firmware version
+        if (ctx->_deviceInfo->_version)
+            systemPrintf("\r\nCurrent firmware version: %s\r\n", ctx->_deviceInfo->_version(ctx).c_str());
 
         // Display the files
         offset = 0;
+        systemPrintf("\r\nFile List:\r\n");
         deviceFirmwareFileList(bufferGetIndex(&dfuFirmwareFileNamesNet),
                                ctx->_fileCountNet,
                                deviceFirmwareGetDevicePrefix(DFU_IDT_NETWORK),
@@ -1232,6 +1236,10 @@ void deviceFirmwareSelectDevice(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
                         if (deviceFirmwareBufferAllocate(ctx) == false)
                             reportFatalError("Failed buffer allocation!");
                     }
+
+                    // Display the firmware version
+                    if (ctx->_deviceInfo->_version)
+                        systemPrintf("Current firmware version: %s\r\n", ctx->_deviceInfo->_version(ctx).c_str());
 
                     // Program the next device
                     goto nextDevice;

--- a/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
+++ b/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
@@ -228,7 +228,6 @@ void deviceFirmwareCleanup(DEVICE_FIRMWARE_CTX * ctx)
 //----------------------------------------
 void deviceFirmwareClose(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
 {
-    systemPrintf("deviceFirmwareClose entered\r\n");
     // Display the CRC
     if (ctx->_complete)
         systemPrintf("CRC: 0x%08x\r\n", ctx->_crc);
@@ -258,7 +257,6 @@ void deviceFirmwareClose(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
         else
             deviceFirmwareStateSet(ctx, ctx->_reboot ? DFUS_REBOOT : DFUS_DONE);
     }
-    systemPrintf("deviceFirmwareClose exiting\r\n");
 }
 
 //----------------------------------------

--- a/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
+++ b/Firmware/Test Sketches/Device_Update/Device_Firmware_Update.ino
@@ -261,8 +261,11 @@ void deviceFirmwareClose(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
         if ((ctx->_outputDeviceType == DFU_ODT_NVM)
             || (ctx->_outputDeviceType == DFU_ODT_SD))
         {
+            // File copy
             deviceFirmwareFileListReload(ctx);
         }
+
+        // Programming a device
         else
             deviceFirmwareStateSet(ctx, ctx->_reboot ? DFUS_REBOOT : DFUS_DONE);
     }

--- a/Firmware/Test Sketches/Device_Update/Device_Update.h
+++ b/Firmware/Test Sketches/Device_Update/Device_Update.h
@@ -109,6 +109,10 @@ typedef struct _DEVICE_FIRMWARE_CTX
     size_t _bytesWritten;               // Number of bytes written to the output device
     uint32_t _packetNumber;             // Current firmware packet number
 
+    // Verbose debug buffer
+    uint8_t * _saveData;                // Buffer to receive input data from device
+    size_t _saveDataLength;             // Size in bytes of the save buffer
+
     // Status values
     uint32_t _attemptNumber;            // Number of attempts
     uint32_t _lastBlinkMsec;            // Blinking LED to indicate activity
@@ -277,7 +281,7 @@ const int dfuBufferInfoCount = sizeof(dfuBufferInfo) / sizeof(dfuBufferInfo[0]);
 #endif  //COMPILE_LG290P
 
 //----------------------------------------
-// Declare the device support routines
+// Declare the forward device support routines
 //----------------------------------------
 
 // Get firmware version
@@ -302,6 +306,11 @@ ssize_t dfuLg290pWrite(DEVICE_FIRMWARE_CTX * ctx,
 // Device close, finalize the firmware update
 void dfuEsp32Close(DEVICE_FIRMWARE_CTX * ctx);
 void dfuLg290pClose(DEVICE_FIRMWARE_CTX * ctx);
+
+// Declare the begin routine
+bool deviceFirmwareUpdateBegin(bool doAll,
+                               bool debugVerbose,
+                               size_t saveDataLength = 8 * 1024);
 
 //----------------------------------------
 // Describe the devices that support firmware update

--- a/Firmware/Test Sketches/Device_Update/Device_Update.h
+++ b/Firmware/Test Sketches/Device_Update/Device_Update.h
@@ -189,6 +189,7 @@ typedef ssize_t (* DEVICE_WRITE)(DEVICE_FIRMWARE_CTX * ctx,
                                  uint8_t * buffer,
                                  size_t bytesToWrite);
 typedef String (* GET_FIRMWARE_VERSION)(DEVICE_FIRMWARE_CTX * ctx);
+typedef bool (* INIT_DEV_CTX)(DEVICE_FIRMWARE_CTX * ctx);
 
 //----------------------------------------
 // Describe a device that needs firmware updates
@@ -206,6 +207,7 @@ typedef struct _DEVICE_FIRMWARE_INFO
     DEVICE_OPEN _open;          // Prepare for firmware updates
     DEVICE_WRITE _write;        // Perform the firmware writes
     DEVICE_CLOSE _close;        // Perform firmware write cleanup
+    INIT_DEV_CTX _initDevCtx;   // Initialize the device specific context
     bool _crcNeeded;            // Is file CRC needed to do firmware update
     bool _useNvm;               // Allow copy to NVM
     size_t _devContextBytes;    // Size of device specific context buffer
@@ -308,13 +310,13 @@ void dfuLg290pClose(struct _DEVICE_FIRMWARE_CTX * ctx);
 // Note: Use the JSON based OTA to get a new ESP32 image when the
 // parsing fails due to website changes on the servers below!
 const DEVICE_FIRMWARE_INFO deviceFirmwareInfo[] =
-{//  Name           present                 Directory                   NameData        Extension  Firmware version             Reset               Open                Write               Close           CRC     useNvm  Context Bytes           Buffer Bytes        Max Write Bytes                 Server     Branch      dPrefix1     dPrefix2  dirEnd      nPrefix  nameEnd     Raw Branch
-    {"ESP32",       nullptr,                nullptr,                    "Firmware_v",      ".bin", dfuEsp32GetFirmwareVersion,  nullptr,            dfuEsp32Open,       dfuEsp32Write,      dfuEsp32Close,  false,  false,  0,                      0,                  0,                              dfuGithub, nullptr,    dfuTree,     dfuItems, dfuListEnd, dfuName, dfuNameEnd, dfuRawHead},
+{//  Name           present                 Directory                   NameData        Extension  Firmware version             Reset               Open                Write               Close           InitDevCtx          CRC     useNvm  Context Bytes           Buffer Bytes        Max Write Bytes                 Server     Branch      dPrefix1     dPrefix2  dirEnd      nPrefix  nameEnd     Raw Branch
+    {"ESP32",       nullptr,                nullptr,                    "Firmware_v",      ".bin", dfuEsp32GetFirmwareVersion,  nullptr,            dfuEsp32Open,       dfuEsp32Write,      dfuEsp32Close,  nullptr,            false,  false,  0,                      0,                  0,                              dfuGithub, nullptr,    dfuTree,     dfuItems, dfuListEnd, dfuName, dfuNameEnd, dfuRawHead},
     // ESP32 must be the first entry in the list, p command does list in reverse
 
     // GNSS devices
 #ifdef  COMPILE_LG290P
-    {"LG290P",      &present.gnss_lg290p,   "/gnss/lg290p",             "LG290P",          ".pkg", dfuGnssGetFirmwareVersion,   dfuLg290pReset,     dfuLg290pOpen,      dfuLg290pWrite,     dfuLg290pClose, true,   false,  0,                      DFU_LG290P_BYTES,   DFU_LG290P_MAX_PAYLOAD_SIZE,    dfuGithub, dfuRawHead, dfuFileTree, dfuItems, dfuListEnd, dfuName, dfuNameEnd, dfuRawHead},
+    {"LG290P",      &present.gnss_lg290p,   "/gnss/lg290p",             "LG290P",          ".pkg", dfuGnssGetFirmwareVersion,   dfuLg290pReset,     dfuLg290pOpen,      dfuLg290pWrite,     dfuLg290pClose, nullptr,            true,   false,  0,                      DFU_LG290P_BYTES,   DFU_LG290P_MAX_PAYLOAD_SIZE,    dfuGithub, dfuRawHead, dfuFileTree, dfuItems, dfuListEnd, dfuName, dfuNameEnd, dfuRawHead},
 #endif  // COMPILE_LG290P
 };
 const int deviceFirmwareInfoCount = sizeof(deviceFirmwareInfo) / sizeof(deviceFirmwareInfo[0]);

--- a/Firmware/Test Sketches/Device_Update/Device_Update.h
+++ b/Firmware/Test Sketches/Device_Update/Device_Update.h
@@ -188,7 +188,7 @@ typedef bool (* DEVICE_RESET)(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec);
 typedef ssize_t (* DEVICE_WRITE)(DEVICE_FIRMWARE_CTX * ctx,
                                  uint8_t * buffer,
                                  size_t bytesToWrite);
-typedef String (* GET_FIRMWARE_VERSION)();
+typedef String (* GET_FIRMWARE_VERSION)(DEVICE_FIRMWARE_CTX * ctx);
 
 //----------------------------------------
 // Describe a device that needs firmware updates
@@ -279,8 +279,8 @@ const int dfuBufferInfoCount = sizeof(dfuBufferInfo) / sizeof(dfuBufferInfo[0]);
 //----------------------------------------
 
 // Get firmware version
-String dfuEsp32FirmwareVersion();
-String dfuGnssGetFirmwareVersion();
+String dfuEsp32GetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx);
+String dfuGnssGetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx);
 
 // Device reset
 bool dfuLg290pReset(struct _DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec);
@@ -309,7 +309,7 @@ void dfuLg290pClose(struct _DEVICE_FIRMWARE_CTX * ctx);
 // parsing fails due to website changes on the servers below!
 const DEVICE_FIRMWARE_INFO deviceFirmwareInfo[] =
 {//  Name           present                 Directory                   NameData        Extension  Firmware version             Reset               Open                Write               Close           CRC     useNvm  Context Bytes           Buffer Bytes        Max Write Bytes                 Server     Branch      dPrefix1     dPrefix2  dirEnd      nPrefix  nameEnd     Raw Branch
-    {"ESP32",       nullptr,                nullptr,                    "Firmware_v",      ".bin", dfuEsp32FirmwareVersion,     nullptr,            dfuEsp32Open,       dfuEsp32Write,      dfuEsp32Close,  false,  false,  0,                      0,                  0,                              dfuGithub, nullptr,    dfuTree,     dfuItems, dfuListEnd, dfuName, dfuNameEnd, dfuRawHead},
+    {"ESP32",       nullptr,                nullptr,                    "Firmware_v",      ".bin", dfuEsp32GetFirmwareVersion,  nullptr,            dfuEsp32Open,       dfuEsp32Write,      dfuEsp32Close,  false,  false,  0,                      0,                  0,                              dfuGithub, nullptr,    dfuTree,     dfuItems, dfuListEnd, dfuName, dfuNameEnd, dfuRawHead},
     // ESP32 must be the first entry in the list, p command does list in reverse
 
     // GNSS devices

--- a/Firmware/Test Sketches/Device_Update/Device_Update.h
+++ b/Firmware/Test Sketches/Device_Update/Device_Update.h
@@ -285,23 +285,23 @@ String dfuEsp32GetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx);
 String dfuGnssGetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx);
 
 // Device reset
-bool dfuLg290pReset(struct _DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec);
+bool dfuLg290pReset(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec);
 
 // Device open, prepare for writing firmware
-bool dfuEsp32Open(struct _DEVICE_FIRMWARE_CTX * ctx);
-bool dfuLg290pOpen(struct _DEVICE_FIRMWARE_CTX * ctx);
+bool dfuEsp32Open(DEVICE_FIRMWARE_CTX * ctx);
+bool dfuLg290pOpen(DEVICE_FIRMWARE_CTX * ctx);
 
 // Device write, perform the firmware update
-ssize_t dfuEsp32Write(struct _DEVICE_FIRMWARE_CTX * ctx,
+ssize_t dfuEsp32Write(DEVICE_FIRMWARE_CTX * ctx,
                       uint8_t * buffer,
                       size_t bytesToWrite);
-ssize_t dfuLg290pWrite(struct _DEVICE_FIRMWARE_CTX * ctx,
+ssize_t dfuLg290pWrite(DEVICE_FIRMWARE_CTX * ctx,
                        uint8_t * buffer,
                        size_t bytesToWrite);
 
 // Device close, finalize the firmware update
-void dfuEsp32Close(struct _DEVICE_FIRMWARE_CTX * ctx);
-void dfuLg290pClose(struct _DEVICE_FIRMWARE_CTX * ctx);
+void dfuEsp32Close(DEVICE_FIRMWARE_CTX * ctx);
+void dfuLg290pClose(DEVICE_FIRMWARE_CTX * ctx);
 
 //----------------------------------------
 // Describe the devices that support firmware update

--- a/Firmware/Test Sketches/Device_Update/Device_Update_ESP32.ino
+++ b/Firmware/Test Sketches/Device_Update/Device_Update_ESP32.ino
@@ -66,7 +66,7 @@ void dfuEsp32Close(DEVICE_FIRMWARE_CTX * ctx)
 //----------------------------------------
 // Get the current ESP32 firmware version
 //----------------------------------------
-String dfuEsp32FirmwareVersion()
+String dfuEsp32GetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx)
 {
     char version[128];
     firmwareVersionGet(version, sizeof(version), true);

--- a/Firmware/Test Sketches/Device_Update/Device_Update_GNSS.ino
+++ b/Firmware/Test Sketches/Device_Update/Device_Update_GNSS.ino
@@ -7,7 +7,7 @@ Device_Update_GNSS.ino
 //----------------------------------------
 // Get the GNSS firmware version
 //----------------------------------------
-String dfuGnssGetFirmwareVersion()
+String dfuGnssGetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx)
 {
     return String(gnssFirmwareVersion);
 }

--- a/Firmware/Test Sketches/Device_Update/Device_Update_Network.ino
+++ b/Firmware/Test Sketches/Device_Update/Device_Update_Network.ino
@@ -191,6 +191,24 @@ void dfuNetworkFileListGetFileName(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMs
 }
 
 //----------------------------------------
+// Display the error message and exit
+//----------------------------------------
+void dfuNetworkFileListError(DEVICE_FIRMWARE_CTX * ctx, const char * message)
+{
+    DFU_BUFFER_DATA * bufferData;
+
+    // Display the error message
+    systemPrintf("ERROR: %s\r\n", message);
+
+    // Restore access to the data buffer
+    bufferData = &dfuFirmwareFileNamesNet;
+    dfuNetworkCleanup(ctx, bufferData);
+
+    // No files available
+    deviceFirmwareStateSet(ctx, DFUS_GET_NVM_FILE_LIST);
+}
+
+//----------------------------------------
 // Request the web page containing the file specifications
 //----------------------------------------
 void dfuNetworkFileListHtmlRequest(DEVICE_FIRMWARE_CTX * ctx,
@@ -203,40 +221,42 @@ void dfuNetworkFileListHtmlRequest(DEVICE_FIRMWARE_CTX * ctx,
     const char * fileListPrefix;
     int httpResponseCode;
 
-    // Connect to the remote web page
-    ctx->_startMsec = currentMsec;
-    ctx->_https = new HTTPClient;
-    ctx->_https->begin(ctx->_url);
-    ctx->_https->setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
-
-    // Send HTTP GET request
-    httpResponseCode = ctx->_https->GET();
-
-    // Display the error
-    if (httpResponseCode != 200)
+    do
     {
-        // Display the response
-        if (settings.debugFirmwareUpdate)
-            systemPrintf("HTTP Response code: %d (%s)\r\n",
-                         httpResponseCode,
-                         ctx->_https->errorToString(httpResponseCode));
+        // Connect to the remote web page
+        ctx->_startMsec = currentMsec;
+        ctx->_https = new HTTPClient;
+        ctx->_https->begin(ctx->_url);
+        ctx->_https->setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
 
-        // Done with the HTTP link
-        dfuNetworkCleanup(ctx, nullptr);
+        // Send HTTP GET request
+        httpResponseCode = ctx->_https->GET();
 
-        // Stop with known error or too many retries
-        if ((httpResponseCode != -1) || (ctx->_attemptNumber++ >= 3))
+        // Display the error
+        if (httpResponseCode != 200)
         {
-            systemPrintf("Failed to open url: %s\r\n", ctx->_url.c_str());
-            deviceFirmwareStateSet(ctx, DFUS_GET_NVM_FILE_LIST);
+            // Display the response
+            if (settings.debugFirmwareUpdate)
+                systemPrintf("HTTP Response code: %d (%s)\r\n",
+                             httpResponseCode,
+                             ctx->_https->errorToString(httpResponseCode));
+
+            // Done with the HTTP link
+            dfuNetworkCleanup(ctx, nullptr);
+
+            // Stop with known error or too many retries
+            if ((httpResponseCode != -1) || (ctx->_attemptNumber++ >= 3))
+            {
+                systemPrintf("Failed to open url: %s\r\n", ctx->_url.c_str());
+                deviceFirmwareStateSet(ctx, DFUS_GET_NVM_FILE_LIST);
+            }
+            else
+            {
+                // Retry accessing the web server
+            }
+            break;
         }
-        else
-        {
-            // Retry accessing the web server
-        }
-    }
-    else
-    {
+
         // Get TCP stream
         ctx->_networkClient = ctx->_https->getStreamPtr();
 
@@ -246,34 +266,35 @@ void dfuNetworkFileListHtmlRequest(DEVICE_FIRMWARE_CTX * ctx,
         ctx->_bufferLength = bufferData->_length;
         ctx->_validDataBytes = 0;
 
-        // Locate the beginning of the directory listing
+        // Get the parsing strings
         dirPrefix = ctx->_deviceInfo->_dirPrefix;
         dirSuffix = ctx->_deviceInfo->_dirSuffix;
         fileListPrefix = ctx->_deviceInfo->_dirPrefix2;
         filePrefix = ctx->_deviceInfo->_entryPrefix;
-        if ((dirPrefix && (ctx->_networkClient->find(dirPrefix) == false))
-            || (fileListPrefix && (ctx->_networkClient->find(fileListPrefix) == false)))
-        {
-            systemPrintf("ERROR: Directory listing not found!\r\n");
-            dfuNetworkCleanup(ctx, bufferData);
-            deviceFirmwareStateSet(ctx, DFUS_GET_NVM_FILE_LIST);
-        }
-        else
-        {
-            // Locate the first file name
-            if (ctx->_networkClient->findUntil(filePrefix, dirSuffix))
-                // Get the list of names
-                deviceFirmwareStateSet(ctx, DFUS_GET_NETWORK_FILE_LIST);
-            else
-            {
-                // Restore access to the data buffer
-                dfuNetworkCleanup(ctx, bufferData);
 
-                // No files available
-                deviceFirmwareStateSet(ctx, DFUS_GET_NVM_FILE_LIST);
-            }
+        // Locate the beginning of the directory listing
+        if (dirPrefix && (ctx->_networkClient->find(dirPrefix) == false))
+        {
+            dfuNetworkFileListError(ctx, "Directory prefix not found!");
+            break;
         }
-    }
+
+        if (fileListPrefix && (ctx->_networkClient->find(fileListPrefix) == false))
+        {
+            dfuNetworkFileListError(ctx, "File list prefix not found!");
+            break;
+        }
+
+        // Locate the first file name
+        if (ctx->_networkClient->findUntil(filePrefix, dirSuffix) == false)
+        {
+            dfuNetworkFileListError(ctx, "File not found!");
+            break;
+        }
+
+        // Get the list of files
+        deviceFirmwareStateSet(ctx, DFUS_GET_NETWORK_FILE_LIST);
+    } while (0);
 }
 
 //----------------------------------------


### PR DESCRIPTION
This pull request includes the following commits:
* Device_Update: if _doAll == true, don't reboot upon failure
* Display the firmware version
* Device_Update: Initialize the device specific context
* Device_Update: Remove struct _ from routine declarations
* Device_Update: Add ctx->_saveData to capture data during serial input
* Device_Update: Loop withing deviceFirmwareUpdate during firmware update
* Device_Update: Prevent NVM --> NVM file copy
* Device_Update: Prevent SD -> SD file copy
* Device_Update: Remove debugging prints from deviceFirmwareClose
* Device_Update: Display a completion message
* Device_Update: Add comments
* Device_Update: Only call deviceFirmwareStopTasks when programming device
* Network update: Breakup parsing to return errors
