### PR TITLE
Add the CSV version of the OTA support

### DIFF
--- a/Firmware/RTK_Everywhere/GNSS_LG290P.h
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.h
@@ -554,6 +554,40 @@ class GNSS_LG290P : GNSS
 
     // Poll routine to update the GNSS state
     void update();
+
+    /**
+     * @brief Reboot the module into bootloader mode, negotiate sync, query bootloader version,
+     *        send firmware metadata, and erase flash.
+     * @param firmwareSize total byte length of the firmware file (pre-computed by caller)
+     * @param firmwareCrc32 CRC32 of the firmware file (pre-computed via initFirmwareCrc32 / computeFirmwareCrc32)
+     * @param skipSoftwareReset set to true to skip PQTMSRR if the GNSS has been reset externally
+     * @return true when the device is erased and ready to receive firmware packets
+     */
+    bool updateFirmwareBegin(size_t firmwareSize, uint32_t firmwareCrc32, bool skipSoftwareReset = false);
+
+    /**
+     * @brief Feed the next chunk of firmware bytes to the module.
+     * @details Accumulates bytes into a 4096-byte buffer; sends a complete packet and waits
+     *          for ACK each time the buffer fills.
+     * @param data pointer to firmware bytes
+     * @param bytesToWrite number of bytes in data
+     * @return true on success, false on protocol error
+     */
+    bool updateFirmware(const uint8_t *data, size_t bytesToWrite);
+
+    /**
+     * @brief Flush any remaining buffered bytes as a final (partial) firmware packet.
+     * @return true if the last packet was accepted, false on error
+     */
+    bool updateFirmwareEnd();
+
+    /**
+     * @brief Send the firmware reset command then poll for up to 15 seconds for the module
+     *        to boot into the new firmware.
+     * @param maxWaitSeconds maximum number of seconds to wait for the module to respond
+     * @return true when the module responds to normal NMEA commands
+     */
+    bool updateFirmwareIsFinished(uint8_t maxWaitSeconds);
 };
 
 // Forward routine declarations

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -3716,4 +3716,177 @@ const char *lg290pGetNavModeNameFromModel(const uint8_t dynamicModel)
     return unknown;
 }
 
+//----------------------------------------
+// Reboot the module into bootloader mode, negotiate sync, query bootloader version,
+// send firmware metadata, and erase flash.
+//----------------------------------------
+bool GNSS_LG290P::updateFirmwareBegin(size_t fileBytes,
+                                      uint32_t firmwareCrc32,
+                                      bool skipSoftwareReset)
+{
+    if (_lg290p == nullptr)
+        return false;
+    return _lg290p->updateFirmwareBegin(fileBytes, firmwareCrc32, skipSoftwareReset);
+}
+
+//----------------------------------------
+// Feed the next chunk of firmware bytes to the module.
+//----------------------------------------
+bool GNSS_LG290P::updateFirmware(const uint8_t *data, size_t bytesToWrite)
+{
+    if (_lg290p == nullptr)
+        return false;
+    return _lg290p->updateFirmware(data, bytesToWrite);
+}
+
+//----------------------------------------
+// Flush any remaining buffered bytes as a final (partial) firmware packet.
+//----------------------------------------
+bool GNSS_LG290P::updateFirmwareEnd()
+{
+    if (_lg290p == nullptr)
+        return false;
+    return _lg290p->updateFirmwareEnd();
+}
+
+//----------------------------------------
+// Send the firmware reset command then poll for up to 15 seconds for the
+// module to boot into the new firmware.
+//----------------------------------------
+bool GNSS_LG290P::updateFirmwareIsFinished(uint8_t maxWaitSeconds)
+{
+    if (_lg290p == nullptr)
+        return false;
+    return _lg290p->updateFirmwareIsFinished(maxWaitSeconds);
+}
+
+//----------------------------------------
+// Put module into bootloader mode and prepare for firmware update
+//----------------------------------------
+bool lg290pFirmwareUpdateBegin(size_t fileBytes, uint32_t expectedCrc)
+{
+    if (productVariant == RTK_FACET_FP)
+        // We don't have hardware reset so use software reset.
+        // Begin update: reboot, sync, version, firmware info, erase (~30 s)
+        return (((GNSS_LG290P *)gnss)->updateFirmwareBegin(fileBytes, expectedCrc, false)); // Use software reset
+
+    // If a previous attempt failed, the device won't respond to software reset commands. Do a hardware reset.
+    gnssReset();
+    delay(100);
+    gnssBoot();
+
+    // Begin update: reboot, sync, version, firmware info, erase (~30 s)
+    return (((GNSS_LG290P *)gnss)->updateFirmwareBegin(fileBytes, expectedCrc, true)); // Skip software reset
+}
+
+//----------------------------------------
+// Given a chunk of bytes, feed the LG290P firmware update machine
+//----------------------------------------
+bool lg290pFirmwareUpdate(uint8_t *dataArray, uint16_t bytesToWrite, bool sendLastLine)
+{
+    if (sendLastLine == true)
+        return (((GNSS_LG290P *)gnss)->updateFirmwareEnd());
+
+    // Bytes will be aggregated into 4096 chunks, then written to the LG290P
+    return ((GNSS_LG290P *)gnss)->updateFirmware(dataArray, bytesToWrite);
+}
+
+//----------------------------------------
+// Wait for LG290P to reboot and respond to the PQTMUNIQID command
+//----------------------------------------
+bool lg290pFirmwareUpdateEnd()
+{
+    if (productVariant == RTK_FACET_FP)
+        return (((GNSS_LG290P *)gnss)->updateFirmwareIsFinished(30));
+
+    gnssReset();
+    delay(100);
+    gnssBoot();
+
+    return (((GNSS_LG290P *)gnss)->updateFirmwareIsFinished(10));
+}
+
+//----------------------------------------
+// Update the LG290P firmware
+//----------------------------------------
+bool lg290pStreamFirmware(NetworkClient * stream,
+                          size_t fileBytes,
+                          uint32_t expectedCrc,
+                          uint8_t * buffer,
+                          size_t bufferBytes)
+{
+    uint32_t crc = 0;
+
+    // Get the LG290P in a state to receive firmware updates
+    if (lg290pFirmwareUpdateBegin(fileBytes, expectedCrc) == false)
+    {
+        systemPrintln(otaEqualSigns);
+        systemPrintln("ERROR: Failed to erase LG290P flash!\r\n");
+        systemPrintln(otaEqualSigns);
+        return false;
+    }
+    systemPrintln("Starting LG290P firmware update...");
+    unsigned long lastDataTime = millis();
+    while (stream->connected() && (fileBytes > 0))
+    {
+        // Wait until some data is available
+        size_t availableBytes = stream->available();
+        if (availableBytes == 0)
+        {
+            if ((millis() - lastDataTime) > OTA_DATA_TIMEOUT)
+            {
+                systemPrintln("LG290P OTA update timed out waiting for data");
+                return false;
+            }
+            delay(1);
+            continue;
+        }
+
+        // Read the received data
+        size_t bytesToRead = (availableBytes > bufferBytes) ? bufferBytes : availableBytes;
+        int bytesRead = stream->readBytes(buffer, bytesToRead);
+        if (bytesRead <= 0)
+            continue;
+
+        // Compute the CRC
+        crc = crc32Compute(crc, buffer, bytesRead);
+
+        // Validate the computed CRC matches the expected CRC
+        bool lastPacket = (fileBytes == bytesRead);
+        if (lastPacket && (crc != expectedCrc))
+        {
+            systemPrintf("ERROR: File has changed, CRC does not match!\r\n");
+            break;
+        }
+
+        // Update this portion of the firmware
+        if (lg290pFirmwareUpdate(buffer, bytesRead, lastPacket) == false)
+        {
+            systemPrintln("LG290P OTA update failed during write");
+            return false;
+        }
+
+        // Account for this data
+        fileBytes -= bytesRead;
+        firmwareUpdateProgressCallback("LG290P", (uint16_t)bytesRead);
+        lastDataTime = millis();
+    }
+
+    systemPrintln(otaEqualSigns);
+    if (fileBytes > 0)
+    {
+        systemPrintln("LG290P OTA update failed during writeStream");
+        return false;
+    }
+
+    if (lg290pFirmwareUpdateEnd() == false)
+    {
+        systemPrintf("LG290P failed to reboot\r\n");
+        return false;
+    }
+    systemPrintln("LG290P update successfully completed.");
+    systemPrintln(otaEqualSigns);
+    return true;
+}
+
 #endif // COMPILE_LG290P

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -4299,7 +4299,7 @@ bool x20pStreamFirmware(char *relativeFirmwareFileLocation)
                     break;
                 }
 
-                firmwareUpdateProgressCallback(bytesRead);
+                firmwareUpdateProgressCallback("X20P", bytesRead);
 
                 if (contentLength > 0)
                     contentLength -= bytesRead;

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -4322,6 +4322,96 @@ bool x20pStreamFirmware(char *relativeFirmwareFileLocation)
 
     return updateOk;
 }
+
+//----------------------------------------
+// Update the X20P firmware
+// Owns the full update sequence: enters bootloader mode, streams the image
+// over WiFi, then verifies/reboots - callers only need to call this one
+// function and do not need to know about Begin()/End().
+//----------------------------------------
+bool x20pStreamFirmware(NetworkClient * stream,
+                        size_t fileBytes,
+                        uint32_t expectedCrc,
+                        uint8_t * buffer,
+                        size_t bufferBytes)
+{
+    uint32_t crc = 0;
+
+    systemPrintln("Starting X20P firmware update...");
+
+    // Stop tasks that absorb serial data from the GNSS
+    tasksStopGnssUart();
+
+    if (x20pFirmwareUpdateBegin() == false)
+    {
+        systemPrintln(otaEqualSigns);
+        systemPrintln("Failed to enter bootloader mode.");
+        systemPrintln(otaEqualSigns);
+        return false;
+    }
+    systemPrintln("Device is in bootloader mode.");
+
+    unsigned long lastDataTime = millis();
+    while (stream->connected() && (fileBytes > 0))
+    {
+        // Wait until some data is available
+        size_t available = stream->available();
+        if (available == 0)
+        {
+            if ((millis() - lastDataTime) > OTA_DATA_TIMEOUT)
+            {
+                systemPrintln("X20P OTA update timed out waiting for data");
+                return false;
+            }
+            delay(1);
+            continue;
+        }
+
+        // Read the received data
+        size_t toRead = min(available, sizeof(buffer));
+        int bytesRead = stream->readBytes(buffer, toRead);
+        if (bytesRead <= 0)
+            break;
+
+        // Compute the CRC
+        crc = crc32Compute(crc, buffer, bytesRead);
+
+        // Validate the computed CRC matches the expected CRC
+        bool lastPacket = (fileBytes == bytesRead);
+        if (lastPacket && (crc != expectedCrc))
+        {
+            systemPrintf("ERROR: File has changed, CRC does not match!\r\n");
+            break;
+        }
+
+        // Update this portion of the firmware
+        if (x20pUpdateFirmware(*serialGNSS, buffer, (uint32_t)bytesRead) == false)
+        {
+            systemPrintln("Firmware update failed during WiFi data upload.");
+            break;
+        }
+
+        // Account for this data
+        fileBytes -= bytesRead;
+        firmwareUpdateProgressCallback("X20P", bytesRead);
+        lastDataTime = millis();
+    }
+
+    systemPrintln(otaEqualSigns);
+    bool success = (fileBytes == 0);
+    if (success)
+        systemPrintln("X20P update successfully completed.");
+    else
+        systemPrintln("X20P firmware update failed.");
+    systemPrintln(otaEqualSigns);
+
+    // x20pFirmwareUpdateBegin() succeeded above, so End() must always run -
+    // it verifies (when success), frees the page buffer, and reboots the device.
+    systemPrintln("Rebooting receiver...");
+    bool updateOk = x20pFirmwareUpdateEnd(success);
+    return updateOk;
+}
+
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 // End of X20P firmware update functions.
 

--- a/Firmware/RTK_Everywhere/LoRa.ino
+++ b/Firmware/RTK_Everywhere/LoRa.ino
@@ -1670,13 +1670,13 @@ bool stm32UpdateFirmware(uint8_t *dataArray, uint16_t bytesToWrite)
     if (productVariant == RTK_TORCH)
     {
         muxSelectUsb();                               // Reconnect USB to print to terminal
-        firmwareUpdateProgressCallback(bytesToWrite); // Notify callback
+        firmwareUpdateProgressCallback("LoRa", bytesToWrite); // Notify callback
         Serial.flush();
         muxSelectLoRaCommunication(); // Disconnect USB, connect to LoRa
     }
     else
     {
-        firmwareUpdateProgressCallback(bytesToWrite); // Notify callback
+        firmwareUpdateProgressCallback("LoRa", bytesToWrite); // Notify callback
     }
     return true;
 }

--- a/Firmware/RTK_Everywhere/LoRa.ino
+++ b/Firmware/RTK_Everywhere/LoRa.ino
@@ -1517,7 +1517,7 @@ void loraProcessRTCM(uint8_t *rtcmData, uint16_t dataLength)
                     systemPrintln("loraProcessRTCM: RTCM for LoRa contains +++. Skipping...");
                 return;
             }
-            
+
             // Send this data to the LoRa radio
             systemFlush();                // Complete prints
 
@@ -1608,6 +1608,38 @@ void loraSharedPrintln(const char *toPrint)
     }
 }
 
