### PR TITLE
Improved corrections reporting

### DIFF
--- a/Firmware/RTK_Everywhere/Developer.ino
+++ b/Firmware/RTK_Everywhere/Developer.ino
@@ -17,6 +17,7 @@ Developer.ino
 
 void lg290pHandler(uint8_t * buffer, int length) {}
 bool lg290pMessageEnabled(char *nmeaSentence, int sentenceLength)   {return false;}
+void lg290pProcessRTCMIS(uint8_t * buffer, int length) {}
 
 #endif // COMPILE_LG290P
 

--- a/Firmware/RTK_Everywhere/Display.ino
+++ b/Firmware/RTK_Everywhere/Display.ino
@@ -910,6 +910,15 @@ void setRadioIcons(std::vector<iconPropertyBlinking> *iconList)
                 usbSerialIncomingRtcm = false;
             }
 
+            if (gnssExternalIncomingRtcm)
+            {
+                // Download : Columns 74 - 81
+                prop.icon = DownloadArrow128x64;
+                prop.duty = 0b11111111;
+                iconList->push_back(prop);
+                gnssExternalIncomingRtcm = false;
+            }
+
             bool networkHasInternet = false;
 
 #ifdef COMPILE_ETHERNET

--- a/Firmware/RTK_Everywhere/GNSS.h
+++ b/Firmware/RTK_Everywhere/GNSS.h
@@ -273,8 +273,10 @@ class GNSS
     // Return true if GNSS receiver has a higher quality DGPS fix than 3D
     virtual bool isDgpsFixed();
 
-    // Returns true if corrections are arriving on the selected port
-    virtual bool isExternalCorrectionActive(uint8_t port);
+    // Returns 0 if corrections can not be arriving on the selected port
+    // Returns 1 if corrections are assumed to be arriving on the selected port
+    // Returns 2 if corrections truly are arriving on the selected port
+    virtual int isExternalCorrectionActive(uint8_t port);
 
     // Some functions merely need to know if we have an RTK Float.
     // This function checks to see if the given platform has reached sufficient

--- a/Firmware/RTK_Everywhere/GNSS.h
+++ b/Firmware/RTK_Everywhere/GNSS.h
@@ -52,8 +52,6 @@ class GNSS
     unsigned long _pvtArrivalMillis;
     bool _pvtUpdated;
 
-    bool _corrRadioExtPortEnabled = false;
-
     unsigned long _autoBaseStartTimer; // Tracks how long the base auto / averaging mode has been running
 
   public:
@@ -272,11 +270,11 @@ class GNSS
     // Date is confirmed once we have GNSS fix
     virtual bool isConfirmedTime();
 
-    // Returns true if data is arriving on the Radio Ext port
-    virtual bool isCorrRadioExtPortActive();
-
     // Return true if GNSS receiver has a higher quality DGPS fix than 3D
     virtual bool isDgpsFixed();
+
+    // Returns true if corrections are arriving on the selected port
+    virtual bool isExternalCorrectionActive(uint8_t port);
 
     // Some functions merely need to know if we have an RTK Float.
     // This function checks to see if the given platform has reached sufficient
@@ -363,9 +361,9 @@ class GNSS
     // Enable all the valid constellations and bands for this platform
     virtual bool setConstellations();
 
-    // Enable / disable corrections protocol(s) on the Radio External port
+    // Enable / disable external corrections protocol(s) on the chosen port
     // Always update if force is true. Otherwise, only update if enable has changed state
-    virtual bool setCorrRadioExtPort(bool enable, bool force);
+    virtual bool setExternalCorrections(uint8_t port, bool enable, bool force, const char *debug = nullptr);
 
     // Set the elevation in degrees
     // Inputs:

--- a/Firmware/RTK_Everywhere/GNSS.ino
+++ b/Firmware/RTK_Everywhere/GNSS.ino
@@ -492,6 +492,9 @@ void gnssUpdate()
             bool lora;
             bool enableExtCorrRadio = gnssExternalCorrectionsSelected(lora);
             // Set the protocols if either LoRa or External Radio _may_ need the port
