### PR TITLE
Facet FP: Retry GNSS detection when GNSS is offline

### DIFF
--- a/Firmware/RTK_Everywhere/GNSS.ino
+++ b/Firmware/RTK_Everywhere/GNSS.ino
@@ -699,21 +699,24 @@ static void pushGPGGA(char *ggaData)
 // using serial or other begin() methods
 // To reduce potential false ID's, record the ID to NVM
 // If we have a previous ID, use it
-void gnssDetectReceiverType()
+bool gnssDetectReceiverType()
 {
     int index;
+    bool ranDetection;
 
     // Currently only the Facet FP requires GNSS receiver detection
     if (productVariant != RTK_FACET_FP)
-        return;
+        return true;
 
     if (gpioExpanderDetectGnss() == true)
     {
         gnssBoot(); // Tell GNSS to run
 
         // Start auto-detect if NVM is not yet set
+        ranDetection = false;
         if (settings.detectedGnssReceiver == GNSS_RECEIVER_UNKNOWN)
         {
+            ranDetection = true;
             systemPrintln("Beginning GNSS autodetection");
             displayGNSSAutodetect(0);
 
@@ -765,7 +768,7 @@ void gnssDetectReceiverType()
                 {
                     if (gnssSupportRoutines[index]._newClass)
                         gnssSupportRoutines[index]._newClass();
-                    return;
+                    return ranDetection;
                 }
             }
         }
@@ -779,6 +782,7 @@ void gnssDetectReceiverType()
     systemPrintln("Failed to detect or identify a Flex module.");
     settings.enablePrintBatteryMessages = true; // Print _something_ to the console
     displayGNSSAutodetectFailed(2000);
+    return true;
 }
 
 // Based on the platform, put the GNSS receiver into run mode

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -1413,7 +1413,7 @@ void setup()
     loadSettings(); // Attempt to load settings after SD is started so we can read the settings file if available
 
     DMW_b("gnssDetectReceiverType");
-    gnssDetectReceiverType(); // If we don't know the receiver from the platform, auto-detect it. Uses settings.
+    bool ranDetect = gnssDetectReceiverType(); // If we don't know the receiver from the platform, auto-detect it. Uses settings.
 
     // Check array defaults - after gnssDetectReceiverType() - before gnss->begin()
     DMW_b("checkArrayDefaults");
@@ -1459,6 +1459,14 @@ void setup()
 
     DMW_b("gnss->begin");
     gnss->begin(); // Requires settings - with array defaults
+
+    // Has the user switched the GNSS board in the Facet FP?
+    if ((online.gnss == false) && (ranDetect == false) && (productVariant == RTK_FACET_FP))
+    {
+        // Possibly, lets detect things again
+        settings.detectedGnssReceiver = GNSS_RECEIVER_UNKNOWN;
+        tiltForceDetectionReboot();
+    }
 
     DMW_b("beginRtcmParse");
     beginRtcmParse();

--- a/Firmware/RTK_Everywhere/Tilt.ino
+++ b/Firmware/RTK_Everywhere/Tilt.ino
@@ -1203,6 +1203,18 @@ void applyCompensationGGA(char *nmeaSentence, int sentenceLength)
         systemPrintf("Compensated GNGGA:\r\n%s\r\n", nmeaSentence);
 }
 
+// Force tilt detection
+void tiltForceDetectionReboot()
+{
+    // Force the tilt detection
+    settings.detectedTilt = false;
+    settings.testedTilt = false;
+    recordSystemSettings();
+
+    // Reboot the system
+    systemReset();
+}
+
 // Determine if a tilt sensor is available or not
 // Records outcome to NVM
 void tiltDetect()

--- a/Firmware/RTK_Everywhere/Tilt.ino
+++ b/Firmware/RTK_Everywhere/Tilt.ino
@@ -1219,6 +1219,8 @@ void tiltForceDetectionReboot()
 // Records outcome to NVM
 void tiltDetect()
 {
+    int x;
+
     // Only test housings that may have a tilt sensor on board
     if (variantHousingProperties->tiltPossible == false)
         return;
@@ -1270,7 +1272,7 @@ void tiltDetect()
     // The library will try twice with a 250ms
     // If communication fails, retry after a 3s timeout
     uint8_t maxTries = 2;
-    for (int x = 0; x < maxTries; x++)
+    for (x = 0; x < maxTries; x++)
     {
         if (tiltSensor->begin(SerialTiltTest) == true)
         {
@@ -1282,6 +1284,13 @@ void tiltDetect()
 
         if (x < (maxTries - 1))
             delay(3000);
+    }
+
+    // Check for tilt sensor not detected
+    if (x == maxTries)
+    {
+        delete tiltSensor;
+        tiltSensor = nullptr;
     }
 
     SerialTiltTest.end(); // Release UART2 for reuse

--- a/Firmware/RTK_Everywhere/menuSystem.ino
+++ b/Firmware/RTK_Everywhere/menuSystem.ino
@@ -1246,6 +1246,9 @@ void menuOperation()
         systemPrint("9) UART Receive Buffer Size: ");
         systemPrintln(settings.uartReceiveBufferSize);
 
+        // Tilt
+        systemPrintf("10) Force Tilt detect\r\n");
+
         // PPL Float Lock timeout
         systemPrint("11) Set PPL RTK Fix Timeout (seconds): ");
         if (settings.pplFixTimeoutS > 0)
@@ -1340,6 +1343,11 @@ void menuOperation()
                 ESP.restart();
             }
         }
+
+        // Allow the user to force tilt detection in case they switched the GNSS
+        // board in the Facet FP to one with the same GNSS but now has the tilt sensor
+        else if (incoming == 10)
+            tiltForceDetectionReboot();
         else if (incoming == 11)
         {
             getNewSetting("Enter number of seconds in RTK float using PPL, before reset", 0, 3600,


### PR DESCRIPTION
Enable the user to re-run tilt detection in case the GNSS board was swapped for one with the same GNSS device but now includes tilt support.