+// Enable printfs to various endpoints
+// https://stackoverflow.com/questions/42131753/wrapper-for-printf
+void usbPrintf(const char *format, ...)
+{
+    va_list args;
+    va_list args2;
+
+    va_start(args, format);
+    va_copy(args2, args);
+    char buf[vsnprintf(nullptr, 0, format, args) + 1];
+    vsnprintf(buf, sizeof buf, format, args2);
+
+    // Connect UART 0 to the USB UART
+    if (productVariant == RTK_TORCH)
+    {
+        Serial.flush(); // Finishing any pending prints to before switching
+        muxSelectUsb(); // Reconnect USB to print to terminal
+    }
+
+    // Send the output to the USB UART
+    systemPrint(buf);
+    va_end(args);
+    va_end(args2);
+
+    // Connect UART 0 back to the LoRa
+    if (productVariant == RTK_TORCH)
+    {
+        Serial.flush();
+        muxSelectLoRaCommunication(); // Torch: Disconnect USB, connect to LoRa
+    }
+}
+
 void loraPrintf(const char *format, ...)
 {
     va_list args;
@@ -1665,7 +1697,7 @@ uint32_t stm32CurrentAddress = 0x08000000; // Next flash address to write; advan
 // flashed every time a full 256 byte page accumulates.
 bool stm32UpdateFirmware(uint8_t *dataArray, uint16_t bytesToWrite)
 {
-    stm32UpdatePageBuffer(dataArray, bytesToWrite);
+    bool success = stm32UpdatePageBuffer(dataArray, bytesToWrite);
 
     if (productVariant == RTK_TORCH)
     {
@@ -1678,7 +1710,7 @@ bool stm32UpdateFirmware(uint8_t *dataArray, uint16_t bytesToWrite)
     {
         firmwareUpdateProgressCallback("LoRa", bytesToWrite); // Notify callback
     }
-    return true;
+    return success;
 }
 
 // Helper to send STM32 commands and wait for ACK (0x79)
@@ -1799,7 +1831,10 @@ bool stm32UpdateFirmwareFlashBlock(uint32_t addr, uint8_t *data, uint16_t len)
     loraWrite(0x31);
     loraWrite(0xCE);
     if (stm32UpdateFirmwareWaitForAck() == false)
+    {
+        usbPrintf("Write memory command failed, addr: 0x%08x, len: 0x%04x\r\n", addr, len);
         return false;
+    }
 
     // Send Address + Checksum
     uint8_t addrBytes[4] = {(uint8_t)(addr >> 24), (uint8_t)(addr >> 16), (uint8_t)(addr >> 8), (uint8_t)addr};
@@ -1808,7 +1843,10 @@ bool stm32UpdateFirmwareFlashBlock(uint32_t addr, uint8_t *data, uint16_t len)
     loraWrite(checksum);
 
     if (stm32UpdateFirmwareWaitForAck() == false)
+    {
+        usbPrintf("Send address failed, addr: 0x%08x, len: 0x%04x\r\n", addr, len);
         return false;
+    }
 
     // Send Number of bytes - 1 (STM32 protocol requirement)
     uint8_t n = len - 1;
@@ -1821,7 +1859,12 @@ bool stm32UpdateFirmwareFlashBlock(uint32_t addr, uint8_t *data, uint16_t len)
     }
     loraWrite(checksum);
 
-    return stm32UpdateFirmwareWaitForAck();
+    if (stm32UpdateFirmwareWaitForAck() == false)
+    {
+        usbPrintf("Send bytes failed, addr: 0x%08x, len: 0x%04x\r\n", addr, len);
+        return false;
+    }
+    return true;
 }
 
 // Add data to the stm32PageBuffer. Write to STM32 when we hit 256 bytes.
@@ -1874,6 +1917,84 @@ bool stm32UpdateFirmwareEnd()
 
     loraExitBootloader(); // Disables BOOT pin, then resets the STM32
 
+    return success;
+}
+
+//----------------------------------------
+// Update the STM32 firmware
+//----------------------------------------
+bool stm32StreamFirmware(NetworkClient * stream,
+                         size_t fileBytes,
+                         uint32_t expectedCrc,
+                         uint8_t * buffer,
+                         size_t bufferBytes)
+{
+    uint32_t crc = 0;
+
+    muxSelectLoRaCommunication(); // Mandatory for Torch: Connect ESP32 to LoRa for communication
+
+    loraSharedPrintln("Starting LoRa/STM32 firmware update...");
+
+    if (stm32UpdateFirmwareBegin() == false)
+    {
+        loraSharedPrintln(otaEqualSigns);
+        loraSharedPrintln("LoRa/STM32 update failed.");
+        loraSharedPrintln(otaEqualSigns);
+        return false;
+    }
+
+    unsigned long lastDataTime = millis();
+    while (stream->connected() && (fileBytes > 0))
+    {
+        // Wait until some data is available
+        size_t available = stream->available();
+        if (available == 0)
+        {
+            if ((millis() - lastDataTime) > OTA_DATA_TIMEOUT)
+            {
+                systemPrintln("LoRa OTA update timed out waiting for data");
+                return false;
+            }
+            delay(1);
+            continue;
+        }
+
+        // Read the received data
+        size_t toRead = min(available, sizeof(buffer));
+        int bytesRead = stream->readBytes(buffer, toRead);
+        if (bytesRead <= 0)
+            break;
+
+        // Compute the CRC
+        crc = crc32Compute(crc, buffer, bytesRead);
+
+        // Validate the computed CRC matches the expected CRC
+        if ((bytesRead >= fileBytes) && (crc != expectedCrc))
+        {
+            systemPrintf("ERROR: File has changed, CRC does not match!\r\n");
+            break;
+        }
+
+        // Update this portion of the firmware
+        if (stm32UpdateFirmware(buffer, (uint16_t)bytesRead) == false)
+        {
+            loraSharedPrintln("LoRa/STM32 update failed during WiFi data upload.");
+            break;
+        }
+
+        // Account for this data
+        fileBytes -= bytesRead;
+        firmwareUpdateProgressCallback("LoRa/STM32", bytesRead);
+        lastDataTime = millis();
+    }
+
+    loraSharedPrintln(otaEqualSigns);
+    bool success = (fileBytes == 0) && stm32UpdateFirmwareEnd();
+    if (success)
+        loraSharedPrintln("LoRa/STM32 updated successfully.");
+    else
+        loraSharedPrintln("LoRa/STM32 update failed.");
+    loraSharedPrintln(otaEqualSigns);
     return success;
 }
 

--- a/Firmware/RTK_Everywhere/NVM.ino
+++ b/Firmware/RTK_Everywhere/NVM.ino
@@ -72,6 +72,9 @@ const uint32_t nvmCrc32Polynomial = 0x04c11db7;
 
 const char * nvmSettingsFileHasCrc = "settingsFileHasCrc";
 
+#define NVM_SETTING_NAME_LENGTH     64
+#define NVM_LINE_LENGTH             192
+
 //----------------------------------------
 // Locals
 //----------------------------------------
@@ -133,6 +136,12 @@ bool loadSettingsUsingTempSetting(bool startFromDefault)
     // This will fail if LFS has been erased, a read error occurs or the file is
     // corrupt.
     loadSuccessful = loadSystemSettingsFromFileLFS(settingsFileName, tempSettings);