+            // Note: this is probably redundant. correctionUpdateSource() will enable / disable
+            // the port protocols as needed, based on the priority of external radio (and LoRa)
+            // corrections
             if (gnss->setExternalCorrections(getGnssExternalCorrectionsPort(), enableExtCorrRadio,
                 true, "gnssUpdate GNSS_CONFIG_EXT_CORRECTIONS") == true) // Force the setting
             {

--- a/Firmware/RTK_Everywhere/GNSS.ino
+++ b/Firmware/RTK_Everywhere/GNSS.ino
@@ -27,7 +27,7 @@ calculation
   * setPppService() - Set the PPP/HAS E6 capabilities of the receiver
   * setMultipathMitigation() - Set the multipath capabilities of the receiver
   * setTilt() - Set the GNSS receiver's output to be compatible with a tilt sensor
-  * setCorrRadioExtPort() - Set corrections protocol(s) on the UART connected to the RADIO port
+  * setExternalCorrections() - Set corrections protocol(s) on the UART connected to the RADIO port
   * saveConfiguration() - Save the current receiver's settings to the receiver's NVM
   * reset() - Reset the receiver (through software or hardware)
   * factoryReset() - Reset the receiver to factory settings
@@ -347,7 +347,10 @@ void gnssUpdate()
 
         if (gnssConfigureRequested(GNSS_CONFIG_BAUD_RATE_RADIO))
         {
-            if (gnss->setBaudRateRadio(settings.radioPortBaud) == true)
+            uint32_t baud = getBaudRateForGnssRadio(); // Override with LoRa baud if needed
+            if (settings.debugGnssConfig == true)
+                systemPrintf("Setting GNSS radio port baud to %ld\r\n", baud);
+            if (gnss->setBaudRateRadio(baud) == true)
             {
                 gnssConfigureClear(GNSS_CONFIG_BAUD_RATE_RADIO);
                 gnssConfigure(GNSS_CONFIG_SAVE); // Request receiver commit this change to NVM
@@ -486,9 +489,11 @@ void gnssUpdate()
         {
             // If settings.enableExtCorrRadio is true, we need RTCM input
             // On Facet FP, we also need RTCM if LoRa is enabled
-            bool enableExtCorrRadio = settings.enableExtCorrRadio
-                 || ((productVariant == RTK_FACET_FP) && settings.enableLora);
-            if (gnss->setCorrRadioExtPort(enableExtCorrRadio, true) == true) // Force the setting
+            bool lora;
+            bool enableExtCorrRadio = gnssExternalCorrectionsSelected(lora);
+            // Set the protocols if either LoRa or External Radio _may_ need the port
+            if (gnss->setExternalCorrections(getGnssExternalCorrectionsPort(), enableExtCorrRadio,
+                true, "gnssUpdate GNSS_CONFIG_EXT_CORRECTIONS") == true) // Force the setting
             {
                 gnssConfigureClear(GNSS_CONFIG_EXT_CORRECTIONS);
                 gnssConfigure(GNSS_CONFIG_SAVE); // Request receiver commit this change to NVM

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.h
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.h
@@ -370,10 +370,12 @@ class GNSS_LG290P : GNSS
     // Return true if GNSS receiver has a higher quality DGPS fix than 3D
     bool isDgpsFixed();
 
-    // Should return true if corrections are enabled and arriving on the selected port
-    // On LG290P, we can check the PQTMRTCMIS MsgNum
-    // Return true if corrections are enabled and being received
-    bool isExternalCorrectionActive(uint8_t port);
+    // Returns 0 if corrections can not be arriving on the selected port
+    // Returns 1 if corrections are assumed to be arriving on the selected port
+    // Returns 2 if corrections truly are arriving on the selected port
+    // Firmware < v2.01 will return 0 or 1
+    // Firmware >= v2.01 will return 0 or 2
+    int isExternalCorrectionActive(uint8_t port);
 
     // Some functions merely need to know if we have an RTK Float.
     // This function checks to see if the given platform has reached sufficient

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.h
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.h
@@ -111,6 +111,8 @@ class GNSS_LG290P : GNSS
   private:
     LG290P *_lg290p; // Library class instance
 
+    int _externalCorrectionsEnabled[3] = { -1, -1, -1 }; // LG290P has UARTS 1-3
+
   protected:
     bool configureOnce();
 
@@ -360,11 +362,11 @@ class GNSS_LG290P : GNSS
     // Date is confirmed once we have GNSS fix
     bool isConfirmedTime();
 
-    // Returns true if data is arriving on the Radio Ext port
-    bool isCorrRadioExtPortActive();
-
     // Return true if GNSS receiver has a higher quality DGPS fix than 3D
     bool isDgpsFixed();
+
+    // Returns true if corrections are arriving on the selected port
+    bool isExternalCorrectionActive(uint8_t port);
 
     // Some functions merely need to know if we have an RTK Float.
     // This function checks to see if the given platform has reached sufficient
@@ -451,9 +453,9 @@ class GNSS_LG290P : GNSS
     // Enable all the valid constellations and bands for this platform
     bool setConstellations();
 
-    // Enable / disable corrections protocol(s) on the Radio External port
+    // Enable / disable external corrections protocol(s) on the chosen port
     // Always update if force is true. Otherwise, only update if enable has changed state
-    bool setCorrRadioExtPort(bool enable, bool force);
+    bool setExternalCorrections(uint8_t port, bool enable, bool force, const char *debug = nullptr);
 
     // Set the elevation in degrees
     // Inputs:

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.h
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.h
@@ -11,6 +11,11 @@ GNSS_LG290P.h
 
 #include <SparkFun_LG290P_GNSS.h> //http://librarymanager/All#SparkFun_LG290P
 
+// Keep count of the number of RTCM messages received on the correction port
+// so we can tell if the port is receiving corrections
+uint32_t lg290pRTCMCorrectionCountPrevious = 0;
+uint32_t lg290pRTCMCorrectionCountCurrent = 0;
+
 // Constellations monitored/used for fix
 // Available constellations: GPS, BDS, GLO, GAL, QZSS, NavIC
 const char *lg290pConstellationNames[] = {
@@ -365,9 +370,9 @@ class GNSS_LG290P : GNSS
     // Return true if GNSS receiver has a higher quality DGPS fix than 3D
     bool isDgpsFixed();
 
-    // Should return true if corrections are arriving on the selected port
-    // On LG290P, we don't know if corrections are arriving
-    // Return true if corrections are enabled
+    // Should return true if corrections are enabled and arriving on the selected port
+    // On LG290P, we can check the PQTMRTCMIS MsgNum
+    // Return true if corrections are enabled and being received
     bool isExternalCorrectionActive(uint8_t port);
 
     // Some functions merely need to know if we have an RTK Float.

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.h
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.h
@@ -365,7 +365,9 @@ class GNSS_LG290P : GNSS
     // Return true if GNSS receiver has a higher quality DGPS fix than 3D
     bool isDgpsFixed();
 
-    // Returns true if corrections are arriving on the selected port
+    // Should return true if corrections are arriving on the selected port
+    // On LG290P, we don't know if corrections are arriving
+    // Return true if corrections are enabled
     bool isExternalCorrectionActive(uint8_t port);
 
     // Some functions merely need to know if we have an RTK Float.

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -1216,18 +1216,29 @@ bool GNSS_LG290P::isDgpsFixed()
 }
 
 //----------------------------------------
-// Should return true if corrections are arriving on the selected port
-// On LG290P, we don't know if corrections are arriving
-// Return true if corrections are enabled
+// Should return true if corrections are enabled and arriving on the selected port
+// On LG290P, we can check the PQTMRTCMIS MsgNum
+// Return true if corrections are enabled and being received
 //----------------------------------------
 bool GNSS_LG290P::isExternalCorrectionActive(uint8_t port)
 {
     if ((port < 1) || (port > 3))
         return false;
 
-    // On LG290P, we don't have access to the UART RX byte counts
-    // We have to assume data is arriving if corrections are enabled...
-    return (_externalCorrectionsEnabled[port - 1] > 0);
+    if (_externalCorrectionsEnabled[port - 1] < 1)
+        return false;
+
+    // PQTMRTCMIS is supported from firmware v2.01
+    if (lg290pFirmwareVersionInt < 201)
+        return true;
+
+    if ((lg290pRTCMCorrectionCountCurrent - lg290pRTCMCorrectionCountPrevious) > 0)
+    {
+        lg290pRTCMCorrectionCountPrevious = lg290pRTCMCorrectionCountCurrent;
+        return true;
+    }
+
+    return false;
 }
 
 //----------------------------------------
@@ -2247,6 +2258,7 @@ bool GNSS_LG290P::setMessagesNMEA()
                 }
                 else if (productVariant == RTK_FACET_FP)
                 {
+                    // Disable NMEA on the LoRa / Ext Radio port if needed
                     if ((portNumber == 2) && ((settings.enableNmeaOnRadio == false) || (settings.enableLora == true)))
                         msgRate = 0;
                 }
@@ -2307,7 +2319,8 @@ bool GNSS_LG290P::setMessagesNMEA()
             {
                 // Enable GGA on a specific port
                 // On Torch X2 and Postcard, the LG290P UART 2 is connected to ESP32.
-                globalResponse &= _lg290p->setMessageRateOnPort("GGA", 1, 2);
+                // On Facet FP, the LG290P UART 1 is connected to ESP32
+                globalResponse &= _lg290p->setMessageRateOnPort("GGA", 1, lg290pGetESP32Port());
             }
             else
                 // Enable GGA on all UARTs. It's the best we can do.
@@ -2355,6 +2368,8 @@ bool GNSS_LG290P::setMessagesNMEA()
 bool GNSS_LG290P::setMessagesOther()
 {
     bool overallResponse = true;
+    bool pqtmrtcmisEnabled = false; // PQTMRTCMIS - Outputs the RTCM input status
+    int pqtmrtcmisMessageNumber;
 
     int portNumber = 1;
 
@@ -2394,6 +2409,17 @@ bool GNSS_LG290P::setMessagesOther()
                 else if (settings.debugGnssConfig)
                     systemPrintf("Set PQTM success at messageNumber %d %s.\r\n", messageNumber,
                                  lgMessagesPQTM[messageNumber].msgTextName);
+
+                // Mark messages needed for other services as enabled if rate > 0
+                if (settings.lg290pMessageRatesPQTM[messageNumber] > 0)
+                {
+                    if (strcmp(lgMessagesPQTM[messageNumber].msgTextName, "PQTMRTCMIS") == 0)
+                        pqtmrtcmisEnabled = true;
+                }
+
+                // Capture the RTCMIS version
+                if (strcmp(lgMessagesPQTM[messageNumber].msgTextName, "PQTMRTCMIS") == 0)
+                    pqtmrtcmisMessageNumber = messageNumber;
             }
         }
 
@@ -2402,6 +2428,31 @@ bool GNSS_LG290P::setMessagesOther()
         // setMessageRateOnPort only supported on v1.4 and above
         if (lg290pFirmwareVersionInt < 104)
             break; // Don't step through portNumbers
+    }
+
+    // Ensure PQTMRTCMIS is enabled - so we can check for RTCM on the corrections port
+    if (pqtmrtcmisEnabled == false)
+    {
+        // Check if this message is supported by the current LG290P firmware
+        if (lg290pFirmwareVersionInt >= lgMessagesPQTM[pqtmrtcmisMessageNumber].firmwareVersionSupported)
+        {
+            if (settings.debugGnssConfig)
+                systemPrintln("Enabling PQTMRTCMIS for RTCM monitoring");
+
+            // If firmware is v1.4 or higher, use setMessageRateOnPort, otherwise setMessageRate
+            if (lg290pFirmwareVersionInt >= 104)
+            {
+                // Enable PQTMRTCMIS on a specific port
+                // On Torch X2 and Postcard, the LG290P UART 2 is connected to ESP32
+                // On Facet FP, LG290P UART 1 is connectedd to ESP32
+                overallResponse &= _lg290p->setMessageRateOnPort("PQTMRTCMIS", 1, lg290pGetESP32Port(),
+                                            lgMessagesPQTM[pqtmrtcmisMessageNumber].msgVersionOffset);
+            }
+            else
+                // Enable PQTMRTCMIS on all UARTs. It's the best we can do.
+                overallResponse &= _lg290p->setMessageRate("PQTMRTCMIS", 1,
+                                            lgMessagesPQTM[pqtmrtcmisMessageNumber].msgVersionOffset);
+        }
     }
 
     // Messages take effect immediately. Save/Reset is not needed.
@@ -2834,6 +2885,73 @@ void lg290pHandler(uint8_t *incomingBuffer, int bufferLength)
 }
 
 //----------------------------------------
+// If we have received PQTMRTCMIS from the LG290P, process and update the correction port RTCM count
+//----------------------------------------
+void lg290pProcessRTCMIS(uint8_t * buffer, int length)
+{
+    const int portIDComma = 4;
+    const int msgNumComma = 10;
+
+    uint8_t portIDStart = 0;
+    uint8_t portIDStop = 0;
+    uint8_t msgNumStart = 0;
+    uint8_t msgNumStop = 0;
+
+    int commaCount = 0;
+    for (int x = 0; x < length; x++) // Assumes sentence is null terminated
+    {
+        if (buffer[x] == ',')
+        {
+            commaCount++;
+            if (commaCount == portIDComma)
+                portIDStart = x + 1;
+            if (commaCount == portIDComma + 1)
+                portIDStop = x;
+            if (commaCount == msgNumComma)
+                msgNumStart = x + 1;
+            if (commaCount == msgNumComma + 1)
+            {
+                msgNumStop = x;
+                break;
+            }
+        }
+        if (buffer[x] == '*')
+        {
+            break;
+        }
+    }
+
+    if (portIDStart == 0 || portIDStop == 0 || msgNumStart == 0 || msgNumStop == 0)
+    {
+        return;
+    }
+
+    // Extract the PortID
+    char PortID[1 + portIDStop - portIDStart];
+    strncpy(PortID, (const char *)&buffer[portIDStart], portIDStop - portIDStart);
+    int portID = atoi(PortID);
+
+    // Extract the MsgNum
+    char MsgNum[1 + msgNumStop - msgNumStart];
+    strncpy(MsgNum, (const char *)&buffer[msgNumStart], msgNumStop - msgNumStart);
+    int msgNum = atoi(MsgNum);
+
+    // If the port matches, update the current count
+    if (portID == getGnssExternalCorrectionsPort())
+    {
+        lg290pRTCMCorrectionCountCurrent = msgNum;
+
+        // It's a lot of messages....
+        static unsigned long lastPrint = millis();
+        if ((millis() - lastPrint > 2000) && (settings.debugCorrections == true) && !inMainMenu)
+        {
+            systemPrintf("lg290pProcessRTCMIS: extracted msgNum %ld\r\n", msgNum);
+            lastPrint = millis();
+        }
+    }
+}
+
+//----------------------------------------
 // Pass a buffer of bytes to LG290P library. Allows a stream outside of library to feed the library.
 //----------------------------------------
 void GNSS_LG290P::lg290pUpdate(uint8_t *incomingBuffer, int bufferLength)
@@ -2920,7 +3038,7 @@ bool GNSS_LG290P::setRtcmRoverMessageRateByName(const char *msgName, uint8_t msg
 
 // Given a sentence, determine if it is enabled in settings
 // This is used to signal to the processUart1Message() task to remove messages that are needed
-// by the library to function (ie, PQTMEPE, PQTMPVT, GNGSV) but have not been enabled by the user,
+// by the library to function (ie, PQTMEPE, PQTMPVT, PQTMRTCMIS, GNGSV) but have not been enabled by the user,
 // so should not be logged or passed to other consumers (Bluetooth, TCP, etc).
 // If the message is unknown, allow messages through - this assumes the user has configured the message outside
 // of the standard firmware settings.
@@ -3471,6 +3589,39 @@ bool lg290pSettingsToFile(char * line,
     break;
     }
     return true;
+}
+
+// Return the GNSS port (UART) connected to ESP32 on this platform
+uint8_t lg290pGetESP32Port()
+{
+    uint8_t uart = 0;
+
+    if (present.gnss_lg290p)
+    {
+        if (productVariant == RTK_POSTCARD)
+        {
+            // UART2 of the LG290P is connected to the ESP32
+            uart = 2;
+        }
+        else if (productVariant == RTK_FACET_FP)
+        {
+            // UART1 of the GNSS is connected to ESP32
+            uart = 1;
+        }
+        else if (productVariant == RTK_TORCH_X2)
+        {
+            // UART2 of the LG290P is connected directly to ESP32
+            uart = 2;
+        }
+        else
+        // This should never appear...
+            systemPrintln("lg290pGetESP32Port: Uncaught LG290P platform");
+    }
+    else
+        // This should never appear...
+        systemPrintln("lg290pGetESP32Port: Uncaught GNSS");
+
+    return uart;
 }
 
 #endif // COMPILE_LG290P

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -2416,11 +2416,11 @@ bool GNSS_LG290P::setMessagesOther()
                     if (strcmp(lgMessagesPQTM[messageNumber].msgTextName, "PQTMRTCMIS") == 0)
                         pqtmrtcmisEnabled = true;
                 }
-
-                // Capture the RTCMIS version
-                if (strcmp(lgMessagesPQTM[messageNumber].msgTextName, "PQTMRTCMIS") == 0)
-                    pqtmrtcmisMessageNumber = messageNumber;
             }
+
+            // Capture the RTCMIS version
+            if (strcmp(lgMessagesPQTM[messageNumber].msgTextName, "PQTMRTCMIS") == 0)
+                pqtmrtcmisMessageNumber = messageNumber;
         }
 
         portNumber++;

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -1216,29 +1216,32 @@ bool GNSS_LG290P::isDgpsFixed()
 }
 
 //----------------------------------------
-// Should return true if corrections are enabled and arriving on the selected port
-// On LG290P, we can check the PQTMRTCMIS MsgNum
-// Return true if corrections are enabled and being received
+// Returns 0 if corrections can not be arriving on the selected port
+// Returns 1 if corrections are assumed to be arriving on the selected port
+// Returns 2 if corrections truly are arriving on the selected port
+// On LG290P, we can check the PQTMRTCMIS MsgNum with firmware >= v2.01
+// Firmware < v2.01 will return 0 or 1
+// Firmware >= v2.01 will return 0 or 2
 //----------------------------------------
-bool GNSS_LG290P::isExternalCorrectionActive(uint8_t port)
+int GNSS_LG290P::isExternalCorrectionActive(uint8_t port)
 {
     if ((port < 1) || (port > 3))
-        return false;
+        return 0;
 
     if (_externalCorrectionsEnabled[port - 1] < 1)
-        return false;
+        return 0;
 
     // PQTMRTCMIS is supported from firmware v2.01
     if (lg290pFirmwareVersionInt < 201)
-        return true;
+        return 1;
 
     if ((lg290pRTCMCorrectionCountCurrent - lg290pRTCMCorrectionCountPrevious) > 0)
     {
         lg290pRTCMCorrectionCountPrevious = lg290pRTCMCorrectionCountCurrent;
-        return true;
+        return 2;
     }
 
-    return false;
+    return 0;
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -3042,6 +3042,7 @@ bool GNSS_LG290P::setRtcmRoverMessageRateByName(const char *msgName, uint8_t msg
 // Given a sentence, determine if it is enabled in settings
 // This is used to signal to the processUart1Message() task to remove messages that are needed
 // by the library to function (ie, PQTMEPE, PQTMPVT, PQTMRTCMIS, GNGSV) but have not been enabled by the user,
+// by the library to function (ie, PQTMEPE, PQTMPVT, PQTMSVINSTATUS, GNGSV) but have not been enabled by the user,
 // so should not be logged or passed to other consumers (Bluetooth, TCP, etc).
 // If the message is unknown, allow messages through - this assumes the user has configured the message outside
 // of the standard firmware settings.
@@ -3085,6 +3086,15 @@ bool lg290pMessageEnabled(char *nmeaSentence, int sentenceLength)
                     systemPrintf("Blocking PQTM sentenceHeader from entering circular buffer: %s\r\n", sentenceHeader);
                 return (false);
             }
+        }
+
+        // Process PQTMSVINSTATUS as a special case. Block messages generated during Base survey-in
+        // We can't easily add PQTMSVINSTATUS to lgMessagesPQTM[] since it is only available in Base Mode
+        if (strncmp("PQTMSVINSTATUS", sentenceHeader, sizeof(sentenceHeader)) == 0)
+        {
+            if (!inMainMenu && settings.debugGnssConfig)
+                systemPrintf("Blocking PQTM sentenceHeader from entering circular buffer: %s\r\n", sentenceHeader);
+            return (false);
         }
     }
     // else if (strnstr(sentenceHeader, "RTCM", sizeof(sentenceHeader)) != nullptr) // TODO

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -177,12 +177,6 @@ void GNSS_LG290P::begin()
     snprintf(gnssUniqueId, sizeof(gnssUniqueId), "%s", getId());
 
     gnssFirmwareVersionInt = lg290pFirmwareVersionInt; // Tell Web Config what version to use
