### PR TITLE
Device_Update: Make ready for addition of CSV support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,12 +64,13 @@ Firmware/Test\ Sketches/?/*
 
 # Executables
 Compare
+File_CRC
+File_to_Hex_Data_Array
 NMEA_Client
 Read_Map_File
 RTK_Reset
 Split_Messages
 X.509_crt_bundle_bin_to_c
-File_to_Hex_Data_Array
 
 # Claude workspace metadata
 **/.claude/

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -236,7 +236,8 @@ void deviceFirmwareClose(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
 {
     // Display the CRC
     if (ctx->_complete)
-        systemPrintf("CRC: 0x%08x\r\n", ctx->_crc);
+        systemPrintf("CRC: 0x%08x, %d (0x%08x) bytes\r\n",
+                     ctx->_crc, ctx->_crcBytes, ctx->_crcBytes);
 
     // Display complete
     systemPrintf("%s\r\n", dfuEqualSigns);
@@ -331,13 +332,13 @@ void deviceFirmwareCrcClose(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
     {
         // Display the statistics
         deviceFirmwarePerformUpdate(ctx);
-        systemPrintf("CRC: 0x%08x\r\n", ctx->_crc);
+        systemPrintf("CRC: 0x%08x, %d (0x%08x) bytes\r\n",
+                     ctx->_crc, ctx->_crcBytes, ctx->_crcBytes);
         ctx->_crcSave = ctx->_crc;
         deviceFirmwareStateSet(ctx, DFUS_DEVICE_OPEN_INPUT);
     }
     else
         deviceFirmwareStateSet(ctx, DFUS_NEXT_DEVICE);
-    ctx->_crc = 0;
 }
 
 //----------------------------------------
@@ -346,6 +347,7 @@ void deviceFirmwareCrcClose(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
 void deviceFirmwareCrcOpen(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
 {
     // Give user a hint as to what is taking so long
+    deviceFirmwareReadInit(ctx, dfuFirmwareData._address, dfuFirmwareData._length);
     if (settings.debugFirmwareUpdate)
     {
         if (ctx->_inputDeviceType == DFU_IDT_NETWORK)
@@ -367,9 +369,6 @@ void deviceFirmwareCrcReadData(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
 {
     if (deviceFirmwareRead(ctx, currentMsec, DFUS_CRC_CLOSE))
     {
-        // Compute the CRC across these bytes
-        ctx->_crc = crc32Compute(ctx->_crc, ctx->_buffer, ctx->_validDataBytes);
-
         // Empty the buffer
         ctx->_validDataBytes = 0;
 
@@ -999,8 +998,11 @@ bool deviceFirmwareRead(DEVICE_FIRMWARE_CTX * ctx,
             return false;
         }
         else if (bytesRead)
+        {
             // Compute the CRC
             ctx->_crc = crc32Compute(ctx->_crc, ctx->_data, bytesRead);
+            ctx->_crcBytes += bytesRead;
+        }
     }
 
     // Remaining data starts at the beginning of the buffer
@@ -1065,6 +1067,8 @@ void deviceFirmwareReadInit(DEVICE_FIRMWARE_CTX * ctx, uint8_t * buffer, size_t 
     ctx->_data = buffer;
     ctx->_bufferLength = length;
     ctx->_bytesRead = 0;
+    ctx->_crc = 0;
+    ctx->_crcBytes = 0;
     ctx->_validDataBytes = 0;
 }
 

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -827,6 +827,7 @@ void deviceFirmwareOpenOutput(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
     {
         ctx->_bytesWritten = 0;
         ctx->_packetNumber = 0;
+        ctx->_percentage = -1;
         result = false;
 
         // Network write data path

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -792,7 +792,7 @@ bool deviceFirmwareOpenInput(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
     if (ctx->_outputDeviceType == DFU_ODT_NONE)
         reportFatalError("Output device type is DFU_ODT_NONE!");
 
-    ctx->_bytesRead = 0;
+    deviceFirmwareReadInit(ctx, dfuFirmwareData._address, dfuFirmwareData._length);
     ctx->_complete = false;
     ctx->_startMsec = millis();
 
@@ -1053,6 +1053,18 @@ void deviceFirmwareReadFirmwareData(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentM
 {
     if (deviceFirmwareRead(ctx, currentMsec, DFUS_CRC_CLOSE))
         deviceFirmwareStateSet(ctx, DFUS_DEVICE_PROGRAM_FIRMWARE);
+}
+
+//----------------------------------------
+// Initialize the read operation
+//----------------------------------------
+void deviceFirmwareReadInit(DEVICE_FIRMWARE_CTX * ctx, uint8_t * buffer, size_t length)
+{
+    ctx->_buffer = buffer;
+    ctx->_data = buffer;
+    ctx->_bufferLength = length;
+    ctx->_bytesRead = 0;
+    ctx->_validDataBytes = 0;
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -1803,7 +1803,7 @@ void deviceFirmwareWrite(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
     ssize_t bytesWritten;
     bool done;
     int percentage;
-    DEVICE_WRITE write;
+    DFU_DEVICE_WRITE write;
 
     // Determine if there is enough data to write
     write = ctx->_deviceInfo->_write;

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -475,7 +475,7 @@ void deviceFirmwareFileListMenu(DEVICE_FIRMWARE_CTX * ctx)
 
         // Display the firmware version
         if (ctx->_deviceInfo->_version)
-            systemPrintf("\r\nCurrent firmware version: %s\r\n", ctx->_deviceInfo->_version(ctx).c_str());
+            systemPrintf("\r\nCurrent firmware version: %d\r\n", ctx->_deviceInfo->_version(ctx));
 
         // Display the files
         offset = 0;
@@ -1325,7 +1325,7 @@ void deviceFirmwareSelectDevice(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
 
                     // Display the firmware version
                     if (ctx->_deviceInfo->_version)
-                        systemPrintf("Current firmware version: %s\r\n", ctx->_deviceInfo->_version(ctx).c_str());
+                        systemPrintf("Current firmware version: %d\r\n", ctx->_deviceInfo->_version(ctx));
 
                     // Program the next device
                     goto nextDevice;

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -1300,6 +1300,7 @@ void deviceFirmwareSelectAction(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
 //----------------------------------------
 void deviceFirmwareSelectDevice(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
 {
+    const DEVICE_FIRMWARE_INFO * deviceInfo;
     int incoming;
     size_t length;
 
@@ -1329,8 +1330,9 @@ void deviceFirmwareSelectDevice(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
 
                 // Determine if the next device is in the system
                 ctx->_deviceInfo -= 1;
-                if ((ctx->_deviceInfo->_present == nullptr)
-                    || (*ctx->_deviceInfo->_present))
+                deviceInfo = ctx->_deviceInfo;
+                if ((deviceInfo->_present == nullptr)
+                    || (*deviceInfo->_present))
                 {
                     if ((dfuBufferInfo[0]._bufferData == nullptr)
                         || (dfuBufferInfo[0]._bufferData->_address == nullptr))
@@ -1341,8 +1343,8 @@ void deviceFirmwareSelectDevice(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
                     }
 
                     // Display the firmware version
-                    if (ctx->_deviceInfo->_version)
-                        systemPrintf("Current firmware version: %d\r\n", ctx->_deviceInfo->_version(ctx));
+                    if (deviceInfo->_version)
+                        systemPrintf("Current firmware version: %d\r\n", deviceInfo->_version(ctx));
 
                     // Program the next device
                     goto nextDevice;
@@ -1374,10 +1376,11 @@ void deviceFirmwareSelectDevice(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
 
 nextDevice:
             // Display the menu choice
-            systemPrintf("Selected device: %s\r\n", ctx->_deviceInfo->_deviceName);
+            deviceInfo = ctx->_deviceInfo;
+            systemPrintf("Selected device: %s\r\n", deviceInfo->_deviceName);
 
             // Allocate the necessary write buffer
-            length = ctx->_deviceInfo->_writeBufferBytes;
+            length = deviceInfo->_writeBufferBytes;
             if (length)
             {
                 // Allocate the write buffer for this device
@@ -1394,7 +1397,7 @@ nextDevice:
             }
 
             // Allocate the device specific context
-            length = ctx->_deviceInfo->_devContextBytes;
+            length = deviceInfo->_devContextBytes;
             if (length)
             {
                 // Allocate the device specific context
@@ -1411,12 +1414,12 @@ nextDevice:
 
                 // Initialize the device specific context
                 memset(ctx->_devCtx, 0, length);
-                if (ctx->_deviceInfo->_initDevCtx)
+                if (deviceInfo->_initDevCtx)
                 {
-                    if (ctx->_deviceInfo->_initDevCtx(ctx) == false)
+                    if (deviceInfo->_initDevCtx(ctx) == false)
                     {
                         systemPrintf("ERROR: Failed to initialize the %s device specific context\r\n",
-                                     ctx->_deviceInfo->_deviceName);
+                                     deviceInfo->_deviceName);
                         if (ctx->_doAll)
                             ctx->_reboot = false;
                         deviceFirmwareStateSet(ctx, DFUS_NEXT_DEVICE);
@@ -1425,8 +1428,8 @@ nextDevice:
             }
 
             // Determine maximum bytes to write at a time
-            ctx->_bytesMax = ctx->_deviceInfo->_maxWriteBytes
-                           ? ctx->_deviceInfo->_maxWriteBytes : ctx->_bufferLength;
+            ctx->_bytesMax = deviceInfo->_maxWriteBytes
+                           ? deviceInfo->_maxWriteBytes : ctx->_bufferLength;
 
             // Get the files
             systemPrintf("Getting the file list...\r\n");

--- a/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
+++ b/Firmware/RTK_Everywhere/Device_Firmware_Update.ino
@@ -725,7 +725,11 @@ void deviceFirmwareNextDevice(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec)
     // Done with the web server
     if (ctx->_https)
     {
-        ctx->_networkClient;
+        if (ctx->_networkClient)
+        {
+            ctx->_networkClient->stop();
+            ctx->_networkClient = nullptr;
+        }
         ctx->_https->end();
         delete ctx->_https;
         ctx->_https = nullptr;

--- a/Firmware/RTK_Everywhere/Device_Update.h
+++ b/Firmware/RTK_Everywhere/Device_Update.h
@@ -196,7 +196,7 @@ typedef bool (* DFU_DEVICE_RESET)(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMse
 typedef ssize_t (* DFU_DEVICE_WRITE)(DEVICE_FIRMWARE_CTX * ctx,
                                      const uint8_t * buffer,
                                      size_t bytesToWrite);
-typedef String (* DFU_GET_FIRMWARE_VERSION)(DEVICE_FIRMWARE_CTX * ctx);
+typedef int (* DFU_GET_FIRMWARE_VERSION)(DEVICE_FIRMWARE_CTX * ctx);
 typedef bool (* DFU_INIT_DEV_CTX)(DEVICE_FIRMWARE_CTX * ctx);
 
 //----------------------------------------
@@ -289,8 +289,8 @@ const int dfuBufferInfoCount = sizeof(dfuBufferInfo) / sizeof(dfuBufferInfo[0]);
 //----------------------------------------
 
 // Get firmware version
-String dfuEsp32GetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx);
-String dfuGnssGetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx);
+int dfuEsp32GetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx);
+int dfuGnssGetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx);
 
 // Device reset
 bool dfuLg290pReset(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec);

--- a/Firmware/RTK_Everywhere/Device_Update.h
+++ b/Firmware/RTK_Everywhere/Device_Update.h
@@ -190,14 +190,14 @@ enum DFU_OUTPUT_DEVICE_TYPE
 //----------------------------------------
 // Declare the generic device firmware update routines
 //----------------------------------------
-typedef void (* DEVICE_CLOSE)(DEVICE_FIRMWARE_CTX * ctx);
-typedef bool (* DEVICE_OPEN)(DEVICE_FIRMWARE_CTX * ctx);
-typedef bool (* DEVICE_RESET)(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec);
-typedef ssize_t (* DEVICE_WRITE)(DEVICE_FIRMWARE_CTX * ctx,
-                                 const uint8_t * buffer,
-                                 size_t bytesToWrite);
-typedef String (* GET_FIRMWARE_VERSION)(DEVICE_FIRMWARE_CTX * ctx);
-typedef bool (* INIT_DEV_CTX)(DEVICE_FIRMWARE_CTX * ctx);
+typedef void (* DFU_DEVICE_CLOSE)(DEVICE_FIRMWARE_CTX * ctx);
+typedef bool (* DFU_DEVICE_OPEN)(DEVICE_FIRMWARE_CTX * ctx);
+typedef bool (* DFU_DEVICE_RESET)(DEVICE_FIRMWARE_CTX * ctx, uint32_t currentMsec);
+typedef ssize_t (* DFU_DEVICE_WRITE)(DEVICE_FIRMWARE_CTX * ctx,
+                                     const uint8_t * buffer,
+                                     size_t bytesToWrite);
+typedef String (* DFU_GET_FIRMWARE_VERSION)(DEVICE_FIRMWARE_CTX * ctx);
+typedef bool (* DFU_INIT_DEV_CTX)(DEVICE_FIRMWARE_CTX * ctx);
 
 //----------------------------------------
 // Describe a device that needs firmware updates
@@ -210,12 +210,12 @@ typedef struct _DEVICE_FIRMWARE_INFO
     const char * _directory;    // Firmware directory
     const char * _nameData;     // Data in file name, may be nullptr
     const char * _extension;    // Data in file name (extension), may be nullptr
-    GET_FIRMWARE_VERSION _version;  // Firmware version display routine
-    DEVICE_RESET _reset;        // Reset the device before loading firmware
-    DEVICE_OPEN _open;          // Prepare for firmware updates
-    DEVICE_WRITE _write;        // Perform the firmware writes
-    DEVICE_CLOSE _close;        // Perform firmware write cleanup
-    INIT_DEV_CTX _initDevCtx;   // Initialize the device specific context
+    DFU_GET_FIRMWARE_VERSION _version; // Firmware version display routine
+    DFU_DEVICE_RESET _reset;    // Reset the device before loading firmware
+    DFU_DEVICE_OPEN _open;      // Prepare for firmware updates
+    DFU_DEVICE_WRITE _write;    // Perform the firmware writes
+    DFU_DEVICE_CLOSE _close;    // Perform firmware write cleanup
+    DFU_INIT_DEV_CTX _initDevCtx; // Initialize the device specific context
     size_t _devContextBytes;    // Size of device specific context buffer
     bool _crcNeeded;            // Is file CRC needed to do firmware update
     bool _useNvm;               // Allow copy to NVM

--- a/Firmware/RTK_Everywhere/Device_Update.h
+++ b/Firmware/RTK_Everywhere/Device_Update.h
@@ -56,6 +56,7 @@ typedef struct _DEVICE_FIRMWARE_CTX
     size_t _fileBytes;                  // Length of the file in bytes
     bool _crcNeeded;                    // Does CRC need to be computed
     uint32_t _crc;                      // CRC value
+    size_t _crcBytes;                   // Number of bytes used to compute the CRC
     uint32_t _crcSave;                  // CRC computed during deviceFirmwareCrcReadData
 
     // Buffer support

--- a/Firmware/RTK_Everywhere/Device_Update_ESP32.ino
+++ b/Firmware/RTK_Everywhere/Device_Update_ESP32.ino
@@ -66,11 +66,9 @@ void dfuEsp32Close(DEVICE_FIRMWARE_CTX * ctx)
 //----------------------------------------
 // Get the current ESP32 firmware version
 //----------------------------------------
-String dfuEsp32GetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx)
+int dfuEsp32GetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx)
 {
-    char version[128];
-    //firmwareVersionGet(version, sizeof(version), true);
-    return String(version);
+    return RTK_IDENTIFIER;
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/Device_Update_GNSS.ino
+++ b/Firmware/RTK_Everywhere/Device_Update_GNSS.ino
@@ -7,7 +7,7 @@ Device_Update_GNSS.ino
 //----------------------------------------
 // Get the GNSS firmware version
 //----------------------------------------
-String dfuGnssGetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx)
+int dfuGnssGetFirmwareVersion(DEVICE_FIRMWARE_CTX * ctx)
 {
-    return String(gnssFirmwareVersion);
+    return gnssFirmwareVersionInt;
 }

--- a/Firmware/RTK_Everywhere/menuFirmware.ino
+++ b/Firmware/RTK_Everywhere/menuFirmware.ino
@@ -76,8 +76,10 @@ bool newOTAFirmwareAvailable = false;
 void firmwareMenu()
 {
     bool debugVerbose;
+    bool developerOptions;
 
     debugVerbose = false;
+    developerOptions = false;
     while (1)
     {
         systemPrintln();
@@ -92,11 +94,15 @@ void firmwareMenu()
         // fails in deviceFirmwareUpdate due to server website changes!
         // Letters: a  c  e  i  r  s  u
         otaMenuDisplay(currentVersion);
-        systemPrintf("d) Single device firmware update\r\n");
-        systemPrintf("p) Program all firmware updates\r\n");
-        systemPrintf("t) %s firmware debugging\r\n", settings.debugFirmwareUpdate ? "Disable" : "Enable");
-        if (settings.debugFirmwareUpdate)
-            systemPrintf("v) %s verbose firmware debugging\r\n", debugVerbose ? "Disable" : "Enable");
+        systemPrintf("D) %s developer options\r\n", developerOptions ? "Disable" : "Enable");
+        if (developerOptions)
+        {
+            systemPrintf("d) %s firmware debugging\r\n", settings.debugFirmwareUpdate ? "Disable" : "Enable");
+            systemPrintf("l) Update all devices to latest released firmware\r\n");
+            systemPrintf("o) Update one device's firmware\r\n");
+            if (settings.debugFirmwareUpdate)
+                systemPrintf("v) %s verbose firmware debugging\r\n", debugVerbose ? "Disable" : "Enable");
+        }
 
         for (int x = 0; x < binCount; x++)
             systemPrintf("%d) Load SD file: %s\r\n", x + 1, binFileNames[x]);
@@ -119,26 +125,30 @@ void firmwareMenu()
         {
         }
 
-        // Perform the device firmware update
-        else if ((incoming == 'd') || (incoming == 'p'))
-        {
-            deviceFirmwareUpdateBegin(incoming == 'p', debugVerbose);
-            while (deviceFirmwareUpdate(millis()))
-            {
-                networkUpdate();
-            }
-        }
+        // Enable / disable developer options
+        else if (incoming == 'D')
+            developerOptions ^= 1;
 
         // Toggle firmware debugging
-        else if (incoming == 't')
+        else if (developerOptions && (incoming == 'd'))
         {
             settings.debugFirmwareUpdate ^= 1;
             if (settings.debugFirmwareUpdate == false)
                 debugVerbose = false;
         }
 
+        // Perform the device firmware update
+        else if (developerOptions && ((incoming == 'l') || (incoming == 'o')))
+        {
+            deviceFirmwareUpdateBegin(incoming == 'l', debugVerbose);
+            while (deviceFirmwareUpdate(millis()))
+            {
+                networkUpdate();
+            }
+        }
+
         // Toggle verbose firmware debugging
-        else if (settings.debugFirmwareUpdate && (incoming == 'v'))
+        else if (developerOptions && settings.debugFirmwareUpdate && (incoming == 'v'))
             debugVerbose ^= 1;
 
         else if (incoming == 'x')

--- a/Firmware/Tools/File_CRC.c
+++ b/Firmware/Tools/File_CRC.c
@@ -1,0 +1,194 @@
+/**********************************************************************
+* File_to_Hex_Data_Array.c
+*
+* Program to read a file and convert the contexts to C array of unsigned
+* characters.
+**********************************************************************/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+//----------------------------------------
+// Constants
+//----------------------------------------
+
+static const uint32_t crc32Table[256] =
+{
+    0x00000000, 0x77073096, 0xee0e612c, 0x990951ba,
+    0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3,
+    0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
+    0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91,
+    0x1db71064, 0x6ab020f2, 0xf3b97148, 0x84be41de,
+    0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
+    0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec,
+    0x14015c4f, 0x63066cd9, 0xfa0f3d63, 0x8d080df5,
+    0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
+    0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b,
+    0x35b5a8fa, 0x42b2986c, 0xdbbbc9d6, 0xacbcf940,
+    0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
+    0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116,
+    0x21b4f4b5, 0x56b3c423, 0xcfba9599, 0xb8bda50f,
+    0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
+    0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d,
+    0x76dc4190, 0x01db7106, 0x98d220bc, 0xefd5102a,
+    0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
+    0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818,
+    0x7f6a0dbb, 0x086d3d2d, 0x91646c97, 0xe6635c01,
+    0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e,
+    0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457,
+    0x65b0d9c6, 0x12b7e950, 0x8bbeb8ea, 0xfcb9887c,
+    0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
+    0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2,
+    0x4adfa541, 0x3dd895d7, 0xa4d1c46d, 0xd3d6f4fb,
+    0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
+    0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9,
+    0x5005713c, 0x270241aa, 0xbe0b1010, 0xc90c2086,
+    0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
+    0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4,
+    0x59b33d17, 0x2eb40d81, 0xb7bd5c3b, 0xc0ba6cad,
+    0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a,
+    0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683,
+    0xe3630b12, 0x94643b84, 0x0d6d6a3e, 0x7a6a5aa8,
+    0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
+    0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe,
+    0xf762575d, 0x806567cb, 0x196c3671, 0x6e6b06e7,
+    0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc,
+    0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5,
+    0xd6d6a3e8, 0xa1d1937e, 0x38d8c2c4, 0x4fdff252,
+    0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
+    0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60,
+    0xdf60efc3, 0xa867df55, 0x316e8eef, 0x4669be79,
+    0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
+    0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f,
+    0xc5ba3bbe, 0xb2bd0b28, 0x2bb45a92, 0x5cb36a04,
+    0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
+    0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a,
+    0x9c0906a9, 0xeb0e363f, 0x72076785, 0x05005713,
+    0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38,
+    0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21,
+    0x86d3d2d4, 0xf1d4e242, 0x68ddb3f8, 0x1fda836e,
+    0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
+    0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c,
+    0x8f659eff, 0xf862ae69, 0x616bffd3, 0x166ccf45,
+    0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2,
+    0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db,
+    0xaed16a4a, 0xd9d65adc, 0x40df0b66, 0x37d83bf0,
+    0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
+    0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6,
+    0xbad03605, 0xcdd70693, 0x54de5729, 0x23d967bf,
+    0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
+    0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
+};
+
+//----------------------------------------
+// Globals
+//----------------------------------------
+
+int binFile;
+uint8_t buffer[64 * 1024];
+size_t offset;
+ssize_t validData;
+
+//----------------------------------------
+// Compute the CRC32 for the specified data region
+//----------------------------------------
+uint32_t crc32Compute(uint32_t initialValue, const uint8_t * data, size_t length)
+{
+    uint32_t crc;
+    const uint8_t * end;
+
+    // Compute the CRC for the data buffer
+    crc = initialValue ^ 0xffffffff;
+    end = &data[length];
+    while (data < end)
+        crc = crc32Table[(crc ^ *data++) & 0xFF] ^ (crc >> 8);
+    crc ^= 0xffffffff;
+    return crc;
+}
+
+//----------------------------------------
+// Read data from the file and compute the CRC
+//----------------------------------------
+int readFileData(const char * fileName)
+{
+    ssize_t bytesRead;
+    uint32_t crc;
+    size_t crcBytes;
+    int exitStatus;
+
+    exitStatus = 0;
+    crc = 0;
+    crcBytes = 0;
+    do
+    {
+        // Read some data from the file
+        bytesRead = read(binFile, buffer, sizeof(buffer));
+        if (bytesRead < 0)
+        {
+            exitStatus = errno;
+            perror("ERROR: Failed to read from file!\n");
+            break;
+        }
+
+        // Compute the CRC on the bytes read
+        if (bytesRead)
+        {
+            // Compute the CRC
+            crc = crc32Compute(crc, buffer, bytesRead);
+            crcBytes += bytesRead;
+        }
+    } while (bytesRead);
+
+    // Finish the array
+    if (exitStatus == 0)
+    {
+        printf("%s\r\n", fileName);
+        printf("Bytes, CRC: %ld,0x%08x\r\n", crcBytes, crc);
+    }
+    return exitStatus;
+}
+
+//----------------------------------------
+// Application
+//----------------------------------------
+int main(int argc, char ** argv)
+{
+    char * fileName;
+    int status;
+
+    do
+    {
+        status = -1;
+
+        // Display the help text
+        if (argc != 2)
+        {
+            printf ("%s  filename\n", argv[0]);
+            return -1;
+        }
+
+        // Open the file
+        fileName = argv[1];
+        binFile = open(fileName, O_RDONLY);
+        if (binFile < 0)
+        {
+            status = errno;
+            perror("ERROR: Unable to open the file\n");
+        }
+
+        // Compute the CRC
+        status = readFileData(fileName);
+    } while (0);
+
+    // Close the file
+    if (binFile >= 0)
+        close(binFile);
+
+    return status;
+}

--- a/Firmware/Tools/makefile
+++ b/Firmware/Tools/makefile
@@ -17,6 +17,7 @@ EXECUTABLES += Read_Map_File
 EXECUTABLES += RTK_Reset
 EXECUTABLES += Split_Messages
 EXECUTABLES += X.509_crt_bundle_bin_to_c
+EXECUTABLES += File_CRC
 EXECUTABLES += File_to_Hex_Data_Array
 
 INCLUDES  = crc24q.h


### PR DESCRIPTION
This PR includes the following commits:
* Device_Update: Add DFU_ prefix to structure routine declarations
* Device_Update: Get and display firmware version as an integer
* Device_Update: Cleanup after using networkClient
* Device_Update: Initialize all of the read variables
* Device_Update: Force percentage display for zero
* Device_Update: Use deviceInfo to reduce ctx pointer references
* menuFirmware: Add 'D' for developer options
    Change 'd' to 'o', Update one device's firmware
    Change 'p' to 'l', Update all devices to latest released firmware
* Device_Update: Add _crcBytes to verify the CRC is properly calculated
* Tools: Add File_CRC to compute the CRC for a file