+    if ((loadSuccessful == false) && (settings.debugSettings == false))
+    {
+        settings.debugSettings = true;
+        loadSystemSettingsFromFileLFS(settingsFileName, tempSettings);
+        settings.debugSettings = false;
+    }
     if (settingsAllocated)
     {
         if (loadSuccessful)
@@ -153,6 +162,12 @@ bool loadSettingsUsingTempSetting(bool startFromDefault)
     // Load the settings from the SD card
     // This will fail if no SD is present. That's OK.
     loadSuccessful = loadSystemSettingsFromFileSD(settingsFileName, tempSettings);
+    if ((loadSuccessful == false) && (settings.debugSettings == false))
+    {
+        settings.debugSettings = true;
+        loadSystemSettingsFromFileSD(settingsFileName, tempSettings);
+        settings.debugSettings = false;
+    }
     if (settingsAllocated)
     {
         // Update the settings with the values read from the SD card
@@ -397,6 +412,12 @@ void loadSettingsPartial()
     // This will fail if LFS has been erased, a read error occurs or the file is
     // corrupt.
     loadSuccessful = loadSystemSettingsFromFileLFS(settingsFileName, tempSettings);
+    if ((loadSuccessful == false) && (settings.debugSettings == false))
+    {
+        settings.debugSettings = true;
+        loadSystemSettingsFromFileLFS(settingsFileName, tempSettings);
+        settings.debugSettings = false;
+    }
     if (settingsAllocated)
     {
         // Update the settings with the values read from NVM
@@ -996,6 +1017,13 @@ bool loadSystemSettingsFromFileSD(char *fileName,
                         // parse each line and load into settings
                         if (parseLine(line, tempSettings) == false)
                         {
+                            // Debug the parse failure
+                            if (settings.debugSettings == false)
+                            {
+                                settings.debugSettings = true;
+                                parseLine(line, tempSettings);
+                                settings.debugSettings = false;
+                            }
                             line[strlen(line) - 1] = 0; // Remove \n for printing
                             systemPrintf("Failed to parse SD:%s line %d: %s\r\n", fileName, lineNumber, line);
                             if (lineNumber == 0)
@@ -1185,6 +1213,13 @@ bool loadSystemSettingsFromFileLFS(char *fileName,
                 // parse each line and load into settings
                 if (parseLine(line, tempSettings) == false)
                 {
+                    // Debug the parse failure
+                    if (settings.debugSettings == false)
+                    {
+                        settings.debugSettings = true;
+                        parseLine(line, tempSettings);
+                        settings.debugSettings = false;
+                    }
                     line[strlen(line) - 1] = 0; // Remove \n for printing
                     systemPrintf("Failed to parse LFS:%s line %d: %s\r\n", fileName, lineNumber, line);
                     if (lineNumber == 0)
@@ -1295,7 +1330,7 @@ bool printSystemSettingsFromFileLFS(char *fileName)
         return (false);
     }
 
-    char line[100];
+    char line[NVM_LINE_LENGTH];
     int lineNumber = 0;
     bool status = true; // File is open. Default status to true
 
@@ -1365,8 +1400,8 @@ bool printSystemSettingsFromFileLFS(char *fileName)
 bool parseLine(const char *theLine, struct Settings * tempSettings)
 {
     // Make a copy. Manipulate the copy, not the original
-    size_t strLen = strnlen(theLine, 100);
-    if (strLen == 100)
+    size_t strLen = strnlen(theLine, NVM_LINE_LENGTH + NVM_SETTING_NAME_LENGTH);
+    if (strLen == (NVM_LINE_LENGTH + NVM_SETTING_NAME_LENGTH))
     {
         if (settings.debugSettings)
             systemPrintln("parseLine: line too long");
@@ -1394,11 +1429,11 @@ bool parseLine(const char *theLine, struct Settings * tempSettings)
     }
 
     // Store this setting name
-    char settingName[100];
+    char settingName[NVM_SETTING_NAME_LENGTH];
     snprintf(settingName, sizeof(settingName), "%s", strPtr);
 
     double d = 0.0;
-    char settingString[100] = "";
+    char settingString[NVM_LINE_LENGTH] = "";
 
     // Move pointer past where the = was
     strPtr = strtok_r(nullptr, "\n", &preservedPointer); // This will blow the \n away
@@ -2785,4 +2820,11 @@ void nvmVerifySdFileCrc(const char * fileName)
         endSD(gotSemaphore, true);
     else if (gotSemaphore)
         xSemaphoreGive(sdCardSemaphore);
+}
+
+void nvmVerifyTables()
+{
+    // Verify the line length in the settings files
+    if (NVM_LINE_LENGTH < OTA_FIRMWARE_CSV_URL_LENGTH)
+        reportFatalError("Increase NVM_LINE_LENGTH to >= OTA_FIRMWARE_CSV_URL_LENGTH\r\n");
 }

--- a/Firmware/RTK_Everywhere/OTA.h
+++ b/Firmware/RTK_Everywhere/OTA.h
@@ -40,6 +40,10 @@ enum OTA_FIRMWARE_UPDATE_REQUEST
 #define OTA_DEVICE_LORA         (1 << OTA_SUBSYSTEM_LORA)
 #define OTA_DEVICE_IMU          (1 << OTA_SUBSYSTEM_IMU)
 
+#define OTA_DATA_TIMEOUT        (15 * MILLISECONDS_IN_A_SECOND)
+
+const char * otaEqualSigns = "==================================================";
+
 const char * csvUrl = "https://raw.githubusercontent.com/sparkfun/SparkFun_RTK_Everywhere_Firmware_Binaries/main/RTK-Everywhere-Variants.csv";
 const char * csvCert = GITHUB_RAW_PUBLIC_CERT;
 
@@ -55,13 +59,18 @@ bool otaDebugVerbose;
 
 typedef uint8_t OTA_SUBSYSTEM_MASK;
 
+typedef bool (*OTA_FIRMWARE_UPDATE)(const struct _OTA_TARGET * target,
+                                    const struct _OTA_SUBSYSTEM_INFO * subsystemInfo,
+                                    uint8_t * buffer,
+                                    size_t bufferBytes);
 typedef bool (*OTA_GET_VERSION)(int &major,
                                 int &minor,
                                 int &patch,
                                 int &revision,
                                 int &releaseCandidate);
-typedef bool (*OTA_STREAM_FIRMWARE)(NetworkClient * client,
+typedef bool (*OTA_STREAM_FIRMWARE)(NetworkClient * stream,
                                     size_t contentLength,
+                                    uint32_t expectedCrc,
                                     uint8_t * buffer,
                                     size_t bufferBytes);
 
@@ -71,6 +80,7 @@ typedef struct _OTA_SUBSYSTEM_INFO
     uint8_t _subsystem;
     const bool * _present;
     OTA_GET_VERSION _getVersion;
+    OTA_FIRMWARE_UPDATE _firmwareUpdate;
     OTA_STREAM_FIRMWARE _streamFirmware;
     size_t _packetBytes;
     bool _rcSupport;

--- a/Firmware/RTK_Everywhere/OTA.h
+++ b/Firmware/RTK_Everywhere/OTA.h
@@ -75,7 +75,6 @@ typedef struct _OTA_SUBSYSTEM_INFO
     size_t _packetBytes;
     bool _rcSupport;
     const char * _directory;
-    const char * _cert;     // Certificate for the server
     const char * _server;   // Server name
     const char * _branch;   // Branch name
 } OTA_SUBSYSTEM_INFO;
@@ -90,7 +89,6 @@ extern const int otaSubsystemInfoTableEntries;
 typedef struct _OTA_TARGET
 {
     char * _url;            // URL built from file name or URL in CSV file
-    const char * _cert;     // Certificate for the web server
     size_t _fileBytes;      // File size
     uint32_t _crc;          // CRC
     uint8_t _requestType;   // Type of request for this subssystem

--- a/Firmware/RTK_Everywhere/OTA.h
+++ b/Firmware/RTK_Everywhere/OTA.h
@@ -44,14 +44,12 @@ enum OTA_FIRMWARE_UPDATE_REQUEST
 
 const char * otaEqualSigns = "==================================================";
 
-const char * csvUrl = "https://raw.githubusercontent.com/sparkfun/SparkFun_RTK_Everywhere_Firmware_Binaries/main/RTK-Everywhere-Variants.csv";
-const char * csvCert = GITHUB_RAW_PUBLIC_CERT;
-
 //----------------------------------------
 // Globals
 //----------------------------------------
 
 bool otaDebugVerbose;
+char otaFirmwareCsvUrl[OTA_FIRMWARE_CSV_URL_LENGTH];
 
 //----------------------------------------
 // Subsystem support

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -734,8 +734,10 @@ void otaMenuDisplay(OTA_SUBSYSTEM_MASK platformDevices,
 {
     bool developerOptions = *developerOptionsAddr;
     OTA_SUBSYSTEM_MASK productSubsystems = otaGetProductSubsystemSupport();
+    bool targetsValid;
 
     // Initialize the OTA targets
+    targetsValid = true;
     for (int subsystem = 0; subsystem < OTA_SUBSYSTEM_MAX; subsystem++)
     {
         if (otaTarget[subsystem]._valid == false)
@@ -745,8 +747,13 @@ void otaMenuDisplay(OTA_SUBSYSTEM_MASK platformDevices,
             else
                 otaTarget[subsystem]._requestType = OTA_REQUEST_SKIP_UPDATE;
             otaTarget[subsystem]._valid = true;
+            if (platformDevices & otaGetSubsystemMaskFromSubsystem(subsystem))
+                targetsValid = false;
         }
     }
+
+    // Display the targets
+    otaDisplayTargets();
 
     // Automatic firmware updates
     systemPrintf("a) Automatic firmware updates: %s\r\n", settings.enableAutoFirmwareUpdate ? "Enabled" : "Disabled");
@@ -789,6 +796,7 @@ void otaMenuDisplay(OTA_SUBSYSTEM_MASK platformDevices,
     {
         systemPrintf("r) Change RC Firmware JSON URL: %s\r\n", otaRcFirmwareJsonUrl);
         systemPrintf("s) Change Firmware JSON URL: %s\r\n", otaFirmwareJsonUrl);
+        systemPrintf("S) Change Firmware CSV URL: %s\r\n", settings.csvUrl);
     }
 
     // Allow user to initiate a firmware update without checking for new firmware first
@@ -926,6 +934,16 @@ bool otaMenuProcessInput(OTA_SUBSYSTEM_MASK platformDevices,
         systemPrint("Enter Firmware JSON URL (empty to use default): ");
         memset(otaFirmwareJsonUrl, 0, sizeof(otaFirmwareJsonUrl));
         getUserInputString(otaFirmwareJsonUrl, sizeof(otaFirmwareJsonUrl) - 1);
+    }
+
+    // Set the CSV URL
+    else if ((incoming == 'S') && developerOptions)
+    {
+        systemPrint("Enter Firmware CSV URL (empty to use default): ");
+        memset(settings.csvUrl, 0, sizeof(settings.csvUrl));
+        getUserInputString(settings.csvUrl, sizeof(settings.csvUrl) - 1);
+        if (strlen(settings.csvUrl) == 0)
+            strcpy(settings.csvUrl, OTA_FIRMWARE_CSV_URL);
     }
 
     else if (incoming == 'u')
@@ -1111,8 +1129,8 @@ void otaUpdate()
                 systemPrintln("Creating list of subsystems to update");
 
             // Get CVS file listing the firmware for this system
-            cert = otaGetCert(csvUrl);
-            if (csvOpenCsvFile(csvUrl,
+            cert = otaGetCert(settings.csvUrl);
+            if (csvOpenCsvFile(settings.csvUrl,
                                cert,
                                &otaCsvFileData,
                                &fileBytes,

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -56,6 +56,7 @@ const char * otaRawBranch = "/main";
 static uint8_t * otaCsvFileData;
 static uint32_t otaLastUpdateCheck;
 static uint8_t otaState;
+static OTA_SUBSYSTEM_MASK otaUpdatesFound;
 
 //----------------------------------------
 // Cleanup after running the updates
@@ -68,6 +69,7 @@ void otaCleanup(bool keepTargets)
     if (keepTargets == false)
     {
         // Release the targets
+        otaUpdatesFound = 0;
         for (int subsysstemIndex = 0; subsysstemIndex < OTA_SUBSYSTEM_MAX; subsysstemIndex++)
         {
             target = &otaTarget[subsysstemIndex];
@@ -174,7 +176,6 @@ void otaDisplayTarget(OTA_TARGET * target)
                      target->_remoteVersion[2], target->_remoteVersion[3],
                      target->_remoteVersion[4] ? " (debug build)" : "");
     systemPrintln();
-    systemPrintf("Cert: %s\r\n", getCertName(target->_cert));
     systemPrintf("URL: %s\r\n", target->_url ? target->_url : "None");
     if ((target->_requestType != OTA_REQUEST_SKIP_UPDATE) && target->_url)
     {
@@ -292,12 +293,12 @@ uint8_t otaGetRequestTypeFromSubsystem(uint8_t subsystem)
 //----------------------------------------
 // Get the required updates
 //----------------------------------------
-bool otaGetRequiredUpdates(const char * fileData,
-                           size_t fileBytes,
-                           int fieldCount,
-                           int lineCount,
-                           bool debug,
-                           bool verbose)
+OTA_SUBSYSTEM_MASK otaGetRequiredUpdates(const char * fileData,
+                                         size_t fileBytes,
+                                         int fieldCount,
+                                         int lineCount,
+                                         bool debug,
+                                         bool verbose)
 {
     const char * buffer;
     const char * bufferEnd;
@@ -313,12 +314,11 @@ bool otaGetRequiredUpdates(const char * fileData,
     int revision;
     const char * subsystem;
     OTA_TARGET * target;
-    bool urlSet;
+    OTA_SUBSYSTEM_MASK updatesFound;
     int versionDelta;
 
     // Walk the list of subsystems
-    urlSet = false;
-    otaTargetCount = 0;
+    updatesFound = 0;
     for (int8_t subsystemIndex = 0; subsystemIndex < OTA_SUBSYSTEM_MAX; subsystemIndex++)
     {
         productSubsystem = otaSubsystem[subsystemIndex];
@@ -383,10 +383,10 @@ bool otaGetRequiredUpdates(const char * fileData,
                             systemPrintf("%s release candidate firmware found\r\n", subsystem);
 
                         // Save the URL for the update
-                        otaGetUrlAndCert(target, subsystemInfo, csvGetField(fileData,
-                                                                            fieldCount,
-                                                                            buffer,
-                                                                            "file_name"));
+                        otaGetUrl(target, subsystemInfo, csvGetField(fileData,
+                                                                     fieldCount,
+                                                                     buffer,
+                                                                     "file_name"));
                         target->_fileBytes = csvGetNumber(fileData, fieldCount, buffer, "file_bytes");
                         target->_crc = csvGetNumber(fileData, fieldCount, buffer, "file_crc32");
 
@@ -396,7 +396,7 @@ bool otaGetRequiredUpdates(const char * fileData,
                         target->_remoteVersion[2] = patch;
                         target->_remoteVersion[3] = revision;
                         target->_remoteVersion[4] = releaseCandidate;
-                        urlSet = true;
+                        updatesFound |= otaGetSubsystemMaskFromSubsystem(subsystemInfo->_subsystem);
                         break;
                     }
                     if (debug && verbose)
@@ -475,12 +475,13 @@ bool otaGetRequiredUpdates(const char * fileData,
             if (target->_requestType != OTA_REQUEST_SKIP_UPDATE)
             {
                 // Save the URL for the update
-                otaGetUrlAndCert(target, subsystemInfo, csvGetField(fileData,
-                                                                    fieldCount,
-                                                                    buffer,
-                                                                    "file_name"));
+                otaGetUrl(target, subsystemInfo, csvGetField(fileData,
+                                                             fieldCount,
+                                                             buffer,
+                                                             "file_name"));
                 target->_fileBytes = csvGetNumber(fileData, fieldCount, buffer, "file_bytes");
                 target->_crc = csvGetNumber(fileData, fieldCount, buffer, "file_crc32");
+                updatesFound |= otaGetSubsystemMaskFromSubsystem(subsystemInfo->_subsystem);
             }
 
             // Save the new firmware version
@@ -489,10 +490,9 @@ bool otaGetRequiredUpdates(const char * fileData,
             target->_remoteVersion[2] = patch;
             target->_remoteVersion[3] = revision;
             target->_remoteVersion[4] = releaseCandidate;
-            urlSet = true;
         }
     }
-    return urlSet;
+    return updatesFound;
 }
 
 //----------------------------------------
@@ -538,22 +538,31 @@ OTA_SUBSYSTEM_MASK otaGetSubsystemMaskFromSubsystem(uint8_t subsystem)
 //----------------------------------------
 // Get the URL and CERT for the link in the CSV file
 //----------------------------------------
-void otaGetUrlAndCert(OTA_TARGET * target,
-                      const OTA_SUBSYSTEM_INFO * subsystemInfo,
-                      const char * fileName)
+void otaGetUrl(OTA_TARGET * target,
+               const OTA_SUBSYSTEM_INFO * subsystemInfo,
+               const char * fileName)
 {
     char * buffer;
     const char * cert;
     const char * url;
     String urlString;
 
-    cert = nullptr;
+    // Free any previous URL value
+    if (target->_url)
+    {
+        rtkFree(target->_url, "Target URL");
+        target->_url = nullptr;
+    }
+
+    // Handle CSV file without file_name field
+    if (fileName == nullptr)
+        return;
+
+    // Determine the new value
     if ((strncmp("http:", fileName, 5) == 0) || (strncmp("https:", fileName, 6) == 0))
-        url = fileName;
+        urlString = fileName;
     else
     {
-        target->_cert = subsystemInfo->_cert;
-
         // https://raw.githubusercontent.com/sparkfun/SparkFun_RTK_Everywhere_Firmware_Binaries
         // /main
         // /imu/im19
@@ -566,15 +575,19 @@ void otaGetUrlAndCert(OTA_TARGET * target,
         urlString += subsystemInfo->_directory;
         urlString += "/";
         urlString += fileName;
-
-        // Allocate a buffer for the URL
-        buffer = (char *)rtkMalloc(urlString.length() + 1, "Target URL");
-        target->_url = buffer;
-        if (buffer == nullptr)
-            systemPrintf("Failed to allocate URL buffer for %s\r\n", otaSubsystem[subsystemInfo->_subsystem]);
-        else
-            strcpy(buffer, urlString.c_str());
     }
+
+    // Allocate a buffer for the URL
+    buffer = (char *)rtkMalloc(urlString.length() + 1, "Target URL");
+    if (buffer == nullptr)
+    {
+        systemPrintf("Failed to allocate URL buffer for %s\r\n", otaSubsystem[subsystemInfo->_subsystem]);
+        return;
+    }
+
+    // Save the URL value
+    strcpy(buffer, urlString.c_str());
+    target->_url = buffer;
 }
 
 //----------------------------------------
@@ -800,12 +813,12 @@ const char *otaStateNameGet(uint8_t state, char *string)
 //----------------------------------------
 void otaUpdate()
 {
+    const char * cert;
     bool connected;
     static uint32_t connectTimer = 0;
-    size_t fileBytes;
     int fieldCount;
+    size_t fileBytes;
     int lineCount;
-    bool updatesFound;
 
     // Check if we need a scheduled check
     connected = networkConsumerIsConnected(NETCONSUMER_OTA_CLIENT);
@@ -903,8 +916,9 @@ void otaUpdate()
                 systemPrintln("Creating list of subsystems to update");
 
             // Get CVS file listing the firmware for this system
-            if (csvOpenCsvFile(csvUrl,
-                               nullptr,
+            cert = otaGetCert(settings.csvUrl);
+            if (csvOpenCsvFile(settings.csvUrl,
+                               cert,
                                &otaCsvFileData,
                                &fileBytes,
                                &fieldCount,
@@ -925,17 +939,18 @@ void otaUpdate()
             // Reduce this list based upon the requested updates, version
             // number checks and the order of entries found in the CSV file
             // to a list of URLs
-            updatesFound = otaGetRequiredUpdates((const char *)otaCsvFileData,
-                                                 fileBytes,
-                                                 fieldCount,
-                                                 lineCount,
-                                                 settings.debugFirmwareUpdate,
-                                                 otaDebugVerbose);
+            otaUpdatesFound = otaGetRequiredUpdates((const char *)otaCsvFileData,
+                                                    fileBytes,
+                                                    fieldCount,
+                                                    lineCount,
+                                                    settings.debugFirmwareUpdate,
+                                                    otaDebugVerbose);
+
             // Display the targets
             otaDisplayTargets();
 
             // Done if no updates found
-            if (updatesFound == false)
+            if (otaUpdatesFound == 0)
             {
                 // Nothing to update
                 if (settings.debugFirmwareUpdate)
@@ -1206,32 +1221,32 @@ void otaVerifyTables()
 // OTA product subsystem support table
 extern const OTA_SUBSYSTEM_INFO otaSubsystemInfoTable[] =
 {
-    // Variant      subsystem               present                 getVersion          streamFirmware          packetBytes         rcSupport   directory          certificate     server          branch
-    {RTK_ALL,       OTA_SUBSYSTEM_ESP32,    nullptr,                otaEsp32GetVersion, nullptr,                OTA_BUFFER_BYTES,   true,       "",                otaGhRawCert,   otaGithubRaw,   otaRawBranch},
+    // Variant      subsystem               present                 getVersion          streamFirmware          packetBytes         rcSupport   directory          server          branch
+    {RTK_ALL,       OTA_SUBSYSTEM_ESP32,    nullptr,                otaEsp32GetVersion, nullptr,                OTA_BUFFER_BYTES,   true,       "",                otaGithubRaw,   otaRawBranch},
 
     // GNSS devices
 #ifdef  COMPILE_LG290P
-    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_lg290p,   gnssGetVersion,     nullptr,                256,                false,      "/gnss/lg290p",    otaGhRawCert,   otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_lg290p,   gnssGetVersion,     nullptr,                256,                false,      "/gnss/lg290p",    otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_LG290P
 #ifdef  COMPILE_MOSAICX5
-    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_mosaicX5, gnssGetVersion,     nullptr,                256,                false,      "/gnss/mosaic-x5", otaGhRawCert,   otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_mosaicX5, gnssGetVersion,     nullptr,                256,                false,      "/gnss/mosaic-x5", otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_MOSAICX5
 #ifdef  COMPILE_UM980
-    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_um980,    gnssGetVersion,     nullptr,                256,                false,      "/gnss/um980",     otaGhRawCert,   otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_um980,    gnssGetVersion,     nullptr,                256,                false,      "/gnss/um980",     otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_UM980
 #ifdef  COMPILE_ZED
-    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_zedf9p,   gnssGetVersion,     nullptr,                256,                false,      "/gnss/zed-f9p",   otaGhRawCert,   otaGithubRaw,   otaRawBranch},
-    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_zedx20p,  gnssGetVersion,     nullptr,                256,                false,      "/gnss/zed-x20p",  otaGhRawCert,   otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_zedf9p,   gnssGetVersion,     nullptr,                256,                false,      "/gnss/zed-f9p",   otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_zedx20p,  gnssGetVersion,     nullptr,                256,                false,      "/gnss/zed-x20p",  otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_ZED
 
     // LoRa devices
 #ifdef  COMPILE_LORA
-    {RTK_ALL,       OTA_SUBSYSTEM_LORA,     &present.radio_lora,    loraGetVersion,     nullptr,                256,                false,      "lora/stm32wl",    otaGhRawCert,   otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_LORA,     &present.radio_lora,    loraGetVersion,     nullptr,                256,                false,      "lora/stm32wl",    otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_LORA
 
     // IMU devices
 #ifdef  COMPILE_IM19_IMU
-    {RTK_ALL,       OTA_SUBSYSTEM_IMU,      &present.imu_im19,      tiltGetVersion,     nullptr,                256,                false,      "/imu/im19",       otaGhRawCert,   otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_IMU,      &present.imu_im19,      tiltGetVersion,     nullptr,                256,                false,      "/imu/im19",       otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_IM19_IMU
 };
 const int otaSubsystemInfoTableEntries = sizeof(otaSubsystemInfoTable)

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -1482,7 +1482,7 @@ extern const OTA_SUBSYSTEM_INFO otaSubsystemInfoTable[] =
 
     // LoRa devices
 #ifdef  COMPILE_LORA
-    {RTK_ALL,       OTA_SUBSYSTEM_LORA,     &present.radio_lora,    loraGetVersion,     nullptr,                nullptr,                256,                false,      "lora/stm32wl",    otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_LORA,     &present.radio_lora,    loraGetVersion,     nullptr,                stm32StreamFirmware,    256,                false,      "/lora/stm32wl",   otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_LORA
 
     // IMU devices

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -153,8 +153,48 @@ int otaCompareVersions(int localMajor, int localMinor, int localPatch, int local
 //----------------------------------------
 // Display the subsystem
 //----------------------------------------
+void otaDisplayTarget(OTA_TARGET * target)
+{
+    int subsystem = target - &otaTarget[0];
+
+    // Display the firmware update status for this subsystem
+    target = &otaTarget[subsystem];
+    systemPrintln("=================================================");
+    systemPrintf("%s: %s\r\n", otaSubsystem[subsystem],
+                 otaGetRequestNameFromRequestType(target->_requestType));
+
+    systemPrintf("%d.%d.%d.%d%s",
+                 target->_localVersion[0], target->_localVersion[1],
+                 target->_localVersion[2], target->_localVersion[3],
+                 target->_localVersion[4] ? " (debug build)" : "");
+
+    if ((target->_requestType != OTA_REQUEST_SKIP_UPDATE) && target->_url)
+        systemPrintf(" --> %d.%d.%d.%d%s",
+                     target->_remoteVersion[0], target->_remoteVersion[1],
+                     target->_remoteVersion[2], target->_remoteVersion[3],
+                     target->_remoteVersion[4] ? " (debug build)" : "");
+    systemPrintln();
+    systemPrintf("Cert: %s\r\n", getCertName(target->_cert));
+    systemPrintf("URL: %s\r\n", target->_url ? target->_url : "None");
+    if ((target->_requestType != OTA_REQUEST_SKIP_UPDATE) && target->_url)
+    {
+        systemPrintf("File bytes: %d (0x%08x)\r\n", target->_fileBytes, target->_fileBytes);
+        systemPrintf("CRC: 0x%08x\r\n", target->_crc);
+    }
+    if (settings.debugFirmwareUpdate && otaDebugVerbose)
+    {
+        systemPrintf("subsystem; %p\r\n", subsystem);
+        systemPrintf("target; %p\r\n", target);
+        systemPrintf("subsystemInfo; %p\r\n", &otaSubsystemInfoTable[subsystem]);
+    }
+}
+
+//----------------------------------------
+// Display the subsystem
+//----------------------------------------
 void otaDisplayTargets()
 {
+    bool displayed;
     OTA_SUBSYSTEM_MASK productSubsystems;
     OTA_TARGET * target;
 
@@ -163,39 +203,25 @@ void otaDisplayTargets()
         return;
 
     // Display each of the targets for this platform
+    displayed = false;
     productSubsystems = otaGetProductSubsystemSupport();
     for (int subsystem = 0; subsystem < OTA_SUBSYSTEM_MAX; subsystem++)
     {
         if ((productSubsystems & otaGetSubsystemMaskFromSubsystem(subsystem)) == 0)
             continue;
 
-        // Display the firmware update status for this subsystem
+        // Skip over invalid entries
         target = &otaTarget[subsystem];
-        systemPrintln("=================================================");
-        systemPrintf("%s: %s\r\n", otaSubsystem[subsystem],
-                     otaGetRequestNameFromRequestType(target->_requestType));
+        if ((target->_url == nullptr) && (target->_requestType != OTA_REQUEST_SKIP_UPDATE))
+            continue;
 
-        systemPrintf("%d.%d.%d.%d%s",
-                     target->_localVersion[0], target->_localVersion[1],
-                     target->_localVersion[2], target->_localVersion[3],
-                     target->_localVersion[4] ? " (debug build)" : "");
-
-        if ((target->_requestType != OTA_REQUEST_SKIP_UPDATE) && target->_url)
-            systemPrintf(" --> %d.%d.%d.%d%s",
-                         target->_remoteVersion[0], target->_remoteVersion[1],
-                         target->_remoteVersion[2], target->_remoteVersion[3],
-                         target->_remoteVersion[4] ? " (debug build)" : "");
-        systemPrintln();
-        systemPrintf("Cert: %s\r\n", getCertName(target->_cert));
-        systemPrintf("URL: %s\r\n", target->_url ? target->_url : "None");
-        if ((target->_requestType != OTA_REQUEST_SKIP_UPDATE) && target->_url)
-        {
-            systemPrintf("File bytes: %d (0x%08x)\r\n", target->_fileBytes, target->_fileBytes);
-            systemPrintf("CRC: 0x%08x\r\n", target->_crc);
-        }
+        // Display the firmware update status for this subsystem
+        otaDisplayTarget(&otaTarget[subsystem]);
+        displayed = true;
     }
 
-    systemPrintln("=================================================");
+    if (displayed)
+        systemPrintln("=================================================");
 }
 
 //----------------------------------------

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -661,7 +661,12 @@ bool otaMenuProcessInput(OTA_SUBSYSTEM_MASK platformDevices,
         // Set the next value for this subsystem
         uint8_t subsystemIndex = incoming - 1;
         OTA_TARGET * target = &otaTarget[subsystemIndex];
+        const OTA_SUBSYSTEM_INFO * subsystemInfo = &otaSubsystemInfoTable[subsystemIndex];
         target->_requestType += 1;
+
+        // Skip release candidate if not supported
+        if ((target->_requestType == OTA_REQUEST_USE_RC) && !subsystemInfo->_rcSupport)
+            target->_requestType += 1;
 
         // Wrap the value as necessary
         if (target->_requestType >= (OTA_REQUEST_MAX - 1))

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -669,7 +669,7 @@ bool otaMenuProcessInput(OTA_SUBSYSTEM_MASK platformDevices,
             target->_requestType += 1;
 
         // Wrap the value as necessary
-        if (target->_requestType >= (OTA_REQUEST_MAX - 1))
+        if (target->_requestType >= OTA_REQUEST_MAX)
             target->_requestType = 0;
     }
 

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -23,6 +23,8 @@ enum OtaState
     OTA_STATE_UPDATE_FIRMWARE_MX5,
     OTA_STATE_UPDATE_FIRMWARE_X20P,
     OTA_STATE_UPDATE_FIRMWARE_ESP,
+    OTA_STATE_UPDATE_FIRMWARE,
+    OTA_STATE_REBOOT,
 
     // Add new states here
     OTA_STATE_MAX
@@ -37,7 +39,9 @@ static const char *const otaStateNames[] = {"OTA_STATE_OFF",
                                             "OTA_STATE_UPDATE_FIRMWARE_LG290P",
                                             "OTA_STATE_UPDATE_FIRMWARE_MX5",
                                             "OTA_STATE_UPDATE_FIRMWARE_X20P",
-                                            "OTA_STATE_UPDATE_FIRMWARE_ESP32"};
+                                            "OTA_STATE_UPDATE_FIRMWARE_ESP32",
+                                            "OTA_STATE_UPDATE_FIRMWARE",
+                                            "OTA_STATE_REBOOT"};
 static const int otaStateEntries = sizeof(otaStateNames) / sizeof(otaStateNames[0]);
 
 static const char * const otaSubsystem[] = {"ESP32", "GNSS", "LoRa", "IMU"};
@@ -54,6 +58,7 @@ const char * otaRawBranch = "/main";
 //----------------------------------------
 
 static uint8_t * otaCsvFileData;
+static uint8_t * otaFirmwareBuffer;
 static uint32_t otaLastUpdateCheck;
 static uint8_t otaState;
 static OTA_SUBSYSTEM_MASK otaUpdatesFound;
@@ -68,6 +73,8 @@ void otaCleanup(bool keepTargets)
     // Keep the targets for configuration (web, serial, ...)
     if (keepTargets == false)
     {
+        csvCleanup(&otaCsvFileData);
+
         // Release the targets
         otaUpdatesFound = 0;
         for (int subsysstemIndex = 0; subsysstemIndex < OTA_SUBSYSTEM_MAX; subsysstemIndex++)
@@ -85,6 +92,12 @@ void otaCleanup(bool keepTargets)
         enableRCFirmware = false;
     }
 
+    // Release the firmware buffer
+    if (otaFirmwareBuffer)
+    {
+        rtkFree(otaFirmwareBuffer, "OTA firmware buffer");
+        otaFirmwareBuffer = nullptr;
+    }
     online.otaClient = false;
 }
 
@@ -150,6 +163,29 @@ int otaCompareVersions(int localMajor, int localMinor, int localPatch, int local
                      remoteMajor, remoteMinor, remotePatch, remoteRevision,
                      remoteReleaseCandidate ? " (debug build)" : "");
     return 0;
+}
+
+//----------------------------------------
+// Display the firmware update performance
+//----------------------------------------
+void otaDisplayPerformance(uint8_t subsystemIndex,
+                           uint32_t startMsec,
+                           uint32_t endMsec,
+                           size_t fileBytes)
+{
+    uint64_t bytesPerSecond;
+    uint32_t milliseconds;
+    uint32_t seconds;
+
+    milliseconds = endMsec - startMsec;
+    bytesPerSecond = 1000ull * fileBytes / milliseconds;
+    seconds = milliseconds / MILLISECONDS_IN_A_SECOND;
+    milliseconds -= seconds * MILLISECONDS_IN_A_SECOND;
+    systemPrintf("%s updated %d bytes in %d.%03d seconds with a rate of %lld bytes/second\r\n",
+                 otaSubsystem[subsystemIndex],
+                 fileBytes,
+                 seconds, milliseconds,
+                 bytesPerSecond);
 }
 
 //----------------------------------------
@@ -223,6 +259,97 @@ void otaDisplayTargets()
 
     if (displayed)
         systemPrintln("=================================================");
+}
+
+//----------------------------------------
+// Get the file from the web, and initiate firmware update
+//----------------------------------------
+bool otaFirmwareUpdate(const OTA_TARGET * target, const OTA_SUBSYSTEM_INFO * subsystemInfo)
+{
+    const char * cert;
+    size_t fileBytes;
+    HTTPClient * https;
+    NetworkClient * stream;
+    uint32_t startMsec;
+    int subsystemIndex;
+    bool success;
+
+    do
+    {
+        // Perform the update for the current target
+        subsystemIndex = subsystemInfo->_subsystem;
+
+        systemPrintf("Getting %s firmware file\r\n", otaSubsystem[subsystemIndex]);
+        String server = getServerFromUrl(target->_url);
+        cert = otaGetCert(target->_url);
+        if (openUrl(target->_url,
+                    cert,
+                    server,
+                    https,
+                    &fileBytes,
+                    &stream,
+                    &startMsec,
+                    settings.debugFirmwareUpdate) == false)
+        {
+            // Failed to open the URL
+            systemPrintln(otaEqualSigns);
+            systemPrintf("%s firmware update failed!\r\n", otaSubsystem[subsystemIndex]);
+            systemPrintln(otaEqualSigns);
+            break;
+        }
+
+        // Verify the file size
+        if ((fileBytes != target->_fileBytes) && (fileBytes != (size_t)-1))
+        {
+            // The file is different than advertized
+            systemPrintln(otaEqualSigns);
+            systemPrintf("ERROR: URL file size (%d) is different than CSV file size(%d)!\r\n",
+                         fileBytes, target->_fileBytes);
+            systemPrintln(otaEqualSigns);
+            break;
+        }
+
+        // Stream the firmware in chunks so we can report progress via
+        // firmwareUpdateProgressCallback() along the way.
+        firmwareUpdateBytesProcessed = 0;
+        firmwareUpdateBytesToProcess = fileBytes;
+
+        // Perform the update for the current target
+        systemPrintf("Updating %s\r\n", otaSubsystem[subsystemIndex]);
+        success = subsystemInfo->_streamFirmware(stream,
+                                                 target->_fileBytes,
+                                                 target->_crc,
+                                                 otaFirmwareBuffer,
+                                                 OTA_BUFFER_BYTES);
+        if ((success == false) && (subsystemIndex == OTA_SUBSYSTEM_ESP32))
+        {
+            webServerSendString((char *)"gettingNewFirmware,ERROR,");
+            commandSendExecuteErrorResponse((char *)"SPEXE", (char *)"UPDATEFIRMWARE", (char *)"OTA Error");
+            break;
+        }
+
+        // Display the performance
+        otaDisplayPerformance(subsystemIndex, startMsec, millis(), fileBytes);
+        return success;
+    } while (0);
+    return false;
+}
+
+//----------------------------------------
+// Determine the certificate that should be used with the URL
+//----------------------------------------
+const char * otaGetCert(const char * url)
+{
+    const char * cert;
+    const char * githubUserContent = "https://raw.githubusercontent.com/";
+
+    cert = nullptr;
+    if (url)
+    {
+        if (strncmp(url, githubUserContent, strlen(githubUserContent)) == 0)
+            cert = GITHUB_RAW_PUBLIC_CERT;
+    }
+    return cert;
 }
 
 //----------------------------------------
@@ -501,6 +628,14 @@ OTA_SUBSYSTEM_MASK otaGetRequiredUpdates(const char * fileData,
 const OTA_SUBSYSTEM_INFO * otaGetSubsystemInfo(uint8_t subsystem)
 {
     const OTA_SUBSYSTEM_INFO * subsystemInfo;
+
+    if (settings.debugFirmwareUpdate && otaDebugVerbose)
+    {
+        systemPrintf("Searching for productVariant: %d or All: %d\r\n",
+                     productVariant, RTK_ALL);
+        systemPrintf("Searching for subsystem: %d (%s)\r\n",
+                     subsystem, otaSubsystem[subsystem]);
+    }
 
     // Walk the device table
     for (int index = 0; index < otaSubsystemInfoTableEntries; index++)
@@ -818,7 +953,13 @@ void otaUpdate()
     static uint32_t connectTimer = 0;
     int fieldCount;
     size_t fileBytes;
+    OTA_SUBSYSTEM_MASK mask;
     int lineCount;
+    OTA_SUBSYSTEM_MASK productSubsystems;
+    int subsystemIndex;
+    const OTA_SUBSYSTEM_INFO * subsystemInfo;
+    const OTA_TARGET * target;
+    bool success;
 
     // Check if we need a scheduled check
     connected = networkConsumerIsConnected(NETCONSUMER_OTA_CLIENT);
@@ -916,8 +1057,8 @@ void otaUpdate()
                 systemPrintln("Creating list of subsystems to update");
 
             // Get CVS file listing the firmware for this system
-            cert = otaGetCert(settings.csvUrl);
-            if (csvOpenCsvFile(settings.csvUrl,
+            cert = otaGetCert(csvUrl);
+            if (csvOpenCsvFile(csvUrl,
                                cert,
                                &otaCsvFileData,
                                &fileBytes,
@@ -1035,6 +1176,106 @@ void otaUpdate()
 
                 otaUpdateStop(false);
             }
+            break;
+
+        case OTA_STATE_UPDATE_FIRMWARE:
+            // Allocate the firmware buffer
+            otaFirmwareBuffer = (uint8_t *)rtkMalloc(OTA_BUFFER_BYTES, "OTA firmware buffer");
+            if (settings.debugFirmwareUpdate && otaDebugVerbose)
+                systemPrintf("otaFirmwareBuffer: %p, bytes: %d\r\n",
+                              otaFirmwareBuffer, OTA_BUFFER_BYTES);
+            if (otaFirmwareBuffer == nullptr)
+            {
+                systemPrintf("ERROR: Failed to allocate the %d byte firmware data buffer\r\n", OTA_BUFFER_BYTES);
+                otaUpdateStop(false);
+                break;
+            }
+
+            online.otaClient = true;
+
+            success = true;
+            productSubsystems = otaGetProductSubsystemSupport();
+            for (subsystemIndex = OTA_SUBSYSTEM_MAX - 1; subsystemIndex >= 0; subsystemIndex--)
+            {
+                // Get the target and subsystemInfo
+                target = &otaTarget[subsystemIndex];
+                subsystemInfo = otaGetSubsystemInfo(subsystemIndex);
+                mask = otaGetSubsystemMaskFromSubsystem(subsystemIndex);
+
+                // Determine if the subsystem should be skipped
+                if ((productSubsystems & mask) == 0)
+                {
+                    if (settings.debugFirmwareUpdate && otaDebugVerbose)
+                    {
+                        systemPrintf("%s is not implemented in this product\r\n",
+                                     otaSubsystem[subsystemIndex]);
+
+                        // Display the subsystemInfo table
+                        for (int index = 0; index < otaSubsystemInfoTableEntries; index++)
+                        {
+                            subsystemInfo = &otaSubsystemInfoTable[index];
+                            systemPrintf("%s: variant: %d, directory: %s, present: %d\r\n",
+                                         otaSubsystem[subsystemInfo->_subsystem],
+                                         productVariant,
+                                         subsystemInfo->_directory,
+                                         subsystemInfo->_present ? *subsystemInfo->_present : 1);
+                        }
+                    }
+                    continue;
+                }
+
+                // Skip this update
+                if ((target->_requestType == OTA_REQUEST_SKIP_UPDATE)
+                    || (target->_url == nullptr))
+                    continue;
+
+                // Verify that at firmware update is supported for this subsystem
+                if ((subsystemInfo->_firmwareUpdate == nullptr)
+                    && (subsystemInfo->_streamFirmware == nullptr))
+                {
+                    systemPrintf("WARNING: Need to implement firmwareUpdate or streamFirmware support for %s!\r\n",
+                                 otaSubsystem[subsystemIndex]);
+                    continue;
+                }
+
+                // Perform the update for the current target
+                if (subsystemInfo->_firmwareUpdate == nullptr)
+                {
+                    if (settings.debugFirmwareUpdate && otaDebugVerbose)
+                        systemPrintf("%s is using _streamFirmware\r\n",
+                                     otaSubsystem[subsystemIndex]);
+                    success &= otaFirmwareUpdate(target, subsystemInfo);
+                }
+                else
+                {
+                    if (settings.debugFirmwareUpdate && otaDebugVerbose)
+                        systemPrintf("%s is calling _firmwareUpdate\r\n",
+                                     otaSubsystem[subsystemIndex]);
+                    uint32_t startMsec = millis();
+                    success &= subsystemInfo->_firmwareUpdate(target,
+                                                              subsystemInfo,
+                                                              otaFirmwareBuffer,
+                                                              OTA_BUFFER_BYTES);
+                    // Display the performance
+                    if (success)
+                        otaDisplayPerformance(subsystemIndex,
+                                              startMsec,
+                                              millis(),
+                                              target->_fileBytes);
+                }
+            }
+
+            // Update finished
+            otaSetState(OTA_STATE_REBOOT);
+
+            // Fall through
+            //      |
+            //      |
+            //      V
+
+        case OTA_STATE_REBOOT:
+            // Update finished
+            otaEsp32Reboot();
             break;
 
         case OTA_STATE_UPDATE_FIRMWARE_IM19:
@@ -1221,32 +1462,32 @@ void otaVerifyTables()
 // OTA product subsystem support table
 extern const OTA_SUBSYSTEM_INFO otaSubsystemInfoTable[] =
 {
-    // Variant      subsystem               present                 getVersion          streamFirmware          packetBytes         rcSupport   directory          server          branch
-    {RTK_ALL,       OTA_SUBSYSTEM_ESP32,    nullptr,                otaEsp32GetVersion, nullptr,                OTA_BUFFER_BYTES,   true,       "",                otaGithubRaw,   otaRawBranch},
+    // Variant      subsystem               present                 getVersion          firmwareUpdate          streamFirmware          packetBytes         rcSupport   directory          server          branch
+    {RTK_ALL,       OTA_SUBSYSTEM_ESP32,    nullptr,                otaEsp32GetVersion, nullptr,                nullptr,                OTA_BUFFER_BYTES,   true,       "",                otaGithubRaw,   otaRawBranch},
 
     // GNSS devices
 #ifdef  COMPILE_LG290P
-    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_lg290p,   gnssGetVersion,     nullptr,                256,                false,      "/gnss/lg290p",    otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_lg290p,   gnssGetVersion,     nullptr,                nullptr,                256,                false,      "/gnss/lg290p",    otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_LG290P
 #ifdef  COMPILE_MOSAICX5
-    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_mosaicX5, gnssGetVersion,     nullptr,                256,                false,      "/gnss/mosaic-x5", otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_mosaicX5, gnssGetVersion,     nullptr,                nullptr,                256,                false,      "/gnss/mosaic-x5", otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_MOSAICX5
 #ifdef  COMPILE_UM980
-    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_um980,    gnssGetVersion,     nullptr,                256,                false,      "/gnss/um980",     otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_um980,    gnssGetVersion,     nullptr,                nullptr,                256,                false,      "/gnss/um980",     otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_UM980
 #ifdef  COMPILE_ZED
-    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_zedf9p,   gnssGetVersion,     nullptr,                256,                false,      "/gnss/zed-f9p",   otaGithubRaw,   otaRawBranch},
-    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_zedx20p,  gnssGetVersion,     nullptr,                256,                false,      "/gnss/zed-x20p",  otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_zedf9p,   gnssGetVersion,     nullptr,                nullptr,                256,                false,      "/gnss/zed-f9p",   otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_zedx20p,  gnssGetVersion,     nullptr,                nullptr,                256,                false,      "/gnss/zed-x20p",  otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_ZED
 
     // LoRa devices
 #ifdef  COMPILE_LORA
-    {RTK_ALL,       OTA_SUBSYSTEM_LORA,     &present.radio_lora,    loraGetVersion,     nullptr,                256,                false,      "lora/stm32wl",    otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_LORA,     &present.radio_lora,    loraGetVersion,     nullptr,                nullptr,                256,                false,      "lora/stm32wl",    otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_LORA
 
     // IMU devices
 #ifdef  COMPILE_IM19_IMU
-    {RTK_ALL,       OTA_SUBSYSTEM_IMU,      &present.imu_im19,      tiltGetVersion,     nullptr,                256,                false,      "/imu/im19",       otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_IMU,      &present.imu_im19,      tiltGetVersion,     nullptr,                nullptr,                256,                false,      "/imu/im19",       otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_IM19_IMU
 };
 const int otaSubsystemInfoTableEntries = sizeof(otaSubsystemInfoTable)

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -1463,7 +1463,7 @@ void otaVerifyTables()
 extern const OTA_SUBSYSTEM_INFO otaSubsystemInfoTable[] =
 {
     // Variant      subsystem               present                 getVersion          firmwareUpdate          streamFirmware          packetBytes         rcSupport   directory          server          branch
-    {RTK_ALL,       OTA_SUBSYSTEM_ESP32,    nullptr,                otaEsp32GetVersion, nullptr,                nullptr,                OTA_BUFFER_BYTES,   true,       "",                otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_ESP32,    nullptr,                otaEsp32GetVersion, nullptr,                otaEsp32StreamFirmware, OTA_BUFFER_BYTES,   true,       "",                otaGithubRaw,   otaRawBranch},
 
     // GNSS devices
 #ifdef  COMPILE_LG290P

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -1477,7 +1477,7 @@ extern const OTA_SUBSYSTEM_INFO otaSubsystemInfoTable[] =
 #endif  // COMPILE_UM980
 #ifdef  COMPILE_ZED
     {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_zedf9p,   gnssGetVersion,     nullptr,                nullptr,                256,                false,      "/gnss/zed-f9p",   otaGithubRaw,   otaRawBranch},
-    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_zedx20p,  gnssGetVersion,     nullptr,                nullptr,                256,                false,      "/gnss/zed-x20p",  otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_zedx20p,  gnssGetVersion,     nullptr,                x20pStreamFirmware,     256,                false,      "/gnss/zed-x20p",  otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_ZED
 
     // LoRa devices

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -1487,7 +1487,7 @@ extern const OTA_SUBSYSTEM_INFO otaSubsystemInfoTable[] =
 
     // IMU devices
 #ifdef  COMPILE_IM19_IMU
-    {RTK_ALL,       OTA_SUBSYSTEM_IMU,      &present.imu_im19,      tiltGetVersion,     nullptr,                nullptr,                256,                false,      "/imu/im19",       otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_IMU,      &present.imu_im19,      tiltGetVersion,     im19FirmwareUpdate,     nullptr,                256,                false,      "/imu/im19",       otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_IM19_IMU
 };
 const int otaSubsystemInfoTableEntries = sizeof(otaSubsystemInfoTable)

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -590,9 +590,15 @@ void otaMenuDisplay(OTA_SUBSYSTEM_MASK platformDevices,
         systemPrintf("r) Change RC Firmware JSON URL: %s\r\n", otaRcFirmwareJsonUrl);
         systemPrintf("s) Change Firmware JSON URL: %s\r\n", otaFirmwareJsonUrl);
         systemPrintf("D) %s firmware debugging\r\n", settings.debugFirmwareUpdate ? "Disable" : "Enable");
+        if (otaEsp32AreFirmwareWritesSupported())
+            systemPrintf("E) ESP32: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_ESP32));
+        if (platformDevices & OTA_DEVICE_GNSS)
+            systemPrintf("G) GNSS: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_GNSS));
+        if (platformDevices & OTA_DEVICE_IMU)
+            systemPrintf("I) IMU: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_IMU));
+        if (platformDevices & OTA_DEVICE_LORA)
+            systemPrintf("L) LoRa: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_LORA));
         systemPrintf("O) Update firmware on one subsystem\r\n");
-        if (settings.debugFirmwareUpdate)
-            systemPrintf("V) %s verbose firmware debugging\r\n", otaDebugVerbose ? "Disable" : "Enable");
     }
 
     // Allow user to initiate a firmware update without checking for new firmware first
@@ -606,14 +612,27 @@ void otaMenuDisplay(OTA_SUBSYSTEM_MASK platformDevices,
                      (otaTargetCount == 1) ? "" : "s",
                      otaRequestFirmwareUpdate ? "Requested" : "Not Requested");
 
-    if (otaEsp32AreFirmwareWritesSupported())
-        systemPrintf("1) ESP32: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_ESP32));
-    if (platformDevices & OTA_DEVICE_GNSS)
-        systemPrintf("2) GNSS: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_GNSS));
-    if (platformDevices & OTA_DEVICE_LORA)
-        systemPrintf("3) LoRa: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_LORA));
-    if (platformDevices & OTA_DEVICE_IMU)
-        systemPrintf("4) IMU: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_IMU));
+    if (developerOptions && settings.debugFirmwareUpdate)
+            systemPrintf("V) %s verbose firmware debugging\r\n", otaDebugVerbose ? "Disable" : "Enable");
+}
+
+//----------------------------------------
+// Set the next subsystem request type
+//----------------------------------------
+void otaMenuNextSubsystemRequestType(uint8_t subsystemIndex)
+{
+    // Set the next value for this subsystem
+    OTA_TARGET * target = &otaTarget[subsystemIndex];
+    const OTA_SUBSYSTEM_INFO * subsystemInfo = &otaSubsystemInfoTable[subsystemIndex];
+    target->_requestType += 1;
+
+    // Skip release candidate if not supported
+    if ((target->_requestType == OTA_REQUEST_USE_RC) && !subsystemInfo->_rcSupport)
+        target->_requestType += 1;
+
+    // Wrap the value as necessary
+    if (target->_requestType >= OTA_REQUEST_MAX)
+        target->_requestType = 0;
 }
 
 //----------------------------------------
@@ -654,25 +673,6 @@ bool otaMenuProcessInput(OTA_SUBSYSTEM_MASK platformDevices,
     else if (incoming == 'u')
         otaRequestFirmwareUpdate ^= 1; // Tell network we need access, and otaUpdate() that we want to update
 
-    else if (((incoming >= 1) && (incoming <= 4)) // Check for legal subsystem
-        && ((incoming != 1) || otaEsp32AreFirmwareWritesSupported()) // ESP32 requires second APP partition
-        && ((incoming == 1) || (platformDevices & (1 << (incoming - 1))))) // Check for subsystem on product
-    {
-        // Set the next value for this subsystem
-        uint8_t subsystemIndex = incoming - 1;
-        OTA_TARGET * target = &otaTarget[subsystemIndex];
-        const OTA_SUBSYSTEM_INFO * subsystemInfo = &otaSubsystemInfoTable[subsystemIndex];
-        target->_requestType += 1;
-
-        // Skip release candidate if not supported
-        if ((target->_requestType == OTA_REQUEST_USE_RC) && !subsystemInfo->_rcSupport)
-            target->_requestType += 1;
-
-        // Wrap the value as necessary
-        if (target->_requestType >= OTA_REQUEST_MAX)
-            target->_requestType = 0;
-    }
-
     // Toggle firmware debugging
     else if (developerOptions && (incoming == 'D'))
     {
@@ -680,6 +680,18 @@ bool otaMenuProcessInput(OTA_SUBSYSTEM_MASK platformDevices,
         if (settings.debugFirmwareUpdate == false)
             otaDebugVerbose = false;
     }
+
+    else if (developerOptions && (incoming == 'E') && otaEsp32AreFirmwareWritesSupported()) // ESP32 requires second APP partition
+        otaMenuNextSubsystemRequestType(OTA_SUBSYSTEM_ESP32);
+
+    else if (developerOptions && (incoming == 'G') && (platformDevices & OTA_DEVICE_GNSS)) // Check for GNSS on product
+        otaMenuNextSubsystemRequestType(OTA_SUBSYSTEM_GNSS);
+
+    else if (developerOptions && (incoming == 'I') && (platformDevices & OTA_DEVICE_IMU)) // Check for IMU on product
+        otaMenuNextSubsystemRequestType(OTA_SUBSYSTEM_IMU);
+
+    else if (developerOptions && (incoming == 'I') && (platformDevices & OTA_DEVICE_LORA)) // Check for LoRa on product
+        otaMenuNextSubsystemRequestType(OTA_SUBSYSTEM_LORA);
 
     // Perform the device firmware update
     else if (developerOptions && (incoming == 'O'))

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -1467,7 +1467,7 @@ extern const OTA_SUBSYSTEM_INFO otaSubsystemInfoTable[] =
 
     // GNSS devices
 #ifdef  COMPILE_LG290P
-    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_lg290p,   gnssGetVersion,     nullptr,                nullptr,                256,                false,      "/gnss/lg290p",    otaGithubRaw,   otaRawBranch},
+    {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_lg290p,   gnssGetVersion,     nullptr,                lg290pStreamFirmware,   4096,               false,      "/gnss/lg290p",    otaGithubRaw,   otaRawBranch},
 #endif  // COMPILE_LG290P
 #ifdef  COMPILE_MOSAICX5
     {RTK_ALL,       OTA_SUBSYSTEM_GNSS,     &present.gnss_mosaicX5, gnssGetVersion,     nullptr,                nullptr,                256,                false,      "/gnss/mosaic-x5", otaGithubRaw,   otaRawBranch},

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -729,9 +729,10 @@ void otaGetUrl(OTA_TARGET * target,
 // Display the OTA portion of the firmware menu
 //----------------------------------------
 void otaMenuDisplay(OTA_SUBSYSTEM_MASK platformDevices,
-                    bool developerOptions,
+                    bool * developerOptionsAddr,
                     char *currentVersion)
 {
+    bool developerOptions = *developerOptionsAddr;
     OTA_SUBSYSTEM_MASK productSubsystems = otaGetProductSubsystemSupport();
 
     // Initialize the OTA targets
@@ -750,29 +751,44 @@ void otaMenuDisplay(OTA_SUBSYSTEM_MASK platformDevices,
     // Automatic firmware updates
     systemPrintf("a) Automatic firmware updates: %s\r\n", settings.enableAutoFirmwareUpdate ? "Enabled" : "Disabled");
 
-    systemPrintf("c) Check for firmware updates: %s\r\n",
+    systemPrintf("c) Check for product firmware updates: %s\r\n",
                  otaRequestFirmwareVersionCheck ? "Requested" : "Not requested");
+    if (developerOptions)
+        systemPrintf("C) Check for newer firmware for all subssystems\r\n");
+
+    systemPrintf("d) %s developer options\r\n", developerOptions ? "Disable" : "Enable");
+    if (developerOptions)
+        systemPrintf("D) %s firmware debugging\r\n", settings.debugFirmwareUpdate ? "Disable" : "Enable");
 
     if (developerOptions)
+    {
         systemPrintf("e) Allow beta firmware: %s\r\n", enableRCFirmware ? "Enabled" : "Disabled");
+        if (otaEsp32AreFirmwareWritesSupported())
+            systemPrintf("E) ESP32: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_ESP32));
+    }
+
+    if (developerOptions)
+    {
+        systemPrintf("F) Force updates to all subssystems\r\n");
+        if (platformDevices & OTA_DEVICE_GNSS)
+            systemPrintf("G) GNSS: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_GNSS));
+    }
 
     if (settings.enableAutoFirmwareUpdate)
         systemPrintf("i) Automatic firmware check minutes: %d\r\n", settings.autoFirmwareCheckMinutes);
+    if (developerOptions && (platformDevices & OTA_DEVICE_IMU))
+        systemPrintf("I) IMU: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_IMU));
+
+    if (developerOptions && (platformDevices & OTA_DEVICE_LORA))
+        systemPrintf("L) LoRa: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_LORA));
+
+    systemPrintf("P) Update to latest product specific firmware\r\n");
+    systemPrintf("q) Cancel check and update requests\r\n");
 
     if (developerOptions)
     {
         systemPrintf("r) Change RC Firmware JSON URL: %s\r\n", otaRcFirmwareJsonUrl);
         systemPrintf("s) Change Firmware JSON URL: %s\r\n", otaFirmwareJsonUrl);
-        systemPrintf("D) %s firmware debugging\r\n", settings.debugFirmwareUpdate ? "Disable" : "Enable");
-        if (otaEsp32AreFirmwareWritesSupported())
-            systemPrintf("E) ESP32: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_ESP32));
-        if (platformDevices & OTA_DEVICE_GNSS)
-            systemPrintf("G) GNSS: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_GNSS));
-        if (platformDevices & OTA_DEVICE_IMU)
-            systemPrintf("I) IMU: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_IMU));
-        if (platformDevices & OTA_DEVICE_LORA)
-            systemPrintf("L) LoRa: %s\r\n", otaGetRequestNameFromSubsystem(OTA_SUBSYSTEM_LORA));
-        systemPrintf("O) Update firmware on one subsystem\r\n");
     }
 
     // Allow user to initiate a firmware update without checking for new firmware first
@@ -813,14 +829,41 @@ void otaMenuNextSubsystemRequestType(uint8_t subsystemIndex)
 // Process the OTA specific firmware menu input
 //----------------------------------------
 bool otaMenuProcessInput(OTA_SUBSYSTEM_MASK platformDevices,
-                         bool developerOptions,
+                         bool * developerOptionsAddr,
                          byte incoming)
 {
+    bool developerOptions = *developerOptionsAddr;
     if (incoming == 'a')
         settings.enableAutoFirmwareUpdate ^= 1;
 
     else if (incoming == 'c')
-        otaRequestFirmwareVersionCheck ^= 1;
+    {
+        for (int subsystemIndex = 0; subsystemIndex < OTA_SUBSYSTEM_MAX; subsystemIndex++)
+            otaTarget[subsystemIndex]._requestType = OTA_REQUEST_PRODUCT_RELEASE;
+        otaRequestFirmwareVersionCheck = true;
+        otaRequestFirmwareUpdate = false;
+    }
+
+    // Check for updates to all subsystems
+    else if (developerOptions && (incoming == 'C'))
+    {
+        for (int subsystemIndex = 0; subsystemIndex < OTA_SUBSYSTEM_MAX; subsystemIndex++)
+            otaTarget[subsystemIndex]._requestType = OTA_REQUEST_LATEST_VERSION;
+        otaRequestFirmwareVersionCheck = true;
+        otaRequestFirmwareUpdate = false;
+    }
+
+    // Enable / disable developer options
+    else if (incoming == 'd')
+        *developerOptionsAddr ^= 1;
+
+    // Toggle firmware debugging
+    else if (developerOptions && (incoming == 'D'))
+    {
+        settings.debugFirmwareUpdate ^= 1;
+        if (settings.debugFirmwareUpdate == false)
+            otaDebugVerbose = false;
+    }
 
     else if ((incoming == 'e') && developerOptions)
     {
@@ -828,8 +871,49 @@ bool otaMenuProcessInput(OTA_SUBSYSTEM_MASK platformDevices,
         strncpy(otaReportedVersion, "", sizeof(otaReportedVersion) - 1); // Reset to force c) menu
     }
 
+    // Select ESP32 request type
+    else if (developerOptions && (incoming == 'E') && otaEsp32AreFirmwareWritesSupported()) // ESP32 requires second APP partition
+        otaMenuNextSubsystemRequestType(OTA_SUBSYSTEM_ESP32);
+
+    // Force updates to all subsystems
+    else if (developerOptions && (incoming == 'F'))
+    {
+        for (int subsystemIndex = 0; subsystemIndex < OTA_SUBSYSTEM_MAX; subsystemIndex++)
+            otaTarget[subsystemIndex]._requestType = OTA_REQUEST_ALWAYS_UPDATE;
+        otaRequestFirmwareVersionCheck = false;
+        otaRequestFirmwareUpdate = true;
+    }
+
+    // Select GNSS request type
+    else if (developerOptions && (incoming == 'G') && (platformDevices & OTA_DEVICE_GNSS)) // Check for GNSS on product
+        otaMenuNextSubsystemRequestType(OTA_SUBSYSTEM_GNSS);
+
     else if ((incoming == 'i') && settings.enableAutoFirmwareUpdate)
         getNewSetting("Enter minutes before next firmware check", 1, 999999, &settings.autoFirmwareCheckMinutes);
+
+    // Select IMU request type
+    else if (developerOptions && (incoming == 'I') && (platformDevices & OTA_DEVICE_IMU)) // Check for IMU on product
+        otaMenuNextSubsystemRequestType(OTA_SUBSYSTEM_IMU);
+
+    // Select LoRa request type
+    else if (developerOptions && (incoming == 'L') && (platformDevices & OTA_DEVICE_LORA)) // Check for LoRa on product
+        otaMenuNextSubsystemRequestType(OTA_SUBSYSTEM_LORA);
+
+    // Update to latest product firmware
+    else if (incoming == 'P')
+    {
+        for (int subsystemIndex = 0; subsystemIndex < OTA_SUBSYSTEM_MAX; subsystemIndex++)
+            otaTarget[subsystemIndex]._requestType = OTA_REQUEST_PRODUCT_RELEASE;
+        otaRequestFirmwareVersionCheck = false;
+        otaRequestFirmwareUpdate = true;
+    }
+
+    // Cancel check and update requests
+    else if (incoming == 'q')
+    {
+        otaRequestFirmwareVersionCheck = false;
+        otaRequestFirmwareUpdate = false;
+    }
 
     else if ((incoming == 'r') && developerOptions)
     {
@@ -846,36 +930,6 @@ bool otaMenuProcessInput(OTA_SUBSYSTEM_MASK platformDevices,
 
     else if (incoming == 'u')
         otaRequestFirmwareUpdate ^= 1; // Tell network we need access, and otaUpdate() that we want to update
-
-    // Toggle firmware debugging
-    else if (developerOptions && (incoming == 'D'))
-    {
-        settings.debugFirmwareUpdate ^= 1;
-        if (settings.debugFirmwareUpdate == false)
-            otaDebugVerbose = false;
-    }
-
-    else if (developerOptions && (incoming == 'E') && otaEsp32AreFirmwareWritesSupported()) // ESP32 requires second APP partition
-        otaMenuNextSubsystemRequestType(OTA_SUBSYSTEM_ESP32);
-
-    else if (developerOptions && (incoming == 'G') && (platformDevices & OTA_DEVICE_GNSS)) // Check for GNSS on product
-        otaMenuNextSubsystemRequestType(OTA_SUBSYSTEM_GNSS);
-
-    else if (developerOptions && (incoming == 'I') && (platformDevices & OTA_DEVICE_IMU)) // Check for IMU on product
-        otaMenuNextSubsystemRequestType(OTA_SUBSYSTEM_IMU);
-
-    else if (developerOptions && (incoming == 'I') && (platformDevices & OTA_DEVICE_LORA)) // Check for LoRa on product
-        otaMenuNextSubsystemRequestType(OTA_SUBSYSTEM_LORA);
-
-    // Perform the device firmware update
-    else if (developerOptions && (incoming == 'O'))
-    {
-        deviceFirmwareUpdateBegin(false, otaDebugVerbose);
-        while (deviceFirmwareUpdate(millis()))
-        {
-            networkUpdate();
-        }
-    }
 
     // Toggle verbose firmware debugging
     else if (developerOptions && settings.debugFirmwareUpdate && (incoming == 'V'))

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -207,6 +207,13 @@ const uint16_t HTTPS_PORT = 443;                                                
 
 #include <ArduinoJson.h> //http://librarymanager/All#Arduino_JSON_messagepack - Needed for settings.h
 
+#define OTA_FIRMWARE_CSV_URL_LENGTH     192
+//                                                                                                      1         1 1
+//            1         2         3         4         5         6         7         8         9         0         1 2
+//   12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678
+#define OTA_FIRMWARE_CSV_URL    \
+    "https://raw.githubusercontent.com/sparkfun/SparkFun_RTK_Everywhere_Firmware_Binaries/main/RTK-Everywhere-Variants.csv"
+
 #include "settings.h"
 #include <esp_mac.h> // MAC address support
 #include "OTA.h"     // Over-The-Air (OTA) support

--- a/Firmware/RTK_Everywhere/System.ino
+++ b/Firmware/RTK_Everywhere/System.ino
@@ -1289,7 +1289,7 @@ void gpioExpanderConnectGNSSToESP32()
 }
 
 // Callback for all firmware update targets. Called with the number of bytes written to flash so far. Used to track and print progress.
-void firmwareUpdateProgressCallback(uint16_t bytesProcessed)
+void firmwareUpdateProgressCallback(const char * subsystemName, uint16_t bytesProcessed)
 {
     const uint8_t progressBarWidth = 20;
     static uint8_t lastUpdatePercent = 0;
@@ -1311,7 +1311,7 @@ void firmwareUpdateProgressCallback(uint16_t bytesProcessed)
 
     lastUpdatePercent = progressPercent;
 
-    systemPrint("Update Progress: [");
+    systemPrintf("%s Update Progress: [", subsystemName);
     for (uint8_t i = 0; i < progressBarWidth; i++)
         systemWrite(i < filled ? '#' : '-');
 

--- a/Firmware/RTK_Everywhere/Tilt.ino
+++ b/Firmware/RTK_Everywhere/Tilt.ino
@@ -1800,7 +1800,7 @@ static bool im19PumpStreamToDevice(WiFiClient *stream, WiFiClientSecure *client,
             return false;
 
         received += bytesRead;
-        firmwareUpdateProgressCallback((uint16_t)bytesRead);
+        firmwareUpdateProgressCallback("IM19", (uint16_t)bytesRead);
     }
 
     return received == byteCount;

--- a/Firmware/RTK_Everywhere/Tilt.ino
+++ b/Firmware/RTK_Everywhere/Tilt.ino
@@ -49,6 +49,8 @@ typedef enum
 } TiltState;
 TiltState tiltState = TILT_DISABLED;
 
+uint32_t tiltCrc;
+
 // Tilt compensation sensor state machine
 void tiltUpdate()
 {
@@ -1778,36 +1780,47 @@ static bool im19PumpStreamToDevice(WiFiClient *stream, WiFiClientSecure *client,
     uint8_t buffer[512];
     uint32_t received = 0;
 
+    unsigned long lastDataTime = millis();
     while (http->connected() && received < byteCount)
     {
+        // Wait until some data is available
         size_t available = stream->available();
         if (available == 0)
         {
-            if (!client->connected())
-                break;
+            if ((millis() - lastDataTime) > OTA_DATA_TIMEOUT)
+            {
+                systemPrintln("IM19 OTA update timed out waiting for data");
+                return false;
+            }
             delay(1);
             continue;
         }
 
+        // Read the received data
         size_t toRead = min(available, (size_t)(byteCount - received));
         toRead = min(toRead, sizeof(buffer));
-
         int bytesRead = stream->readBytes(buffer, toRead);
         if (bytesRead <= 0)
             break;
 
+        // Compute the CRC
+        tiltCrc = crc32Compute(tiltCrc, buffer, bytesRead);
+
+        // Update this portion of the firmware
         if (!im19UpdateFirmware(buffer, (uint32_t)bytesRead))
             return false;
 
+        // Account for this data
         received += bytesRead;
         firmwareUpdateProgressCallback("IM19", (uint16_t)bytesRead);
+        lastDataTime = millis();
     }
 
     return received == byteCount;
 }
 
 // Re-downloads only [startByte, endByte] (inclusive) and streams it to the IM19.
-static bool im19StreamRange(const char *relativeFirmwareFileLocation, uint32_t startByte, uint32_t endByte)
+static bool im19StreamRange(const char *url, uint32_t startByte, uint32_t endByte)
 {
     WiFiClientSecure client;
     if (!otaSecurelyConnectGitHub(client))
@@ -1817,7 +1830,7 @@ static bool im19StreamRange(const char *relativeFirmwareFileLocation, uint32_t s
     }
 
     HTTPClient http;
-    if (!http.begin(client, otaGetGithubFileLocation(relativeFirmwareFileLocation)))
+    if (!http.begin(client, url))
     {
         systemPrintln("Unable to begin HTTP request.");
         return false;
@@ -1845,7 +1858,7 @@ static bool im19StreamRange(const char *relativeFirmwareFileLocation, uint32_t s
 
 // Walks im19FrameMap for runs of missing frames and re-requests just those byte
 // ranges from the source URL, instead of re-streaming the entire firmware image.
-static bool im19StreamMissingRanges(const char *relativeFirmwareFileLocation)
+static bool im19StreamMissingRanges(const char *url)
 {
     uint32_t frame = 0;
     while (frame < im19TotalFrames)
@@ -1867,7 +1880,7 @@ static bool im19StreamMissingRanges(const char *relativeFirmwareFileLocation)
         systemPrintf("Requesting missing frames %lu-%lu (%lu bytes) from source.\r\n", (unsigned long)runStart,
                      (unsigned long)(frame - 1), (unsigned long)(endByte - startByte + 1));
 
-        if (!im19StreamRange(relativeFirmwareFileLocation, startByte, endByte))
+        if (!im19StreamRange(url, startByte, endByte))
             return false;
     }
     return true;
@@ -1892,7 +1905,8 @@ bool im19StreamFirmware(const char *relativeFirmwareFileLocation)
     }
 
     HTTPClient http;
-    if (!http.begin(client, otaGetGithubFileLocation(relativeFirmwareFileLocation)))
+    const char * url = otaGetGithubFileLocation(relativeFirmwareFileLocation);
+    if (!http.begin(client, url))
     {
         systemPrintln("Unable to begin HTTP request.");
         return false;
@@ -1952,7 +1966,7 @@ bool im19StreamFirmware(const char *relativeFirmwareFileLocation)
 
         // IM19_UPDATE_RETRY - the IM19 told us exactly which frames it's missing.
         systemPrintf("Attempt %d: IM19 reports missing frames.\r\n", attempt);
-        if (!im19StreamMissingRanges(relativeFirmwareFileLocation))
+        if (!im19StreamMissingRanges(url))
         {
             systemPrintln("Firmware update failed while re-requesting missing frames.");
             return false;
@@ -1960,6 +1974,133 @@ bool im19StreamFirmware(const char *relativeFirmwareFileLocation)
     }
 
     systemPrintln("IM19 firmware update failed: too many retries.");
+    return false;
+}
+
+//----------------------------------------
+// Updates the IM19 module firmware from the given URL over WiFi.
+//
+// Structure (see the header comment at the top of the .ino for the general pattern):
+//   1. Connect to WiFi.
+//   2. im19UpdateFirmwareBegin() puts the IM19 into its bootloader.
+//   3. Stream the file once, feeding chunks to im19UpdateFirmware().
+//   4. im19UpdateFirmwareEnd() asks the IM19 what it's missing. If anything, re-request
+//      only those byte ranges (im19StreamMissingRanges) and ask again - up to a few
+//      attempts - rather than re-streaming the whole binary.
+//----------------------------------------
+bool im19FirmwareUpdate(const OTA_TARGET * target,
+                        const OTA_SUBSYSTEM_INFO * subsystemInfo,
+                        uint8_t * buffer,
+                        size_t bufferBytes)
+{
+    WiFiClientSecure client;
+    if (!otaSecurelyConnectGitHub(client))
+    {
+        systemPrintln(otaEqualSigns);
+        systemPrintln("Failed to securely connect to GitHub.");
+        systemPrintln(otaEqualSigns);
+        return false;
+    }
+
+    HTTPClient http;
+    if (!http.begin(client, target->_url))
+    {
+        systemPrintln(otaEqualSigns);
+        systemPrintln("Unable to begin HTTP request.");
+        systemPrintln(otaEqualSigns);
+        return false;
+    }
+
+    int httpCode = http.GET();
+    if (httpCode != HTTP_CODE_OK)
+    {
+        systemPrintln(otaEqualSigns);
+        systemPrintf("HTTP GET failed, code: %d\r\n", httpCode);
+        systemPrintln(otaEqualSigns);
+        http.end();
+        return false;
+    }
+
+    size_t fileBytes = http.getSize();
+    if ((ssize_t)fileBytes <= 0)
+    {
+        systemPrintln(otaEqualSigns);
+        systemPrintln("Server did not report a firmware size.");
+        systemPrintln(otaEqualSigns);
+        http.end();
+        return false;
+    }
+
+    // Stream the firmware in chunks so we can report progress via
+    // firmwareUpdateProgressCallback() along the way.
+    firmwareUpdateBytesProcessed = 0;
+    firmwareUpdateBytesToProcess = fileBytes;
+    tiltCrc = 0;
+
+    if (!im19UpdateFirmwareBegin(fileBytes))
+    {
+        systemPrintln(otaEqualSigns);
+        systemPrintln("IM19 did not respond to the bootloader entry command.");
+        systemPrintln(otaEqualSigns);
+        http.end();
+        return false;
+    }
+
+    // Now that the IM19 is in its bootloader and waiting, stream the already-open
+    // response body straight to it.
+    bool streamed = im19PumpStreamToDevice(http.getStreamPtr(), &client, &http, 0, fileBytes);
+    http.end();
+
+    // Validate the computed CRC matches the expected CRC
+    if (streamed && (tiltCrc != target->_crc))
+    {
+        systemPrintln(otaEqualSigns);
+        systemPrintf("ERROR: File has changed, CRC does not match!\r\n");
+        systemPrintln(otaEqualSigns);
+        return false;
+    }
+
+    if (!streamed)
+    {
+        systemPrintln(otaEqualSigns);
+        systemPrintln("Firmware update failed during initial WiFi download.");
+        systemPrintln(otaEqualSigns);
+        return false;
+    }
+
+    const int maxAttempts = 5;
+    for (int attempt = 1; attempt <= maxAttempts; attempt++)
+    {
+        Im19UpdateResult result = im19UpdateFirmwareEnd();
+
+        if (result == IM19_UPDATE_SUCCESS)
+        {
+            systemPrintln(otaEqualSigns);
+            systemPrintln("IM19 firmware update successful.");
+            systemPrintln(otaEqualSigns);
+            return true;
+        }
+
+        if (result == IM19_UPDATE_FAILED)
+        {
+            systemPrintln("IM19 firmware update failed: no response from IM19.");
+            return false;
+        }
+
+        // IM19_UPDATE_RETRY - the IM19 told us exactly which frames it's missing.
+        systemPrintf("Attempt %d: IM19 reports missing frames.\r\n", attempt);
+        if (!im19StreamMissingRanges(target->_url))
+        {
+            systemPrintln(otaEqualSigns);
+            systemPrintln("Firmware update failed while re-requesting missing frames.");
+            systemPrintln(otaEqualSigns);
+            return false;
+        }
+    }
+
+    systemPrintln(otaEqualSigns);
+    systemPrintln("IM19 firmware update failed: too many retries.");
+    systemPrintln(otaEqualSigns);
     return false;
 }
 

--- a/Firmware/RTK_Everywhere/menuFirmware.ino
+++ b/Firmware/RTK_Everywhere/menuFirmware.ino
@@ -655,6 +655,100 @@ void otaEsp32Reboot()
     ESP.restart();
 }
 
+//----------------------------------------
+// Update the ESP32 firmware
+//----------------------------------------
+bool otaEsp32StreamFirmware(NetworkClient * stream,
+                            size_t fileBytes,
+                            uint32_t expectedCrc,
+                            uint8_t * buffer,
+                            size_t bufferBytes)
+{
+    uint32_t crc = 0;
+
+    if (Update.begin(fileBytes) == false)
+    {
+        systemPrintln(otaEqualSigns);
+        systemPrintln("Update begin failed. Not enough partition space available.");
+        systemPrintln(otaEqualSigns);
+        return false;
+    }
+
+    systemPrintln("Starting ESP32 firmware update...");
+
+    unsigned long lastDataTime = millis();
+
+    // Stream the firmware in chunks so we can report progress via
+    // firmwareUpdateProgressCallback() along the way.
+    while (stream->connected() && (fileBytes > 0))
+    {
+        // Wait until some data is available
+        size_t availableBytes = stream->available();
+        if (availableBytes == 0)
+        {
+            if ((millis() - lastDataTime) > OTA_DATA_TIMEOUT)
+            {
+                systemPrintln("ESP32 OTA update timed out waiting for data");
+                return false;
+            }
+            delay(1);
+            continue;
+        }
+
+        // Read the received data
+        size_t bytesToRead = (availableBytes > bufferBytes) ? bufferBytes : availableBytes;
+        int bytesRead = stream->readBytes(buffer, bytesToRead);
+        if (bytesRead <= 0)
+            continue;
+
+        // Compute the CRC
+        crc = crc32Compute(crc, buffer, bytesRead);
+
+        // Validate the computed CRC matches the expected CRC
+        if ((fileBytes == 0) && (crc != expectedCrc))
+        {
+            systemPrintf("ERROR: File has changed, CRC does not match!\r\n");
+            break;
+        }
+
+        // Update this portion of the firmware
+        if (Update.write(buffer, bytesRead) != (size_t)bytesRead)
+        {
+            systemPrintln("ESP32 OTA update failed during write");
+            return false;
+        }
+
+        // Account for this data
+        fileBytes -= bytesRead;
+        firmwareUpdateProgressCallback("ESP32", (uint16_t)bytesRead);
+        lastDataTime = millis();
+    }
+
+    systemPrintln(otaEqualSigns);
+    if (fileBytes > 0)
+    {
+        systemPrintln("ESP32 OTA update failed during writeStream");
+        return false;
+    }
+
+    if (Update.end() == false)
+    {
+        systemPrintln("ESP32 OTA error occurred. Error #: " + String(Update.getError()));
+        return false;
+    }
+
+    systemPrintln("ESP32 OTA done!");
+    if (Update.isFinished() == false)
+    {
+        systemPrintln("ESP32 update not finished? Something went wrong!");
+        return false;
+    }
+
+    systemPrintln("ESP32 update successfully completed.");
+    systemPrintln(otaEqualSigns);
+    return true;
+}
+
 // Update the ESP32 firmware
 bool espStreamFirmware(char *relativeFirmwareFileLocation)
 {
@@ -1165,4 +1259,5 @@ bool otaSecurelyConnectGitHub(WiFiClientSecure &client)
     client.stop();
     return true;
 }
+
 #endif // COMPILE_OTA_AUTO

--- a/Firmware/RTK_Everywhere/menuFirmware.ino
+++ b/Firmware/RTK_Everywhere/menuFirmware.ino
@@ -33,7 +33,7 @@ void firmwareMenu()
         // Display the OTA portion of the menu
         // Note: Use otaMenuDisplay to get a new ESP32 image when the parsing
         // fails in deviceFirmwareUpdate due to server website changes!
-        // Letters: a c d e i q r s u C D E F G I L O P V 1... for files
+        // Letters: a c d e i q r s u C D E F G I L O P S V 1... for files
         otaMenuDisplay(subsystemMask, &developerOptions, currentVersion);
 
         for (int x = 0; x < binCount; x++)

--- a/Firmware/RTK_Everywhere/menuFirmware.ino
+++ b/Firmware/RTK_Everywhere/menuFirmware.ino
@@ -643,6 +643,18 @@ char *otaSubsystemFilePath(char subsystemCode)
     return nullptr;
 }
 
+//----------------------------------------
+// Reboot the ESP32
+//----------------------------------------
+void otaEsp32Reboot()
+{
+    // Restart ESP32 to see changes
+    systemPrintf("Rebooting. Goodbye!\r\n");
+    Serial.flush();
+    delay(1000);
+    ESP.restart();
+}
+
 // Update the ESP32 firmware
 bool espStreamFirmware(char *relativeFirmwareFileLocation)
 {

--- a/Firmware/RTK_Everywhere/menuFirmware.ino
+++ b/Firmware/RTK_Everywhere/menuFirmware.ino
@@ -723,7 +723,7 @@ bool espStreamFirmware(char *relativeFirmwareFileLocation)
             bytesWritten += bytesRead;
             lastDataTime = millis();
 
-            firmwareUpdateProgressCallback((uint16_t)bytesRead);
+            firmwareUpdateProgressCallback("ESP32", (uint16_t)bytesRead);
         }
         if (readError)
             break;

--- a/Firmware/RTK_Everywhere/menuFirmware.ino
+++ b/Firmware/RTK_Everywhere/menuFirmware.ino
@@ -33,10 +33,8 @@ void firmwareMenu()
         // Display the OTA portion of the menu
         // Note: Use otaMenuDisplay to get a new ESP32 image when the parsing
         // fails in deviceFirmwareUpdate due to server website changes!
-        // Letters: a  c  e  i  r  s  u, D, E, G, I, L, O, V, 1, ... for files
-        otaMenuDisplay(subsystemMask, developerOptions, currentVersion);
-        systemPrintf("d) %s developer options\r\n", developerOptions ? "Disable" : "Enable");
-        systemPrintf("p) Update firmware on all subsystems\r\n");
+        // Letters: a c d e i q r s u C D E F G I L O P V 1... for files
+        otaMenuDisplay(subsystemMask, &developerOptions, currentVersion);
 
         for (int x = 0; x < binCount; x++)
             systemPrintf("%d) Load SD file: %s\r\n", x + 1, binFileNames[x]);
@@ -55,22 +53,8 @@ void firmwareMenu()
         // Note: Use otaMenuProcessInput to get a new ESP32 image when the
         // parsing fails in deviceFirmwareUpdate due to server website
         // changes!
-        else if (otaMenuProcessInput(subsystemMask, developerOptions, incoming))
+        else if (otaMenuProcessInput(subsystemMask, &developerOptions, incoming))
         {
-        }
-
-        // Enable / disable developer options
-        else if (incoming == 'd')
-            developerOptions ^= 1;
-
-        // Restore product to production firmware
-        else if (incoming == 'p')
-        {
-            deviceFirmwareUpdateBegin(true, otaDebugVerbose);
-            while (deviceFirmwareUpdate(millis()))
-            {
-                networkUpdate();
-            }
         }
 
         else if (incoming == 'x')

--- a/Firmware/RTK_Everywhere/menuFirmware.ino
+++ b/Firmware/RTK_Everywhere/menuFirmware.ino
@@ -33,7 +33,7 @@ void firmwareMenu()
         // Display the OTA portion of the menu
         // Note: Use otaMenuDisplay to get a new ESP32 image when the parsing
         // fails in deviceFirmwareUpdate due to server website changes!
-        // Letters: a  c  e  i  r  s  u, 1, 2, 3, 4
+        // Letters: a  c  e  i  r  s  u, D, E, G, I, L, O, V, 1, ... for files
         otaMenuDisplay(subsystemMask, developerOptions, currentVersion);
         systemPrintf("d) %s developer options\r\n", developerOptions ? "Disable" : "Enable");
         systemPrintf("p) Update firmware on all subsystems\r\n");

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -826,6 +826,7 @@ struct Settings
     uint32_t autoFirmwareCheckMinutes = 24 * 60;
     bool debugFirmwareUpdate = false;
     bool enableAutoFirmwareUpdate = false;
+    char csvUrl[OTA_FIRMWARE_CSV_URL_LENGTH] = OTA_FIRMWARE_CSV_URL;
 
     // GNSS
     muxConnectionType_e dataPortChannel = MUX_GNSS_UART; // Mux default to GNSS UART
@@ -1462,6 +1463,7 @@ const RTK_Settings_Entry rtkSettingsEntries[] =
     { 1, 1, 0, 1, 1, 1, 1, ALL, 1, _uint32_t, 0, & settings.autoFirmwareCheckMinutes, "autoFirmwareCheckMinutes", nullptr, },
     { 0, 0, 0, 1, 1, 1, 1, ALL, 1, _bool,     0, & settings.debugFirmwareUpdate, "debugFirmwareUpdate", nullptr, },
     { 1, 1, 0, 1, 1, 1, 1, ALL, 1, _bool,     0, & settings.enableAutoFirmwareUpdate, "enableAutoFirmwareUpdate", nullptr, },
+    { 1, 1, 0, 1, 1, 1, 1, ALL, 1, tCharArry, sizeof(settings.csvUrl), & settings.csvUrl, "csvUrl", nullptr, },
 
     // GNSS UART
     { 0, 0, 0, 1, 1, 1, 1, ALL, 1, _uint16_t, 0, & settings.serialGNSSRxFullThreshold, "serialGNSSRxFullThreshold", nullptr, },

--- a/Firmware/RTK_Everywhere/support.ino
+++ b/Firmware/RTK_Everywhere/support.ino
@@ -771,6 +771,7 @@ void verifyTables()
     wifiVerifyTables();
     gnssVerifyTables();
     lg290pVerifyTables();
+    nvmVerifyTables();
 
     if (CORR_NUM >= (int)('x' - 'a'))
         reportFatalError("Too many correction sources");


### PR DESCRIPTION
This pull request includes the following commits:
* menuFirmware: Display RC request only if subsystem supports RC builds
* menuFirmware: Bug fix, add always to list of request types
* menuFirmware: Use E, G, I, L for subsystems since 1... used for files
* OTA: Breakout otaDisplayTarget from otaDisplayTargets
* OTA: Change return value from otaGetRequiredUpdates
* OTA: Add subsystem name parameter to firmwareUpdateProgressCallback
* OTA: Add OTA_STATE_UPDATE_FIRMWARE
* OTA: Add ESP32 support
* OTA: Add LoRa (STM32) support
* OTA: Add LG290P support
* OTA: Add IM19 support
* OTA: Add X20P support
* menuFirmware: Update the menu options
    The following options were updated:
    * Modified c to check for latest product firmware
    * Add C to check for newer firmware
    * Add F to force firmware updates to newest firmware
    * Remove O update one subsystem using DFU
    * Remove p update all subsystems using DFU
    * Add P to update to latest product firmware
    * Add q to cancel check and update requests
* OTA: Save and restore csvUrl setting