-
-    // On Facet FP: set UART2 (Radio) protocol(s)
-    // Both Ext Radio and LoRa need RTCM on UART2
-    // Note: this is probably redundant? I only added it because I added it on mosaic...
-    if (productVariant == RTK_FACET_FP)
-        setCorrRadioExtPort((settings.enableExtCorrRadio || settings.enableLora), true); // Force the setting
 }
 
 //----------------------------------------
@@ -1201,16 +1195,6 @@ bool GNSS_LG290P::isConfirmedTime()
     return isValidTime();
 }
 
-// Returns true if data is arriving on the Radio Ext port
-bool GNSS_LG290P::isCorrRadioExtPortActive()
-{
-    // On LG290P, we don't have access to the UART RX byte counts
-    // We have to assume data is arriving if ext radio is enabled...
-    // And on Facet FP, we also have to fake the arrival of LoRa traffic
-    // to maintain the Radio Ext protocols...
-    return (settings.enableExtCorrRadio || ((productVariant == RTK_FACET_FP) && settings.enableLora));
-}
-
 //----------------------------------------
 // Return true if GNSS receiver has a higher quality DGPS fix than 3D
 //----------------------------------------
@@ -1229,6 +1213,19 @@ bool GNSS_LG290P::isDgpsFixed()
             return (true);
     }
     return false;
+}
+
+//----------------------------------------
+// Returns true if data is arriving on the Radio Ext port
+//----------------------------------------
+bool GNSS_LG290P::isExternalCorrectionActive(uint8_t port)
+{
+    if ((port < 1) || (port > 3))
+        return false;
+
+    // On LG290P, we don't have access to the UART RX byte counts
+    // We have to assume data is arriving if corrections are enabled...
+    return (_externalCorrectionsEnabled[port - 1] > 0);
 }
 
 //----------------------------------------
@@ -2034,54 +2031,51 @@ bool GNSS_LG290P::setConstellations()
     return (response);
 }
 
-// Enable / disable corrections protocol(s) on the Radio External port
+// Enable / disable external corrections protocol(s) on the chosen port
 // Always update if force is true. Otherwise, only update if enable has changed state
-bool GNSS_LG290P::setCorrRadioExtPort(bool enable, bool force)
+bool GNSS_LG290P::setExternalCorrections(uint8_t port, bool enable, bool force, const char *debug)
 {
+    // LG290P has UARTs 1-3
+    if ((port < 1) || (port > 3))
+    {
+        systemPrintf("setExternalCorrections: invalid port %d\r\n", port);
+        return false;
+    }
+
     if (online.gnss)
     {
         // Someday, read/modify/write setPortInputProtocols
 
-        if (force || (enable != _corrRadioExtPortEnabled))
+        if (force || (enable != _externalCorrectionsEnabled[port - 1]))
         {
-            uint8_t radioUart = 0;
-            if (productVariant == RTK_POSTCARD)
-            {
-                // UART3 of the LG290P is connected to the locking JST connector labled RADIO
-                radioUart = 3;
-            }
-            else if (productVariant == RTK_FACET_FP)
-            {
-                // UART2 of the LG290P is connected to SW4, which is connected to LoRa UART0
-                radioUart = 2;
-            }
-            else if (productVariant == RTK_TORCH_X2)
-            {
-                // UART1 of the LG290P is connected to SW, which is connected to ESP32 UART0
-                // Not really used at this time but available for configuration
-                radioUart = 1;
-            }
-            else
-                systemPrintln("setCorrRadioExtPort: Uncaught platform");
-
             // Set port InputProt: RTCM3 (4) vs NMEA (1)
-            if (_lg290p->setPortInputProtocols(radioUart, enable ? 4 : 1))
+            if (_lg290p->setPortInputProtocols(port, enable ? 4 : 1))
             {
                 if ((settings.debugCorrections == true) && !inMainMenu)
                 {
-                    systemPrintf("Radio Ext corrections: %s -> %s%s\r\n",
-                                 _corrRadioExtPortEnabled ? "enabled" : "disabled", enable ? "enabled" : "disabled",
-                                 force ? " (Forced)" : "");
+                    systemPrintf("setExternalCorrections: %s -> %s%s%s%s%s\r\n",
+                                 _externalCorrectionsEnabled[port - 1] == -1 ? "not set" :
+                                 _externalCorrectionsEnabled[port - 1] ? "enabled" : "disabled",
+                                 enable ? "enabled" : "disabled",
+                                 force ? " (Forced)" : "",
+                                 debug ? " (" : "",
+                                 debug ? debug : "",
+                                 debug ? ")" : "");
                 }
 
-                _corrRadioExtPortEnabled = enable;
+                _externalCorrectionsEnabled[port - 1] = enable;
                 return true;
             }
             else
             {
-                systemPrintf("Radio Ext corrections FAILED: %s -> %s%s\r\n",
-                             _corrRadioExtPortEnabled ? "enabled" : "disabled", enable ? "enabled" : "disabled",
-                             force ? " (Forced)" : "");
+                systemPrintf("setExternalCorrections FAILED: %s -> %s%s%s%s%s\r\n",
+                                 _externalCorrectionsEnabled[port - 1] == -1 ? "not set" :
+                                 _externalCorrectionsEnabled[port - 1] ? "enabled" : "disabled",
+                                 enable ? "enabled" : "disabled",
+                                 force ? " (Forced)" : "",
+                                 debug ? " (" : "",
+                                 debug ? debug : "",
+                                 debug ? ")" : "");
             }
         }
     }
@@ -2858,8 +2852,11 @@ void GNSS_LG290P::update()
 
 //----------------------------------------
 // Check if given baud rate is allowed
+// According to the protocol specification, only 9600, 115200, 230400, 460800 and 921600
+// are supported. But we know the LG290P also supports 57600 - which is convenient for
+// SiK radios. What to do? Include it, or not? Let's include it - to improve the user experience.
 //----------------------------------------
-const uint32_t lg290pAllowedRates[] = {9600, 115200, 230400, 460800, 921600};
+const uint32_t lg290pAllowedRates[] = {9600, 57600, 115200, 230400, 460800, 921600};
 const int lg290pAllowedRatesCount = sizeof(lg290pAllowedRates) / sizeof(lg290pAllowedRates[0]);
 
 bool GNSS_LG290P::baudIsAllowed(uint32_t baudRate)

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -1216,7 +1216,9 @@ bool GNSS_LG290P::isDgpsFixed()
 }
 
 //----------------------------------------
-// Returns true if data is arriving on the Radio Ext port
+// Should return true if corrections are arriving on the selected port
+// On LG290P, we don't know if corrections are arriving
+// Return true if corrections are enabled
 //----------------------------------------
 bool GNSS_LG290P::isExternalCorrectionActive(uint8_t port)
 {

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -281,8 +281,9 @@ bool GNSS_LG290P::configureBase()
 
         reset();
 
-        // When a device is changed from Rover to Base, NMEA messages are disabled. Turn them back on.
+        // When a device is changed from Rover to Base, NMEA and PQTM messages are disabled. Turn them back on.
         gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_NMEA);
+        gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_OTHER);
 
         // In Survey-In mode, configuring the RTCM Base will trigger a print warning because the survey-in
         // takes a few seconds to start during which gnssInBaseSurveyInMode() incorrectly reports false.
@@ -1622,6 +1623,7 @@ void GNSS_LG290P::menuMessages()
                 settings.lg290pMessageRatesPQTM[x] = lgMessagesPQTM[x].msgDefaultRate;
 
             gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_NMEA);
+            gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_OTHER);
             if (inBaseMode()) // If the system is in Base mode
                 gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_RTCM_BASE);
             else
@@ -1665,6 +1667,8 @@ void GNSS_LG290P::menuMessages()
 
             gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_NMEA);       // Request receiver to use new settings
             gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_RTCM_ROVER); // Request receiver to use new settings
+
+            // I think it is OK to skip gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_OTHER); here?
 
             if (incoming == 12)
                 systemPrintln("Reset to High-rate PPP Logging Defaults (NMEAx7 / RTCMx4 - 1Hz)");

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -3041,8 +3041,7 @@ bool GNSS_LG290P::setRtcmRoverMessageRateByName(const char *msgName, uint8_t msg
 
 // Given a sentence, determine if it is enabled in settings
 // This is used to signal to the processUart1Message() task to remove messages that are needed
-// by the library to function (ie, PQTMEPE, PQTMPVT, PQTMRTCMIS, GNGSV) but have not been enabled by the user,
-// by the library to function (ie, PQTMEPE, PQTMPVT, PQTMSVINSTATUS, GNGSV) but have not been enabled by the user,
+// by the library to function (ie, PQTMEPE, PQTMPVT, PQTMSVINSTATUS, PQTMRTCMIS, GNGSV) but have not been enabled by the user,
 // so should not be logged or passed to other consumers (Bluetooth, TCP, etc).
 // If the message is unknown, allow messages through - this assumes the user has configured the message outside
 // of the standard firmware settings.

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.h
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.h
@@ -906,8 +906,9 @@ public:
     // Return true if GNSS receiver has a higher quality DGPS fix than 3D
     bool isDgpsFixed();
 
-    // Returns true if corrections are enabled and arriving on the selected port
-    bool isExternalCorrectionActive(uint8_t port);
+    // Returns 0 if corrections can not be arriving on the selected port
+    // Returns 2 if corrections truly are arriving on the selected port
+    int isExternalCorrectionActive(uint8_t port);
 
     // Some functions merely need to know if we have an RTK Float.
     // This function checks to see if the given platform has reached sufficient

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.h
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.h
@@ -906,7 +906,7 @@ public:
     // Return true if GNSS receiver has a higher quality DGPS fix than 3D
     bool isDgpsFixed();
 
-    // Returns true if corrections are arriving on the selected port
+    // Returns true if corrections are enabled and arriving on the selected port
     bool isExternalCorrectionActive(uint8_t port);
 
     // Some functions merely need to know if we have an RTK Float.

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.h
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.h
@@ -609,11 +609,11 @@ protected:
     // On the mosaic, we know that InputLink will arrive at 1Hz. But on the ZED, UBX-MON-COMMS
     // is tied to the navigation rate. To keep it simple, record the last time NrBytesReceived
     // was seen to increase and use that for corrections timeout. This is updated by the SBF
-    // InputLink message. isCorrRadioExtPortActive returns true if the bytes-received has
+    // InputLink message. isExternalCorrectionActive returns true if the bytes-received has
     // increased in the previous settings.correctionsSourcesLifetime_s
     uint32_t _radioExtBytesReceived_millis;
 
-    // See notes at GNSS_MOSAIC::setCorrRadioExtPort
+    // See notes at GNSS_MOSAIC::setExternalCorrections
     uint32_t previousNrBytesReceived = 0;
     bool firstTimeNrBytesReceived = true;
 
@@ -625,6 +625,8 @@ protected:
 
     // Set the minimum satellite signal level for navigation.
     bool setMinCN0(uint8_t cnoValue);
+
+    int _externalCorrectionsEnabled = -1; // mosaic has COM1-4 but only COM2 is used for corrections
 
 public:
     // Allow access from parser routines
@@ -901,11 +903,11 @@ public:
     // Date is confirmed once we have GNSS fix
     bool isConfirmedTime();
 
-    // Returns true if data is arriving on the Radio Ext port
-    bool isCorrRadioExtPortActive();
-
     // Return true if GNSS receiver has a higher quality DGPS fix than 3D
     bool isDgpsFixed();
+
+    // Returns true if corrections are arriving on the selected port
+    bool isExternalCorrectionActive(uint8_t port);
 
     // Some functions merely need to know if we have an RTK Float.
     // This function checks to see if the given platform has reached sufficient
@@ -1082,9 +1084,9 @@ public:
     // Enable all the valid constellations and bands for this platform
     bool setConstellations();
 
-    // Enable / disable corrections protocol(s) on the Radio External port
+    // Enable / disable external corrections protocol(s) on the chosen port
     // Always update if force is true. Otherwise, only update if enable has changed state
-    bool setCorrRadioExtPort(bool enable, bool force);
+    bool setExternalCorrections(uint8_t port, bool enable, bool force, const char *debug = nullptr);
 
     // Set the elevation in degrees
     // Inputs:

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
@@ -1392,24 +1392,25 @@ bool GNSS_MOSAIC::isDgpsFixed()
 }
 
 //----------------------------------------
