### PR TITLE
Stop RTCM and NMEA on ZED I2C

### DIFF
--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -3025,7 +3025,10 @@ bool messageSupported(int messageNumber)
         if (gnssFirmwareVersionInt >= ubxMessages[messageNumber].x20pFirmwareVersionSupported)
         {
             messageSupported = true;
-            if (gnssFirmwareVersionInt >= ubxMessages[messageNumber].x20pFirmwareVersionNotSupported)
+            // If the message is supported, check if it is no longer supported
+            // We use 0 to indicate "all versions", so we need to be careful when we use >=
+            if ((ubxMessages[messageNumber].x20pFirmwareVersionNotSupported > 0)
+                && (gnssFirmwareVersionInt >= ubxMessages[messageNumber].x20pFirmwareVersionNotSupported))
                 messageSupported = false;
         }
     }

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -2222,6 +2222,10 @@ bool GNSS_ZED::setMessagesNMEA()
                 // Set NMEA messages to user's settings on UART1 interface
                 response &= _zed->addCfgValset(ubxMessages[messageNumber].msgConfigKey,
                                                rate); // msgConfigKey defaults to UART1
+                
+                // Disable NMEA on I2C : UBLOX_CFG UART1 - 1 = I2C
+                if (ubxMessages[messageNumber].msgClass == UBX_CLASS_NMEA)
+                    response &= _zed->addCfgValset(ubxMessages[messageNumber].msgConfigKey - 1, 0);
 
                 // Mark messages needed for other services (NTRIP Client, PointPerfect, etc) as enabled if rate
                 // > 0
@@ -2334,6 +2338,20 @@ bool GNSS_ZED::setMessagesRTCMBase()
     // (Secondary) USB in case the RTK device is used as an NTRIP caster connected to SBC or other
     // (Tertiary) UART1 in case RTK device is sending RTCM to a phone that is then NTRIP Caster
 
+    // On Facet FPX:
+    //
+    // Messages output on UART1 are parsed by the SEMP and logged / forwarded to clients as needed
+    // Messages output on UART2 are passed directly to LoRa or the Ext Radio JST connector
+    // Messages output on USB could be picked up through the USB Hub
+    // Messages output on I2C will be processed by the callbacks:
+    //   TIM_TM2 for events
+    //   PVT for basic date, time and fix type information
+    //   HPPOSLLH for high-precision position information and horizontal accuracy
+    //   TIM_TP for time pulse interrupts for NTP
+    //   MON_HW for antenna sort / open
+    //   MON_COMMS for the UART(2) byte counts
+    // Do we need to output RTCM and / or NMEA on I2C? I don't think we do...
+
     // ubxMessageRatesBase is an array of ~12 uint8_ts
     // ubxMessage is an array of ~80 messages
     // We use firstRTCMRecord as an offset for the keys, but use x as the rate
@@ -2350,8 +2368,9 @@ bool GNSS_ZED::setMessagesRTCMBase()
     {
         if (messageSupported(firstRTCMRecord + x))
         {
-            response &= _zed->addCfgValset(ubxMessages[firstRTCMRecord + x].msgConfigKey - 1,
-                                           settings.ubxMessageRatesBase[x]); // UBLOX_CFG UART1 - 1 = I2C
+            // Disable RTCM on I2C : UBLOX_CFG UART1 - 1 = I2C
+            response &= _zed->addCfgValset(ubxMessages[firstRTCMRecord + x].msgConfigKey - 1, 0);
+
             response &= _zed->addCfgValset(ubxMessages[firstRTCMRecord + x].msgConfigKey,
                                            settings.ubxMessageRatesBase[x]); // UBLOX_CFG UART1
             response &= _zed->addCfgValset(ubxMessages[firstRTCMRecord + x].msgConfigKey + 1,


### PR DESCRIPTION
Facet FPX : in Base mode, there is a lot of unnecessary RTCM traffic on the I2C bus. It ties up the bus and makes the firmware quite sluggish…

It is caused by this [piece of code](https://github.com/sparkfun/SparkFun_RTK_Everywhere_Firmware/blob/9a7a2740c7780154fbd208f5479e0f9138346214/Firmware/RTK_Everywhere/GNSS_ZED.ino#L2327-L2354), which we added years ago with good intent

Now that we’re using SEMP to process RTCM on UART, RTCM doesn’t need to be enabled on I2C

I’m proposing we block RTCM output on I2C and, just for good measure, also make sure that the default NMEA messages on I2C are blocked too