### PR TITLE
menuSystem: Add option 10 to operations menu to force tilt detection

### DIFF
--- a/Firmware/RTK_Everywhere/menuSystem.ino
+++ b/Firmware/RTK_Everywhere/menuSystem.ino
@@ -1233,6 +1233,9 @@ void menuOperation()
         systemPrint("9) UART Receive Buffer Size: ");
         systemPrintln(settings.uartReceiveBufferSize);
 
+        // Tilt
+        systemPrintf("10) Force Tilt detect\r\n");
+
         // PPL Float Lock timeout
         systemPrint("11) Set PPL RTK Fix Timeout (seconds): ");
         if (settings.pplFixTimeoutS > 0)
@@ -1327,6 +1330,11 @@ void menuOperation()
                 ESP.restart();
             }
         }
+
+        // Allow the user to force tilt detection in case they switched the GNSS
+        // board in the Facet FP to one with the same GNSS but now has the tilt sensor
+        else if (incoming == 10)
+            tiltForceDetectionReboot();
         else if (incoming == 11)
         {
             getNewSetting("Enter number of seconds in RTK float using PPL, before reset", 0, 3600,


### PR DESCRIPTION
Enable the user to re-run tilt detection in case the GNSS board was swapped for one with the same GNSS device but now includes tilt support.