-// Returns true if corrections are enabled and data is arriving on the selected port
+// Returns 0 if corrections can not be arriving on the selected port
+// Returns 2 if corrections truly are arriving on the selected port
 //----------------------------------------
-bool GNSS_MOSAIC::isExternalCorrectionActive(uint8_t port)
+int GNSS_MOSAIC::isExternalCorrectionActive(uint8_t port)
 {
     // FPM and Facet mosaic only support corrections on COM2
     // Ignore port
     if (_externalCorrectionsEnabled < 1)
-        return false;
+        return 0;
 
     if (_radioExtBytesReceived_millis > 0) // Avoid a false positive
     {
         // Return true if _radioExtBytesReceived_millis increased
         // in the last settings.correctionsSourcesLifetime_s
         if ((millis() - _radioExtBytesReceived_millis) < (settings.correctionsSourcesLifetime_s * 1000))
-            return true;
+            return 2;
     }
 
-    return false;
+    return 0;
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
@@ -311,10 +311,7 @@ void GNSS_MOSAIC::begin()
         if (isPresent() == false) // Detect if the module is present
             return;
 
-        // Set COM2 (Radio) protocol(s)
-        // Both Ext Radio and LoRa need RTCM on UART2
-        // Note: this is probably redundant? I'm now not sure why I added it...
-        setCorrRadioExtPort((settings.enableExtCorrRadio || settings.enableLora), true); // Force the setting
+        // Set COM2 (Radio) protocol(s) is handled by correctionUpdateSource()
 
         updateSD(); // Check card size and free space
 
@@ -633,7 +630,7 @@ bool GNSS_MOSAIC::configureOnce()
     // Configure COM1. NMEA and RTCMv3 will be encapsulated in SBF format
     response &= configureGNSSCOM(pointPerfectLbandNeeded());
 
-    // COM2 is configured by setCorrRadioExtPort
+    // COM2 is configured by setExternalCorrections
 
     // Configure USB1 for NMEA and RTCMv3. No L-Band. Not encapsulated.
     response &= sendWithResponse("sdio,USB1,auto,RTCMv3+NMEA\n\r", "DataInOut");
@@ -1382,10 +1379,24 @@ bool GNSS_MOSAIC::isConfirmedTime()
     return _validTime;
 }
 
-// Returns true if data is arriving on the Radio Ext port
-bool GNSS_MOSAIC::isCorrRadioExtPortActive()
+//----------------------------------------
+// Return true if GNSS receiver has a higher quality DGPS fix than 3D
+//----------------------------------------
+bool GNSS_MOSAIC::isDgpsFixed()
 {
-    if (!settings.enableExtCorrRadio)
+    // 2: Differential PVT
+    // 6: SBAS aided PVT
+    if ((_fixType == 2) || (_fixType == 6))
+        return (true);
+    return (false);
+}
+
+//----------------------------------------
+// Returns true if data is arriving on the selected port
+//----------------------------------------
+bool GNSS_MOSAIC::isExternalCorrectionActive(uint8_t port)
+{
+    if (_externalCorrectionsEnabled < 1)
         return false;
 
     if (_radioExtBytesReceived_millis > 0) // Avoid a false positive
@@ -1397,18 +1408,6 @@ bool GNSS_MOSAIC::isCorrRadioExtPortActive()
     }
 
     return false;
-}
-
-//----------------------------------------
-// Return true if GNSS receiver has a higher quality DGPS fix than 3D
-//----------------------------------------
-bool GNSS_MOSAIC::isDgpsFixed()
-{
-    // 2: Differential PVT
-    // 6: SBAS aided PVT
-    if ((_fixType == 2) || (_fixType == 6))
-        return (true);
-    return (false);
 }
 
 //----------------------------------------
@@ -2180,42 +2179,65 @@ bool GNSS_MOSAIC::setConstellations()
     return (sendWithResponse(setting, "SatelliteTracking", 1000, 200));
 }
 
-// Enable / disable corrections protocol(s) on the Radio External port
+// Enable / disable external corrections protocol(s) on the chosen port
 // Always update if force is true. Otherwise, only update if enable has changed state
 // Notes:
 //   NrBytesReceived is reset when sdio,COM2 is sent. This causes  NrBytesReceived to
 //   be less than previousNrBytesReceived, which in turn causes a corrections timeout.
 //   So, we need to reset previousNrBytesReceived and firstTimeNrBytesReceived here.
-bool GNSS_MOSAIC::setCorrRadioExtPort(bool enable, bool force)
+bool GNSS_MOSAIC::setExternalCorrections(uint8_t port, bool enable, bool force, const char *debug)
 {
-    if (force || (enable != _corrRadioExtPortEnabled))
+    // mosaic has UARTs 1-4, but we will only ever use 2 for corrections
+    if ((port < 2) || (port > 2))
     {
-        String setting = String("sdio,COM2,");
-        if (enable)
-            setting += String("RTCMv3,");
-        else
-            setting += String("none,");
-        // Configure COM2 for NMEA and RTCMv3 output. No L-Band. Not encapsulated.
-        setting += String("RTCMv3+NMEA\n\r");
+        systemPrintf("setExternalCorrections: invalid port %d\r\n", port);
+        return false;
+    }
 
-        if (sendWithResponse(setting, "DataInOut"))
+    if (online.gnss)
+    {
+        // Someday, read/modify/write setPortInputProtocols
+
+        if (force || (enable != _externalCorrectionsEnabled))
         {
-            if ((settings.debugCorrections == true) && !inMainMenu)
+            String setting = String("sdio,COM2,");
+            if (enable)
+                setting += String("RTCMv3,");
+            else
+                setting += String("none,");
+            // Configure COM2 for NMEA and RTCMv3 output. No L-Band. Not encapsulated.
+            setting += String("RTCMv3+NMEA\n\r");
+
+            if (sendWithResponse(setting, "DataInOut"))
             {
-                systemPrintf("Radio Ext corrections: %s -> %s%s\r\n", _corrRadioExtPortEnabled ? "enabled" : "disabled",
-                             enable ? "enabled" : "disabled", force ? " (Forced)" : "");
-            }
+                if ((settings.debugCorrections == true) && !inMainMenu)
+                {
+                    systemPrintf("setExternalCorrections: %s -> %s%s%s%s%s\r\n",
+                                 _externalCorrectionsEnabled == -1 ? "not set" :
+                                 _externalCorrectionsEnabled ? "enabled" : "disabled",
+                                 enable ? "enabled" : "disabled",
+                                 force ? " (Forced)" : "",
+                                 debug ? " (" : "",
+                                 debug ? debug : "",
+                                 debug ? ")" : "");
+                }
 
-            _corrRadioExtPortEnabled = enable;
-            previousNrBytesReceived = 0;
-            firstTimeNrBytesReceived = true;
-            return true;
-        }
-        else
-        {
-            systemPrintf("Radio Ext corrections FAILED: %s -> %s%s\r\n",
-                         _corrRadioExtPortEnabled ? "enabled" : "disabled", enable ? "enabled" : "disabled",
-                         force ? " (Forced)" : "");
+                _externalCorrectionsEnabled = enable;
+                previousNrBytesReceived = 0;
+                firstTimeNrBytesReceived = true;
+                return true;
+            }
+            else
+            {
+                systemPrintf("setExternalCorrections FAILED: %s -> %s%s%s%s%s\r\n",
+                                 _externalCorrectionsEnabled == -1 ? "not set" :
+                                 _externalCorrectionsEnabled ? "enabled" : "disabled",
+                                 enable ? "enabled" : "disabled",
+                                 force ? " (Forced)" : "",
+                                 debug ? " (" : "",
+                                 debug ? debug : "",
+                                 debug ? ")" : "");
+            }
         }
     }
 

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
@@ -1396,6 +1396,8 @@ bool GNSS_MOSAIC::isDgpsFixed()
 //----------------------------------------
 bool GNSS_MOSAIC::isExternalCorrectionActive(uint8_t port)
 {
+    // FPM and Facet mosaic only support corrections on COM2
+    // Ignore port
     if (_externalCorrectionsEnabled < 1)
         return false;
 

--- a/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
+++ b/Firmware/RTK_Everywhere/GNSS_Mosaic.ino
@@ -1392,7 +1392,7 @@ bool GNSS_MOSAIC::isDgpsFixed()
 }
 
 //----------------------------------------
-// Returns true if data is arriving on the selected port
+// Returns true if corrections are enabled and data is arriving on the selected port
 //----------------------------------------
 bool GNSS_MOSAIC::isExternalCorrectionActive(uint8_t port)
 {

--- a/Firmware/RTK_Everywhere/GNSS_None.h
+++ b/Firmware/RTK_Everywhere/GNSS_None.h
@@ -397,10 +397,10 @@ public:
         return false;
     }
 
-    // Returns true if corrections are arriving on the selected port
-    bool isExternalCorrectionActive(uint8_t port)
+    // Returns 0 since corrections can not be arriving on the selected port
+    int isExternalCorrectionActive(uint8_t port)
     {
-        return false;
+        return 0;
     }
 
     // Some functions merely need to know if we have an RTK Float.

--- a/Firmware/RTK_Everywhere/GNSS_None.h
+++ b/Firmware/RTK_Everywhere/GNSS_None.h
@@ -391,14 +391,14 @@ public:
         return false;
     }
 
-    // Returns true if data is arriving on the Radio Ext port
-    bool isCorrRadioExtPortActive()
+    // Return true if GNSS receiver has a higher quality DGPS fix than 3D
+    bool isDgpsFixed()
     {
         return false;
     }
 
-    // Return true if GNSS receiver has a higher quality DGPS fix than 3D
-    bool isDgpsFixed()
+    // Returns true if corrections are arriving on the selected port
+    bool isExternalCorrectionActive(uint8_t port)
     {
         return false;
     }
@@ -554,8 +554,8 @@ public:
         return true;
     }
 
-    // Enable / disable corrections protocol(s) on the Radio External port
-    bool setCorrRadioExtPort(bool enable, bool force)
+    // Enable / disable external corrections protocol(s) on the chosen port
+    bool setExternalCorrections(uint8_t port, bool enable, bool force, const char *debug = nullptr)
     {
         return true;
     }

--- a/Firmware/RTK_Everywhere/GNSS_UM980.h
+++ b/Firmware/RTK_Everywhere/GNSS_UM980.h
@@ -333,10 +333,10 @@ class GNSS_UM980 : GNSS
     // Return true if GNSS receiver has a higher quality DGPS fix than 3D
     bool isDgpsFixed();
 
-    // Returns true if corrections are arriving on the selected port
-    bool isExternalCorrectionActive(uint8_t port)
+    // Returns 0 since corrections can not be arriving on the selected port
+    int isExternalCorrectionActive(uint8_t port)
     {
-        return false; // Torch has no Radio port...
+        return 0; // Torch has no Radio port...
     }
 
     // Some functions merely need to know if we have an RTK Float.

--- a/Firmware/RTK_Everywhere/GNSS_UM980.h
+++ b/Firmware/RTK_Everywhere/GNSS_UM980.h
@@ -330,14 +330,14 @@ class GNSS_UM980 : GNSS
     // Date is confirmed once we have GNSS fix
     bool isConfirmedTime();
 
-    // Returns true if data is arriving on the Radio Ext port
-    bool isCorrRadioExtPortActive()
+    // Return true if GNSS receiver has a higher quality DGPS fix than 3D
+    bool isDgpsFixed();
+
+    // Returns true if corrections are arriving on the selected port
+    bool isExternalCorrectionActive(uint8_t port)
     {
         return false; // Torch has no Radio port...
     }
-
-    // Return true if GNSS receiver has a higher quality DGPS fix than 3D
-    bool isDgpsFixed();
 
     // Some functions merely need to know if we have an RTK Float.
     // This function checks to see if the given platform has reached sufficient
@@ -424,8 +424,8 @@ class GNSS_UM980 : GNSS
     // Enable all the valid constellations and bands for this platform
     bool setConstellations();
 
-    // Enable / disable corrections protocol(s) on the Radio External port
-    bool setCorrRadioExtPort(bool enable, bool force)
+    // Enable / disable external corrections protocol(s) on the chosen port
+    bool setExternalCorrections(uint8_t port, bool enable, bool force, const char *debug = nullptr)
     {
         return true;
     }

--- a/Firmware/RTK_Everywhere/GNSS_ZED.h
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.h
@@ -546,8 +546,9 @@ class GNSS_ZED : GNSS
     // Return true if GNSS receiver has a higher quality DGPS fix than 3D
     bool isDgpsFixed();
 
-    // Returns true if corrections are enabled and arriving on the selected port
-    bool isExternalCorrectionActive(uint8_t port);
+    // Returns 0 if corrections can not be arriving on the selected port
+    // Returns 2 if corrections truly are arriving on the selected port
+    int isExternalCorrectionActive(uint8_t port);
 
     // Some functions merely need to know if we have an RTK Float.
     // This function checks to see if the given platform has reached sufficient

--- a/Firmware/RTK_Everywhere/GNSS_ZED.h
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.h
@@ -546,7 +546,7 @@ class GNSS_ZED : GNSS
     // Return true if GNSS receiver has a higher quality DGPS fix than 3D
     bool isDgpsFixed();
 
-    // Returns true if corrections are arriving on the selected port
+    // Returns true if corrections are enabled and arriving on the selected port
     bool isExternalCorrectionActive(uint8_t port);
 
     // Some functions merely need to know if we have an RTK Float.

--- a/Firmware/RTK_Everywhere/GNSS_ZED.h
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.h
@@ -314,13 +314,15 @@ class GNSS_ZED : GNSS
     // On the mosaic, we know that InputLink will arrive at 1Hz. But on the ZED, UBX-MON-COMMS
     // is tied to the navigation rate. To keep it simple, record the last time rxBytes
     // was seen to increase and use that for corrections timeout. This is updated by the
-    // UBX-MON-COMMS callback. isCorrRadioExtPortActive returns true if the bytes-received has
+    // UBX-MON-COMMS callback. isExternalCorrectionActive returns true if the bytes-received has
     // increased in the previous settings.correctionsSourcesLifetime_s
     uint32_t _radioExtBytesReceived_millis;
 
     // Given a sub type (ie "RTCM", "NMEA") present menu showing messages with this subtype
     // Controls the messages that get broadcast over Bluetooth and logged (if enabled)
     void menuMessagesSubtype(uint8_t *localMessageRate, const char *messageType);
+
+    int _externalCorrectionsEnabled = -1; // ZED has UARTs 1-2 but only UART2 is used for corrections
 
   public:
     // Constructor
@@ -541,11 +543,11 @@ class GNSS_ZED : GNSS
     // Date is confirmed once we have GNSS fix
     bool isConfirmedTime();
 
-    // Returns true if data is arriving on the Radio Ext port
-    bool isCorrRadioExtPortActive();
-
     // Return true if GNSS receiver has a higher quality DGPS fix than 3D
     bool isDgpsFixed();
+
+    // Returns true if corrections are arriving on the selected port
+    bool isExternalCorrectionActive(uint8_t port);
 
     // Some functions merely need to know if we have an RTK Float.
     // This function checks to see if the given platform has reached sufficient
@@ -645,9 +647,9 @@ class GNSS_ZED : GNSS
     // Enable all the valid constellations and bands for this platform
     bool setConstellations();
 
-    // Enable / disable corrections protocol(s) on the Radio External port
+    // Enable / disable external corrections protocol(s) on the chosen port
     // Always update if force is true. Otherwise, only update if enable has changed state
-    bool setCorrRadioExtPort(bool enable, bool force);
+    bool setExternalCorrections(uint8_t port, bool enable, bool force, const char *debug = nullptr);
 
     // Set the elevation in degrees
     // Inputs:

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -1363,7 +1363,9 @@ bool GNSS_ZED::isDgpsFixed()
     return (false);
 }
 
-// Returns true if data is arriving on the selected port
+//----------------------------------------
+// Returns true if corrections are enabled and data is arriving on the selected port
+//----------------------------------------
 bool GNSS_ZED::isExternalCorrectionActive(uint8_t port)
 {
     if (_externalCorrectionsEnabled < 1)

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -1368,6 +1368,8 @@ bool GNSS_ZED::isDgpsFixed()
 //----------------------------------------
 bool GNSS_ZED::isExternalCorrectionActive(uint8_t port)
 {
+    // ZED only supports corrections on UART2
+    // Ignore port
     if (_externalCorrectionsEnabled < 1)
         return false;
 

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -1364,24 +1364,25 @@ bool GNSS_ZED::isDgpsFixed()
 }
 
 //----------------------------------------
-// Returns true if corrections are enabled and data is arriving on the selected port
+// Returns 0 if corrections can not be arriving on the selected port
+// Returns 2 if corrections truly are arriving on the selected port
 //----------------------------------------
-bool GNSS_ZED::isExternalCorrectionActive(uint8_t port)
+int GNSS_ZED::isExternalCorrectionActive(uint8_t port)
 {
     // ZED only supports corrections on UART2
     // Ignore port
     if (_externalCorrectionsEnabled < 1)
-        return false;
+        return 0;
 
     if (_radioExtBytesReceived_millis > 0) // Avoid a false positive
     {
         // Return true if _radioExtBytesReceived_millis increased
         // in the last settings.correctionsSourcesLifetime_s
         if ((millis() - _radioExtBytesReceived_millis) < (settings.correctionsSourcesLifetime_s * 1000))
-            return true;
+            return 2;
     }
 
-    return false;
+    return 0;
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -230,11 +230,7 @@ void GNSS_ZED::begin()
 
             present.dynamicModel = true; // EVK and FPX ZED modules support dynamic model configuration
 
-            // On Facet FP: set UART2 (Radio) protocol(s)
-            // Both Ext Radio and LoRa need RTCM on UART2
-            // Note: this is probably redundant? I only added it because I added it on mosaic...
-            if (productVariant == RTK_FACET_FP)
-                setCorrRadioExtPort((settings.enableExtCorrRadio || settings.enableLora), true); // Force the setting
+            // On Facet FP: UART2 (Radio) protocol(s) are set by correctionUpdateSource()
 
             return;
         }
@@ -406,7 +402,7 @@ bool GNSS_ZED::configure()
     if (commandSupported(UBLOX_CFG_UART2OUTPROT_RTCM3X))
         response &= _zed->addCfgValset(UBLOX_CFG_UART2OUTPROT_RTCM3X, 1);
 
-    // UART2INPROT is set by setCorrRadioExtPort
+    // UART2INPROT is set by setExternalCorrections
 
     // We don't want NMEA over I2C, but we will want to deliver RTCM, and UBX+RTCM is not an option
     response &= _zed->addCfgValset(UBLOX_CFG_I2COUTPROT_UBX, 1);
@@ -483,8 +479,7 @@ bool GNSS_ZED::configure()
     if (response == false)
         systemPrintln("Module failed config block 1");
 
-    // Enable RTCM3 if needed - if not enable NMEA IN to keep skipped updated
-    gnssConfigure(GNSS_CONFIG_EXT_CORRECTIONS); // Request receiver to use new settings
+    // Enable RTCM3 if needed on UART2 - handled by 
 
     if (response)
     {
@@ -1359,10 +1354,19 @@ bool GNSS_ZED::isConfirmedTime()
     return (_confirmedTime);
 }
 
-// Returns true if data is arriving on the Radio Ext port
-bool GNSS_ZED::isCorrRadioExtPortActive()
+//----------------------------------------
+// Return true if GNSS receiver has a higher quality DGPS fix than 3D
+//----------------------------------------
+bool GNSS_ZED::isDgpsFixed()
 {
-    if (!settings.enableExtCorrRadio)
+    // Not supported
+    return (false);
+}
+
+// Returns true if data is arriving on the selected port
+bool GNSS_ZED::isExternalCorrectionActive(uint8_t port)
+{
+    if (_externalCorrectionsEnabled < 1)
         return false;
 
     if (_radioExtBytesReceived_millis > 0) // Avoid a false positive
@@ -1374,15 +1378,6 @@ bool GNSS_ZED::isCorrRadioExtPortActive()
     }
 
     return false;
-}
-
-//----------------------------------------
-// Return true if GNSS receiver has a higher quality DGPS fix than 3D
-//----------------------------------------
-bool GNSS_ZED::isDgpsFixed()
-{
-    // Not supported
-    return (false);
 }
 
 //----------------------------------------
@@ -2020,40 +2015,63 @@ bool GNSS_ZED::setConstellations()
     return (overallResponse);
 }
 
-// Enable / disable corrections protocol(s) on the Radio External port
+// Enable / disable external corrections protocol(s) on the chosen port
 // Always update if force is true. Otherwise, only update if enable has changed state
-bool GNSS_ZED::setCorrRadioExtPort(bool enable, bool force)
+bool GNSS_ZED::setExternalCorrections(uint8_t port, bool enable, bool force, const char *debug)
 {
-    if (force || (enable != _corrRadioExtPortEnabled))
+    // ZED has UARTs 1-2, but we will only ever use 2 for corrections
+    if ((port < 2) || (port > 2))
     {
-        bool response = _zed->newCfgValset(VAL_LAYER_ALL);
+        systemPrintf("setExternalCorrections: invalid port %d\r\n", port);
+        return false;
+    }
 
-        // Leave NMEA IN (poll requests) enabled so MON-COMMS skipped keeps updating
-        response &= _zed->addCfgValset(UBLOX_CFG_UART2INPROT_NMEA, enable ? 0 : 1);
+    if (online.gnss)
+    {
+        // Someday, read/modify/write UART2INPROT
 
-        response &= _zed->addCfgValset(UBLOX_CFG_UART2INPROT_UBX, enable ? 1 : 0);
-        response &= _zed->addCfgValset(UBLOX_CFG_UART2INPROT_RTCM3X, enable ? 1 : 0);
-        if (commandSupported(UBLOX_CFG_UART2INPROT_SPARTN))
-            response &= _zed->addCfgValset(UBLOX_CFG_UART2INPROT_SPARTN, enable ? 1 : 0);
-
-        response &= _zed->sendCfgValset(); // Closing
-
-        if (response)
+        if (force || (enable != _externalCorrectionsEnabled))
         {
-            if ((settings.debugCorrections == true) && !inMainMenu)
+            bool response = _zed->newCfgValset(VAL_LAYER_ALL);
+
+            // Leave NMEA IN (poll requests) enabled so MON-COMMS skipped keeps updating
+            response &= _zed->addCfgValset(UBLOX_CFG_UART2INPROT_NMEA, enable ? 0 : 1);
+
+            response &= _zed->addCfgValset(UBLOX_CFG_UART2INPROT_UBX, enable ? 1 : 0);
+            response &= _zed->addCfgValset(UBLOX_CFG_UART2INPROT_RTCM3X, enable ? 1 : 0);
+            if (commandSupported(UBLOX_CFG_UART2INPROT_SPARTN))
+                response &= _zed->addCfgValset(UBLOX_CFG_UART2INPROT_SPARTN, enable ? 1 : 0);
+
+            response &= _zed->sendCfgValset(); // Closing
+
+            if (response)
             {
-                systemPrintf("Radio Ext corrections: %s -> %s%s\r\n", _corrRadioExtPortEnabled ? "enabled" : "disabled",
-                             enable ? "enabled" : "disabled", force ? " (Forced)" : "");
-            }
+                if ((settings.debugCorrections == true) && !inMainMenu)
+                {
+                    systemPrintf("setExternalCorrections: %s -> %s%s%s%s%s\r\n",
+                                 _externalCorrectionsEnabled == -1 ? "not set" :
+                                 _externalCorrectionsEnabled ? "enabled" : "disabled",
+                                 enable ? "enabled" : "disabled",
+                                 force ? " (Forced)" : "",
+                                 debug ? " (" : "",
+                                 debug ? debug : "",
+                                 debug ? ")" : "");
+                }
 
-            _corrRadioExtPortEnabled = enable;
-            return true;
-        }
-        else
-        {
-            systemPrintf("Radio Ext corrections FAILED: %s -> %s%s\r\n",
-                         _corrRadioExtPortEnabled ? "enabled" : "disabled", enable ? "enabled" : "disabled",
-                         force ? " (Forced)" : "");
+                _externalCorrectionsEnabled = enable;
+                return true;
+            }
+            else
+            {
+                systemPrintf("setExternalCorrections FAILED: %s -> %s%s%s%s%s\r\n",
+                                 _externalCorrectionsEnabled == -1 ? "not set" :
+                                 _externalCorrectionsEnabled ? "enabled" : "disabled",
+                                 enable ? "enabled" : "disabled",
+                                 force ? " (Forced)" : "",
+                                 debug ? " (" : "",
+                                 debug ? debug : "",
+                                 debug ? ")" : "");
+            }
         }
     }
 

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -479,7 +479,7 @@ bool GNSS_ZED::configure()
     if (response == false)
         systemPrintln("Module failed config block 1");
 
-    // Enable RTCM3 if needed on UART2 - handled by 
+    // Enable RTCM3 if needed on UART2 - handled by setExternalCorrections
 
     if (response)
     {

--- a/Firmware/RTK_Everywhere/LoRa.ino
+++ b/Firmware/RTK_Everywhere/LoRa.ino
@@ -102,6 +102,7 @@ void updateLora()
 
     if (settings.enableLora == false && (loraState >= LORA_IDLE && loraState < LORA_STATE_MAX))
     {
+        loraHangup();   // On Facet FP, select external radio and restore baud rate
         loraPowerOff(); // Leave serial inteface in place
         loraState = LORA_DISABLED;
     }
@@ -121,6 +122,7 @@ void updateLora()
                          // mode.
             if (settings.enableLora == false)
             {
+                loraHangup();   // On Facet FP, select external radio and restore baud rate
                 loraPowerOff(); // Power off system. Leave serial inteface in place
                 loraState = LORA_DISABLED;
             }
@@ -698,11 +700,10 @@ void loraSetupTransmit()
     // If platform has a dedicated LoRa UART - i.e. Facet FP
     // Set the switch(es) to connect the GNSS to LoRa
     // And override the baud rate
-    // TODO: improve this so it works better with settings.radioPortBaud and GNSS_CONFIG_BAUD_RATE_RADIO
     if (present.loraDedicatedUart == true)
     {
-        gnss->setBaudRateRadio(115200);
         gpioExpanderSelectLoraCommunication();
+        gnssConfigure(GNSS_CONFIG_BAUD_RATE_RADIO);
     }
 
     loraSetup(true);
@@ -713,14 +714,26 @@ void loraSetupReceive()
     // If platform has a dedicated LoRa UART - i.e. Facet FP
     // Set the switch(es) to connect the GNSS to LoRa
     // And override the baud rate
-    // TODO: improve this so it works better with settings.radioPortBaud and GNSS_CONFIG_BAUD_RATE_RADIO
     if (present.loraDedicatedUart == true)
     {
-        gnss->setBaudRateRadio(115200);
         gpioExpanderSelectLoraCommunication();
+        gnssConfigure(GNSS_CONFIG_BAUD_RATE_RADIO);
     }
 
     loraSetup(false);
+}
+
+void loraHangup()
+{
+    // LoRa is no longer needed
+    // If platform has a dedicated LoRa UART - i.e. Facet FP
+    // Set the switch(es) to connect the GNSS to External radio
+    // And restore the baud rate
+    if (present.loraDedicatedUart == true)
+    {
+        gpioExpanderSelectRadioPort();
+        gnssConfigure(GNSS_CONFIG_BAUD_RATE_RADIO);
+    }
 }
 
 // Setup LoRa radio for receiving or transmitting

--- a/Firmware/RTK_Everywhere/LoRa.ino
+++ b/Firmware/RTK_Everywhere/LoRa.ino
@@ -1520,12 +1520,40 @@ void loraProcessRTCM(uint8_t *rtcmData, uint16_t dataLength)
             
             // Send this data to the LoRa radio
             systemFlush();                // Complete prints
+
+// Test for LoRa Framing Error - which will stall Torch LoRa Base TX
+// Generate a framing error by dropping the baud rate to 4800 so that a single 0 is longer
+// than a full byte at 115200
+// #define TORCH_LORA_FE_TEST
+// #if defined(TORCH_LORA_FE_TEST)
+//             static int rtcmCount = 0;
+//             const int feEvery = 100;
+//             rtcmCount++;
+//             if ((productVariant == RTK_TORCH) && (rtcmCount % feEvery == 0))
+//             {
+//                 systemPrintln("<<<<< TORCH LORA FE TEST >>>>>");
+//                 systemFlush();  // Complete prints
+//                 Serial.end();
+//                 Serial.begin(4800); // Drop the baud rate to generate framing errors
+//             }
+// #endif
+
             muxSelectLoRaCommunication(); // Connect the LoRa radio to ESP32 UART0 (shared with USB)
 
             loraWrite(rtcmData, dataLength);
 
             systemFlush();  // Complete prints
             muxSelectUsb(); // Connect USB
+
+// #if defined(TORCH_LORA_FE_TEST)
+//             if ((productVariant == RTK_TORCH) && (rtcmCount % feEvery == 0))
+//             {
+//                 Serial.end();
+//                 Serial.begin(115200);
+//                 systemPrintln(">>>>> TORCH LORA FE TEST <<<<<");
+//                 systemFlush();  // Complete prints
+//             }
+// #endif
         }
 
         // Keep a record of how many LoRa bytes _should_ be being sent

--- a/Firmware/RTK_Everywhere/LoRa.ino
+++ b/Firmware/RTK_Everywhere/LoRa.ino
@@ -1499,6 +1499,25 @@ void loraProcessRTCM(uint8_t *rtcmData, uint16_t dataLength)
         // Only needed for Torch. Facet FP has GNSS tied directly to LoRa.
         if (productVariant == RTK_TORCH)
         {
+            // Check to see if the RTCM data conatins the "+++" escape sequence
+            // Will strnstr work on binary data? Probably not?
+            //if (strnstr(rtcmData, "+++", dataLength))
+            uint16_t ptr = 0;
+            uint8_t consecutivePlus = 0;
+            while ((ptr < dataLength) && (consecutivePlus < 3))
+            {
+                if (rtcmData[ptr++] == '+')
+                    consecutivePlus++;
+                else
+                    consecutivePlus = 0;
+            }
+            if (consecutivePlus == 3)
+            {
+                if (settings.debugLora == true)
+                    systemPrintln("loraProcessRTCM: RTCM for LoRa contains +++. Skipping...");
+                return;
+            }
+            
             // Send this data to the LoRa radio
             systemFlush();                // Complete prints
             muxSelectLoRaCommunication(); // Connect the LoRa radio to ESP32 UART0 (shared with USB)

--- a/Firmware/RTK_Everywhere/LoRa.ino
+++ b/Firmware/RTK_Everywhere/LoRa.ino
@@ -240,10 +240,10 @@ void updateLora()
                     loraBytesSent = 0;
                 }
             }
-
-            if (inBaseMode() == false)
-                loraState = LORA_IDLE; // Force restart to move to other modes
         }
+
+        if (inBaseMode() == false)
+            loraState = LORA_IDLE; // Force restart to move to other modes
 
         break;
 

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -546,6 +546,8 @@ bool usbSerialIncomingRtcm; // Incoming RTCM over the USB serial port
 #define RTCM_CORRECTION_INPUT_TIMEOUT (2 * 1000)
 #define RTCM_CORRECTION_WRITE_TIMEOUT (3 * 1000)
 
+bool gnssExternalIncomingRtcm; // Incoming RTCM direct to GNSS (Radio Ext - or LoRa on Facet FP)
+
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
 // Extensible Message Parser

--- a/Firmware/RTK_Everywhere/States.ino
+++ b/Firmware/RTK_Everywhere/States.ino
@@ -850,28 +850,28 @@ const char *stateToRtkMode(SystemState state)
 
 bool inRoverMode()
 {
-    if (systemState >= STATE_ROVER_NOT_STARTED && systemState <= STATE_ROVER_RTK_FIX)
+    if ((systemState >= STATE_ROVER_NOT_STARTED) && (systemState <= STATE_ROVER_RTK_FIX))
         return (true);
     return (false);
 }
 
 bool inBaseMode()
 {
-    if (systemState >= STATE_BASE_CASTER_NOT_STARTED && systemState <= STATE_BASE_FIXED_TRANSMITTING)
+    if ((systemState >= STATE_BASE_CASTER_NOT_STARTED) && (systemState <= STATE_BASE_FIXED_TRANSMITTING))
         return (true);
     return (false);
 }
 
 bool inWebConfigMode()
 {
-    if (systemState >= STATE_WEB_CONFIG_NOT_STARTED && systemState <= STATE_WEB_CONFIG)
+    if ((systemState >= STATE_WEB_CONFIG_NOT_STARTED) && (systemState <= STATE_WEB_CONFIG))
         return (true);
     return (false);
 }
 
 bool inNtpMode()
 {
-    if (systemState >= STATE_NTPSERVER_NOT_STARTED && systemState <= STATE_NTPSERVER_SYNC)
+    if ((systemState >= STATE_NTPSERVER_NOT_STARTED) && (systemState <= STATE_NTPSERVER_SYNC))
         return (true);
     return (false);
 }

--- a/Firmware/RTK_Everywhere/System.ino
+++ b/Firmware/RTK_Everywhere/System.ino
@@ -1225,10 +1225,6 @@ void gpioExpanderSelectLoraCommunication()
 }
 
 // Connect Facet FP GNSS UART2 to 4-pin JST RADIO port via SW4 (Default)
-// Currently never called... But that is probably OK. SW4 defaults to JST RADIO.
-// Selecting LoRa TX or RX will switch SW4 to LoRa, and leave it there.
-// If LoRa is enabled and then disabled, we should then gpioExpanderSelectRadioPort
-// to select JST RADIO again. And reset the baud rate to settings.radioPortBaud
 void gpioExpanderSelectRadioPort()
 {
     if (online.gpioExpanderSwitches == true)

--- a/Firmware/RTK_Everywhere/Tasks.ino
+++ b/Firmware/RTK_Everywhere/Tasks.ino
@@ -1092,10 +1092,17 @@ void processUart1Message(SEMP_PARSE_STATE *parse, uint16_t type)
 
         if (type == RTK_NMEA_PARSER_INDEX)
         {
+            if (strstr(sempNmeaGetSentenceName(parse), "PQTMRTCMIS") != nullptr)
+            {
+                // Extract correction port RTCM count from PQTMRTCMIS
+                lg290pProcessRTCMIS(parse->buffer, parse->length);
+            }
+
             // Suppress PQTM/NMEA messages as needed
             if (lg290pMessageEnabled((char *)parse->buffer, parse->length) == false)
             {
-                if (settings.enableNtripClient == true && settings.ntripClient_TransmitGGA == true)
+                if ((strstr(sempNmeaGetSentenceName(parse), "GGA") != nullptr)
+                    && settings.enableNtripClient == true && settings.ntripClient_TransmitGGA == true)
                 {
                     // GGA is disabled, but the user has enabled the NTRIP Client.
                     // Allow GGA to get through, unmodified.

--- a/Firmware/RTK_Everywhere/Tasks.ino
+++ b/Firmware/RTK_Everywhere/Tasks.ino
@@ -1110,6 +1110,8 @@ void processUart1Message(SEMP_PARSE_STATE *parse, uint16_t type)
                 else
                 {
                     // Remove the contents of this message
+                    // Note: I know we're not using the PPL any more but this code will prevent
+                    // ZDA from reaching the PPL. Is that what we want?
                     parse->buffer[0] = 0;
                     parse->length = 0;
                 }
@@ -1222,13 +1224,13 @@ void processUart1Message(SEMP_PARSE_STATE *parse, uint16_t type)
     }
 
     // Push GGA to Caster if enabled
-    if (type == RTK_NMEA_PARSER_INDEX && strstr(sempNmeaGetSentenceName(parse), "GGA") != nullptr)
+    if ((type == RTK_NMEA_PARSER_INDEX) && (strstr(sempNmeaGetSentenceName(parse), "GGA") != nullptr))
     {
         pushGPGGA((char *)parse->buffer);
     }
 
     // If the user has not specifically enabled RTCM used by the PPL, then suppress it
-    if (inRoverMode() && gnss->getActiveRtcmMessageCount() == 0 && type == RTK_RTCM_PARSER_INDEX)
+    if (inRoverMode() && (gnss->getActiveRtcmMessageCount() == 0) && (type == RTK_RTCM_PARSER_INDEX))
     {
         // Erase buffer
         parse->buffer[0] = 0;

--- a/Firmware/RTK_Everywhere/menuCorrectionsPriorities.ino
+++ b/Firmware/RTK_Everywhere/menuCorrectionsPriorities.ino
@@ -804,11 +804,23 @@ bool gnssExternalCorrectionsSelected(bool &lora)
 // Usually this is settings.radioPortBaud but on Facet FP we need to allow LoRa to override
 uint32_t getBaudRateForGnssRadio()
 {
-    if (present.loraDedicatedUart == true)
+    if (present.loraDedicatedUart == true) // Facet FP
     {
+        // Check for Base mode
+        if (inBaseMode())
+        {
+            if (settings.enableLora)
+                return 115200;
+            else
+                return settings.radioPortBaud;
+        }
+
+        // Rover mode
         bool lora;
         if (gnssExternalCorrectionsSelected(lora) && lora)
             return 115200; // Facet FP LoRa UART baud is fixed at 115200
+        else
+            return settings.radioPortBaud;
     }
 
     return settings.radioPortBaud;

--- a/Firmware/RTK_Everywhere/menuCorrectionsPriorities.ino
+++ b/Firmware/RTK_Everywhere/menuCorrectionsPriorities.ino
@@ -430,6 +430,28 @@ const char *correctionGetName(CORRECTION_ID_T id)
 }
 
 //----------------------------------------
+// Get the priority of a correction source
+// Inputs:
+//    id: correctionsSource value, ID of the correction source
+// Outputs:
+//    Returns the priority of the source or
+//    CORR_NUM when id is invalid
+//----------------------------------------
+CORRECTION_ID_T correctionGetPriority(CORRECTION_ID_T id)
+{
+    // Validate the id value
+    if (id >= CORR_NUM)
+    {
+        systemPrintf("ERROR: correctionGetPriority invalid correction id value %d, valid range (0 - %d)!\r\n", id,
+                     CORR_NUM - 1);
+        return CORR_NUM;
+    }
+
+    // Return the priority of the correction source
+    return settings.correctionsSourcesPriority[id];
+}
+
+//----------------------------------------
 // Get the ID of the source providing corrections
 // Outputs:
 //    Returns the correctionsSource ID providing corrections
@@ -610,27 +632,42 @@ bool correctionPriorityValidation()
 //----------------------------------------
 void correctionUpdateSource()
 {
-    // Periodically check if data is arriving on the Radio Ext port
-    // If needed, fake the arrival of data on the Radio Ext port
+    // Periodically check if data is arriving on the external corrections port
+    // If needed, fake the arrival of data on the corrections port
     // The code is the same:
     //   On ZED / mosaic, we can detect if the port is active.
     //   On LG290P, we fake the arrival of data if needed.
-    //   On Facet FPL, we fake the arrival of radio data if LoRa is active
+    //   On Facet FPL, we fake the arrival of correction data
     //     again to prevent a timeout and maintain the port protocol
-    static uint32_t lastRadioExtCheck = millis();
-    uint32_t radioCheckIntervalMsec = settings.correctionsSourcesLifetime_s * 500; // Check twice per lifetime
-    bool setCorrRadioPort = false;
+    static uint32_t lastExternalCorrectionsCheck = millis(); // We can wait...
+    // settings.correctionsSourcesLifetime_s is in the range 5-120
+    // To keep life simple and improve the user experience, check every 2 seconds
+    uint32_t correctionsCheckIntervalMsec = 2000;
+    bool correctionsMayNeedUpdating = false;
 
-    if ((millis() - lastRadioExtCheck) > radioCheckIntervalMsec)
+    if ((millis() - lastExternalCorrectionsCheck) > correctionsCheckIntervalMsec)
     {
-        // LG290P will return settings.enableExtCorrRadio.
-        // ZED / mosaic will return true if settings.enableExtCorrRadio is
-        // true and the port is actually active.
-        if (gnss->isCorrRadioExtPortActive())
-            correctionLastSeen(CORR_RADIO_EXT);
+        // What needs to happen here?
+        // We want to find out if external radio or LoRa corrections are active
+        // If corrections are active, update correctionLastSeen with CORR_RADIO_LORA or
+        // CORR_RADIO_EXT as appropriate
+        // Call GNSS::isExternalCorrectionActive every correctionsCheckIntervalMsec
+        // LG290P will return true if corrections are enabled
+        // ZED / mosaic will return true if corrections are enabled and the port is actually active.
+        // The GNSS does not know the source of the corrections
+        // gnssExternalCorrectionsSelected returns true if corrections have been selected
+        // and the type via the lora reference
+        if (gnss->isExternalCorrectionActive(getGnssExternalCorrectionsPort()))
+        {
+            // If the corrections are active, then update correctionLastSeen with the source
+            // If corrections are not active, don't update - allowing the source to timeout
+            bool lora;
+            if(gnssExternalCorrectionsSelected(lora))
+                correctionLastSeen(lora ? CORR_RADIO_LORA : CORR_RADIO_EXT);
+        }
 
-        lastRadioExtCheck = millis();
-        setCorrRadioPort = true; // Update the port protocols after updating the sources
+        lastExternalCorrectionsCheck = millis();
+        correctionsMayNeedUpdating = true; // Update the port protocols after updating the sources
     }
 
     // Now update the sources
@@ -649,11 +686,59 @@ void correctionUpdateSource()
     }
 
     // Now that the sources have been updated
-    // If radioCheckIntervalMsec expired
-    if (setCorrRadioPort)
+    // If correctionsCheckIntervalMsec expired
+    if (correctionsMayNeedUpdating)
     {
-        // Update the input protocols, based on CORR_RADIO_EXT being the active correction source
-        gnss->setCorrRadioExtPort(correctionGetSource() == CORR_RADIO_EXT, false); // Don't force
+        // On Facet FP, SW4 to connects LoRa or External Radio to the GNSS UART2
+        // But, setting SW4 is looked after by the loraState state machine
+        // Here we are only concerned about the port protocol:
+        // disable RTCM if CORR_RADIO_EXT / CORR_RADIO_LORA is not the highest priority;
+        // ensure RTCM is enabled if the priority of CORR_RADIO_EXT / CORR_RADIO_LORA is
+        // higher than that of the current source.
+    
+        bool lora;
+        if(gnssExternalCorrectionsSelected(lora))
+        {
+            // Update the input protocols, based on the active correction source
+            // *** setExternalCorrections will only communicate with the GNSS if things have changed ***
+
+            // If no correction source is active, ensure the protocol is enabled
+            if (correctionGetSource() >= CORR_NUM)
+            {
+                gnss->setExternalCorrections(getGnssExternalCorrectionsPort(), true,
+                    false, "correctionUpdateSource no active source"); // Don't force
+            }
+            // Else if the priority of LoRa is higher than the priority of the active correction source
+            // then ensure the protocol is enabled
+            // Remember that 0 is the highest priority
+            // Use <= because the current source could be LoRa
+            else if (lora && (correctionGetPriority(CORR_RADIO_LORA) <= correctionGetPriority(correctionGetSource())))
+            {
+                gnss->setExternalCorrections(getGnssExternalCorrectionsPort(), true,
+                    false, "correctionUpdateSource lora priority"); // Don't force
+            }
+            // Else if the priority of External Radio is higher than the priority of the active correction source
+            // then ensure the protocol is enabled
+            // Remember that 0 is the highest priority
+            // Use <= because the current source could be External Radio
+            else if (!lora && (correctionGetPriority(CORR_RADIO_EXT) <= correctionGetPriority(correctionGetSource())))
+            {
+                gnss->setExternalCorrections(getGnssExternalCorrectionsPort(), true,
+                    false, "correctionUpdateSource radio ext priority"); // Don't force
+            }
+            // Else disable the protocol to disable the corrections
+            else
+            {
+                gnss->setExternalCorrections(getGnssExternalCorrectionsPort(), false,
+                    false, "correctionUpdateSource no priority"); // Don't force
+            }
+        }
+        else
+        {
+            // External corrections not selected. Ensure the protocol is disabled
+            gnss->setExternalCorrections(getGnssExternalCorrectionsPort(), false,
+                false, "correctionUpdateSource not selected"); // Don't force
+        }
     }
 }
 
@@ -686,4 +771,111 @@ void markPppCorrectionsPresent()
         if (settings.debugCorrections == true && !inMainMenu)
             systemPrintln("PPP signal detected, but it is not the top priority");
     }    
+}
+
+// Return true if external corrections (external radio or LoRa) are enabled
+// Set lora true if external corrections are LoRa
+// If both are enabled on Facet FP, LoRa always wins regardless of the corrections priority
+// since the loraState machine will go into receive/transmit if LoRa is enabled
+bool gnssExternalCorrectionsSelected(bool &lora)
+{
+    if ((productVariant == RTK_FACET_FP) && settings.enableLora) // On Facet FP, LoRa always wins
+    {
+        lora = true;
+        return true;
+    }
+
+    if (settings.enableExtCorrRadio)
+    {
+        lora = false;
+        return true;
+    }
+
+    return false;
+}
+
+// Return the baud rate for the GNSS Radio port
+// Usually this is settings.radioPortBaud but on Facet FP we need to allow LoRa to override
+uint32_t getBaudRateForGnssRadio()
+{
+    if (present.loraDedicatedUart == true)
+    {
+        bool lora;
+        if (gnssExternalCorrectionsSelected(lora) && lora)
+            return 115200; // Facet FP LoRa UART baud is fixed at 115200
+    }
+
+    return settings.radioPortBaud;
+}
+
+// Return the GNSS external corrections port (UART) for this platform
+uint8_t getGnssExternalCorrectionsPort()
+{
+    uint8_t radioUart = 0;
+
+    if (present.gnss_lg290p)
+    {
+        if (productVariant == RTK_POSTCARD)
+        {
+            // UART3 of the LG290P is connected to the locking JST connector labled RADIO
+            radioUart = 3;
+        }
+        else if (productVariant == RTK_FACET_FP)
+        {
+            // UART2 of the GNSS is connected to SW4, which is connected to LoRa UART0
+            radioUart = 2;
+        }
+        else if (productVariant == RTK_TORCH_X2)
+        {
+            // UART1 of the LG290P is connected to SW, which is connected to ESP32 UART0
+            // Not really used at this time but available for configuration
+            radioUart = 1;
+        }
+        else
+            systemPrintln("getGnssExternalCorrectionsPort: Uncaught LG290P platform");
+    }
+    else if (present.gnss_mosaicX5)
+    {
+        if (productVariant == RTK_FACET_FP)
+        {
+            // UART2 of the GNSS is connected to SW4, which is connected to LoRa UART1
+            radioUart = 2;
+        }
+        else if (productVariant == RTK_FACET_MOSAIC)
+        {
+            // COM2 of the GNSS is connected to the Radio port
+            radioUart = 2;
+        }
+        else
+            systemPrintln("getGnssExternalCorrectionsPort: Uncaught mosaicX5 platform");
+    }
+    else if (present.gnss_um980)
+    {
+        if (productVariant == RTK_TORCH)
+        {
+            // UART3 of the GNSS is connected to ESP32. ESP32 provides corrections
+            radioUart = 3;
+        }
+        else
+            systemPrintln("getGnssExternalCorrectionsPort: Uncaught UM980 platform");
+    }
+    else if (present.gnss_zedf9p || present.gnss_zedx20p)
+    {
+        if (productVariant == RTK_FACET_FP)
+        {
+            // UART2 of the GNSS is connected to SW4, which is connected to LoRa UART1
+            radioUart = 2;
+        }
+        else if (productVariant == RTK_EVK)
+        {
+            // UART2 of the GNSS is accessible via the IO screw terminals
+            radioUart = 2;
+        }
+        else
+            systemPrintln("getGnssExternalCorrectionsPort: Uncaught ZED platform");
+    }
+    else
+        systemPrintln("getGnssExternalCorrectionsPort: Uncaught GNSS");
+
+    return radioUart;
 }

--- a/Firmware/RTK_Everywhere/menuCorrectionsPriorities.ino
+++ b/Firmware/RTK_Everywhere/menuCorrectionsPriorities.ino
@@ -652,13 +652,14 @@ void correctionUpdateSource()
         // If corrections are active, update correctionLastSeen with CORR_RADIO_LORA or
         // CORR_RADIO_EXT as appropriate
         // Call GNSS::isExternalCorrectionActive every correctionsCheckIntervalMsec
-        // LG290P will return true if corrections are enabled
-        // ZED / mosaic will return true if corrections are enabled and the port is actually active
+        // LG290P will return 1 if corrections are assumed to be enabled, 2 if truly being received
+        // ZED / mosaic will return 2 if corrections are enabled and the port is actually active
         // The GNSS does not know the source of the corrections (Facet FP: LoRa vs. Ext Radio);
         // we get that from the gnssExternalCorrectionsSelected lora reference
         // If the corrections are active, then update correctionLastSeen with the source
         // If corrections are not active, don't update - allowing the source to timeout
-        if (gnss->isExternalCorrectionActive(getGnssExternalCorrectionsPort()))
+        int activity = gnss->isExternalCorrectionActive(getGnssExternalCorrectionsPort());
+        if (activity > 0)
         {
             // gnssExternalCorrectionsSelected returns true if corrections have been selected
             // and returns the type via the lora reference
@@ -667,7 +668,8 @@ void correctionUpdateSource()
                 correctionLastSeen(lora ? CORR_RADIO_LORA : CORR_RADIO_EXT);
             
             // Tell the display about the incoming corrections
-            gnssExternalIncomingRtcm = true;
+            // Only display the arrow if corrections are truly arriving
+            gnssExternalIncomingRtcm = activity > 1;
         }
 
         lastExternalCorrectionsCheck = millis();

--- a/Firmware/RTK_Everywhere/menuCorrectionsPriorities.ino
+++ b/Firmware/RTK_Everywhere/menuCorrectionsPriorities.ino
@@ -665,6 +665,9 @@ void correctionUpdateSource()
             bool lora;
             if(gnssExternalCorrectionsSelected(lora))
                 correctionLastSeen(lora ? CORR_RADIO_LORA : CORR_RADIO_EXT);
+            
+            // Tell the display about the incoming corrections
+            gnssExternalIncomingRtcm = true;
         }
 
         lastExternalCorrectionsCheck = millis();

--- a/Firmware/RTK_Everywhere/menuCorrectionsPriorities.ino
+++ b/Firmware/RTK_Everywhere/menuCorrectionsPriorities.ino
@@ -653,14 +653,15 @@ void correctionUpdateSource()
         // CORR_RADIO_EXT as appropriate
         // Call GNSS::isExternalCorrectionActive every correctionsCheckIntervalMsec
         // LG290P will return true if corrections are enabled
-        // ZED / mosaic will return true if corrections are enabled and the port is actually active.
-        // The GNSS does not know the source of the corrections
-        // gnssExternalCorrectionsSelected returns true if corrections have been selected
-        // and the type via the lora reference
+        // ZED / mosaic will return true if corrections are enabled and the port is actually active
+        // The GNSS does not know the source of the corrections (Facet FP: LoRa vs. Ext Radio);
+        // we get that from the gnssExternalCorrectionsSelected lora reference
+        // If the corrections are active, then update correctionLastSeen with the source
+        // If corrections are not active, don't update - allowing the source to timeout
         if (gnss->isExternalCorrectionActive(getGnssExternalCorrectionsPort()))
         {
-            // If the corrections are active, then update correctionLastSeen with the source
-            // If corrections are not active, don't update - allowing the source to timeout
+            // gnssExternalCorrectionsSelected returns true if corrections have been selected
+            // and returns the type via the lora reference
             bool lora;
             if(gnssExternalCorrectionsSelected(lora))
                 correctionLastSeen(lora ? CORR_RADIO_LORA : CORR_RADIO_EXT);

--- a/Firmware/RTK_Everywhere/menuCorrectionsPriorities.ino
+++ b/Firmware/RTK_Everywhere/menuCorrectionsPriorities.ino
@@ -767,15 +767,23 @@ void markPppCorrectionsPresent()
 {
     // The GNSS is reporting that PPP is detected/converged.
     // Determine if PPP is the correction source to use
+    // It's a lot of messages
+    static unsigned long lastPrint = 0;
     if (correctionLastSeen(CORR_PPP_HAS_B2B))
     {
-        if (settings.debugCorrections == true && !inMainMenu)
+        if (((millis() - lastPrint) > 2000) && (settings.debugCorrections == true) && !inMainMenu)
+        {
             systemPrintln("PPP Signal detected. Using corrections.");
+            lastPrint = millis();
+        }
     }
     else
     {
-        if (settings.debugCorrections == true && !inMainMenu)
+        if (((millis() - lastPrint) > 2000) && (settings.debugCorrections == true) && !inMainMenu)
+        {
             systemPrintln("PPP signal detected, but it is not the top priority");
+            lastPrint = millis();
+        }
     }    
 }
 

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -634,6 +634,8 @@ void menuRadio()
             settings.enableLora ^= 1;
             gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_NMEA); // We may need to enable / disable NMEA
             gnssConfigure(GNSS_CONFIG_EXT_CORRECTIONS);   // We may need to enable RTCM input
+            // Setting the GNSS baud rate for LoRa is handled by the loraState machine
+
         }
         else if (present.radio_lora == true && settings.enableLora == true && incoming == 11)
         {

--- a/Firmware/RTK_Everywhere/menuMain.ino
+++ b/Firmware/RTK_Everywhere/menuMain.ino
@@ -633,6 +633,7 @@ void menuRadio()
         {
             settings.enableLora ^= 1;
             gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_NMEA); // We may need to enable / disable NMEA
+            gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_OTHER); // Make sure PQTMRTCMIS is enabled on LG290P
             gnssConfigure(GNSS_CONFIG_EXT_CORRECTIONS);   // We may need to enable RTCM input
             // Setting the GNSS baud rate for LoRa is handled by the loraState machine
 

--- a/Firmware/RTK_Everywhere/menuPorts.ino
+++ b/Firmware/RTK_Everywhere/menuPorts.ino
@@ -158,6 +158,7 @@ void menuPortsNoMux()
             // Toggle the enable for the external corrections radio
             settings.enableExtCorrRadio ^= 1;
             gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_NMEA); // We may need to enable / disable NMEA
+            gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_OTHER); // Make sure PQTMRTCMIS is enabled on LG290P
             gnssConfigure(GNSS_CONFIG_EXT_CORRECTIONS); // Request receiver to use new settings
         }
 
@@ -168,6 +169,7 @@ void menuPortsNoMux()
         {
             settings.enableNmeaOnRadio ^= 1;
             gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_NMEA); // We may need to enable / disable NMEA
+            gnssConfigure(GNSS_CONFIG_MESSAGE_RATE_OTHER); // Make sure PQTMRTCMIS is enabled on LG290P
         }
         else if (incoming == 'x')
             break;

--- a/Firmware/RTK_Everywhere/menuSupport.ino
+++ b/Firmware/RTK_Everywhere/menuSupport.ino
@@ -218,16 +218,26 @@ void checkGNSSArrayDefaults()
         {
             defaultsApplied = true;
             if (productVariant == RTK_POSTCARD)
-                // User has to enable UART3 (JST) manually for the same reason as LG290P on FP
-                settings.enableExtCorrRadio = false;
+            {
+                if(lg290pFirmwareVersionInt >= 201)
+                    // Firmware v2.01 supports PQTMRTCMIS. It is safe to enable Ext Radio by default
+                    settings.enableExtCorrRadio = true;
+                else
+                    // User has to enable UART3 (JST) manually for the same reason as LG290P on FP
+                    settings.enableExtCorrRadio = false;
+            }
             else if (productVariant == RTK_FACET_FP)
             {
-                // With LG290P on Facet FP:
-                // We do not know if ext radio / LoRa corrections are arriving
-                // because we don't have access to the UART2 byte counts. We have to assume
-                // that corrections are arriving. See GNSS_LG290P::isExternalCorrectionActive()
-                // We must set settings.enableExtCorrRadio to false to prevent this.
-                settings.enableExtCorrRadio = false;
+                if(lg290pFirmwareVersionInt >= 201)
+                    // Firmware v2.01 supports PQTMRTCMIS. It is safe to enable Ext Radio by default
+                    settings.enableExtCorrRadio = true;
+                else
+                    // With LG290P firmware < v2.01 on Facet FP:
+                    // We do not know if ext radio / LoRa corrections are arriving
+                    // because we don't have access to the UART2 byte counts. We have to assume
+                    // that corrections are arriving. See GNSS_LG290P::isExternalCorrectionActive()
+                    // We must set settings.enableExtCorrRadio to false to prevent this.
+                    settings.enableExtCorrRadio = false;
             }
             else if (productVariant == RTK_TORCH_X2)
                 settings.enableExtCorrRadio = false; // GNSS UART1 isn't really accessible

--- a/Firmware/RTK_Everywhere/menuSupport.ino
+++ b/Firmware/RTK_Everywhere/menuSupport.ino
@@ -225,7 +225,7 @@ void checkGNSSArrayDefaults()
                 // With LG290P on Facet FP:
                 // We do not know if ext radio / LoRa corrections are arriving
                 // because we don't have access to the UART2 byte counts. We have to assume
-                // that corrections are arriving. See GNSS_LG290P::isCorrRadioExtPortActive()
+                // that corrections are arriving. See GNSS_LG290P::isExternalCorrectionActive()
                 // We must set settings.enableExtCorrRadio to false to prevent this.
                 settings.enableExtCorrRadio = false;
             }


### PR DESCRIPTION
This PR:
* Resolves #1059 by correctly reporting LoRa corrections vs. Radio External corrections on Facet FP
* Uses the PQTMRTCMIS message on LG290P (firmware >= v2.01) to monitor the arrival and use of external corrections
* External corrections now correctly respect the priority system
    * It's a fun thing to watch Postcard external corrections (via the JST connector) take priority over (e.g.) NTRIP corrections arriving over WiFi
    * Nudge the priority to watch the corrections switch from one to the other
    * The LoRa corrections icon is displayed correctly when LoRa external corrections are being used
    * The downarrow icon now correctly indicates the arrival of external corrections
* Fixes a small gremlin where GGA could be enabled on the wrong GNSS UART when needed for NTRIP
    * This only happened if GGA was disabled via the message rates, and then enabled for NTRIP
* Prevents any RTCM messages containing the +++ escape sequence from reaching LoRa on Torch
    * If the Base binary RTCM messages happened by chance to contain "+++", this would cause LoRa to exit TRANS
    * This _may_ resolve the occasional Torch LoRa disconnects reported [here](https://community.sparkfun.com/t/rtk-torch-is-there-a-method-to-restart-lora/68725)
* Prevent LG290P PQTMSVINSTATUS from entering the circular buffer - when the message rate should be zero
    * Cherry-picked from #1094 