### PR TITLE
OTA: LG290p support, read full packets before write

### DIFF
--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -3780,15 +3780,12 @@ bool lg290pFirmwareUpdateBegin(size_t fileBytes, uint32_t expectedCrc)
 }
 
 //----------------------------------------
-// Given a chunk of bytes, feed the LG290P firmware update machine
+// Write firmware to the LG290P
 //----------------------------------------
-bool lg290pFirmwareUpdate(uint8_t *dataArray, uint16_t bytesToWrite, bool sendLastLine)
+bool lg290pFirmwareUpdate(const uint8_t * buffer, size_t dataBytes)
 {
-    if (sendLastLine == true)
-        return (((GNSS_LG290P *)gnss)->updateFirmwareEnd());
-
     // Bytes will be aggregated into 4096 chunks, then written to the LG290P
-    return ((GNSS_LG290P *)gnss)->updateFirmware(dataArray, bytesToWrite);
+    return ((GNSS_LG290P *)gnss)->updateFirmware(buffer, dataBytes);
 }
 
 //----------------------------------------
@@ -3821,12 +3818,13 @@ bool lg290pStreamFirmware(NetworkClient * stream,
     if (lg290pFirmwareUpdateBegin(fileBytes, expectedCrc) == false)
     {
         systemPrintln(otaEqualSigns);
-        systemPrintln("ERROR: Failed to erase LG290P flash!\r\n");
+        systemPrintln("ERROR: lg290pFirmwareUpdateBegin failed!\r\n");
         systemPrintln(otaEqualSigns);
         return false;
     }
     systemPrintln("Starting LG290P firmware update...");
     unsigned long lastDataTime = millis();
+    size_t validData = 0;
     while (stream->connected() && (fileBytes > 0))
     {
         // Wait until some data is available
@@ -3843,50 +3841,52 @@ bool lg290pStreamFirmware(NetworkClient * stream,
         }
 
         // Read the received data
-        size_t bytesToRead = (availableBytes > packetBytes) ? packetBytes : availableBytes;
-        int bytesRead = stream->readBytes(buffer, bytesToRead);
+        size_t bytesToRead = min(availableBytes, packetBytes - validData);
+        int bytesRead = stream->readBytes(&buffer[validData], bytesToRead);
         if (bytesRead <= 0)
+            break;
+        validData += bytesRead;
+
+        // Fill the packet
+        if ((validData < packetBytes) && (validData != fileBytes))
             continue;
 
         // Compute the CRC
-        crc = crc32Compute(crc, buffer, bytesRead);
+        crc = crc32Compute(crc, buffer, validData);
 
         // Validate the computed CRC matches the expected CRC
-        bool lastPacket = (fileBytes == bytesRead);
-        if (lastPacket && (crc != expectedCrc))
+        if ((fileBytes == validData) && (crc != expectedCrc))
         {
             systemPrintf("ERROR: File has changed, CRC does not match!\r\n");
             break;
         }
 
         // Update this portion of the firmware
-        if (lg290pFirmwareUpdate(buffer, bytesRead, lastPacket) == false)
+        if (lg290pFirmwareUpdate(buffer, validData) == false)
         {
             systemPrintln("LG290P OTA update failed during write");
-            return false;
+            break;
         }
+        delay(1);
 
         // Account for this data
-        fileBytes -= bytesRead;
-        firmwareUpdateProgressCallback("LG290P", (uint16_t)bytesRead);
+        fileBytes -= validData;
+        firmwareUpdateProgressCallback("LG290P", (uint16_t)validData);
         lastDataTime = millis();
+        validData = 0;
     }
 
+    // Release the buffers in the LG290P driver
+    lg290pFirmwareUpdateEnd();
+
+    // Done with the firmware update
     systemPrintln(otaEqualSigns);
     if (fileBytes > 0)
-    {
         systemPrintln("LG290P OTA update failed during writeStream");
-        return false;
-    }
-
-    if (lg290pFirmwareUpdateEnd() == false)
-    {
-        systemPrintf("LG290P failed to reboot\r\n");
-        return false;
-    }
-    systemPrintln("LG290P update successfully completed.");
+    else
+        systemPrintln("LG290P update successfully completed.");
     systemPrintln(otaEqualSigns);
-    return true;
+    return (fileBytes == 0);
 }
 
 #endif // COMPILE_LG290P

--- a/Firmware/RTK_Everywhere/GNSS_LG290P.ino
+++ b/Firmware/RTK_Everywhere/GNSS_LG290P.ino
@@ -3813,7 +3813,7 @@ bool lg290pStreamFirmware(NetworkClient * stream,
                           size_t fileBytes,
                           uint32_t expectedCrc,
                           uint8_t * buffer,
-                          size_t bufferBytes)
+                          size_t packetBytes)
 {
     uint32_t crc = 0;
 
@@ -3843,7 +3843,7 @@ bool lg290pStreamFirmware(NetworkClient * stream,
         }
 
         // Read the received data
-        size_t bytesToRead = (availableBytes > bufferBytes) ? bufferBytes : availableBytes;
+        size_t bytesToRead = (availableBytes > packetBytes) ? packetBytes : availableBytes;
         int bytesRead = stream->readBytes(buffer, bytesToRead);
         if (bytesRead <= 0)
             continue;

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -4267,11 +4267,12 @@ bool x20pStreamFirmware(NetworkClient * stream,
     systemPrintln("Device is in bootloader mode.");
 
     unsigned long lastDataTime = millis();
+    size_t validData = 0;
     while (stream->connected() && (fileBytes > 0))
     {
         // Wait until some data is available
-        size_t available = stream->available();
-        if (available == 0)
+        size_t availableBytes = stream->available();
+        if (availableBytes == 0)
         {
             if ((millis() - lastDataTime) > OTA_DATA_TIMEOUT)
             {
@@ -4283,33 +4284,38 @@ bool x20pStreamFirmware(NetworkClient * stream,
         }
 
         // Read the received data
-        size_t toRead = min(available, packetBytes);
-        int bytesRead = stream->readBytes(buffer, toRead);
+        size_t toRead = min(availableBytes, packetBytes - validData);
+        int bytesRead = stream->readBytes(&buffer[validData], toRead);
         if (bytesRead <= 0)
             break;
+        validData += bytesRead;
+
+        // Fill the packet
+        if ((validData < packetBytes) && (validData != fileBytes))
+            continue;
 
         // Compute the CRC
-        crc = crc32Compute(crc, buffer, bytesRead);
+        crc = crc32Compute(crc, buffer, validData);
 
         // Validate the computed CRC matches the expected CRC
-        bool lastPacket = (fileBytes == bytesRead);
-        if (lastPacket && (crc != expectedCrc))
+        if ((fileBytes == validData) && (crc != expectedCrc))
         {
             systemPrintf("ERROR: File has changed, CRC does not match!\r\n");
             break;
         }
 
         // Update this portion of the firmware
-        if (x20pUpdateFirmware(*serialGNSS, buffer, (uint32_t)bytesRead) == false)
+        if (x20pUpdateFirmware(*serialGNSS, buffer, (uint32_t)validData) == false)
         {
             systemPrintln("Firmware update failed during WiFi data upload.");
             break;
         }
 
         // Account for this data
-        fileBytes -= bytesRead;
-        firmwareUpdateProgressCallback("X20P", bytesRead);
+        fileBytes -= validData;
+        firmwareUpdateProgressCallback("X20P", validData);
         lastDataTime = millis();
+        validData = 0;
     }
 
     systemPrintln(otaEqualSigns);

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -3615,8 +3615,6 @@ void f9pNewClass()
 //  x20pFirmwareUpdateBegin(), freed in x20pFirmwareUpdateEnd().
 // ==================================================================
 
-static uint8_t *x20pPageBuffer = nullptr; // Accumulates incoming bytes; flushed every PACKET_SIZE bytes
-static uint16_t x20pBufferIndex = 0;
 static uint32_t x20pCurrentAddress = FW_BASE_ADDR; // Next flash address to write; advances as pages are flashed
 
 static bool x20pEraseComplete = false; // In/out state shared with x20pWriteChunk across calls (see its header comment)
@@ -3830,7 +3828,11 @@ void x20pSendDataFrame(HardwareSerial &ser, uint32_t address, const uint8_t *chu
  * eraseComplete / eraseCompleteAt are in/out: once the CERASE response is
  * seen they are set and remain true for all subsequent packet calls.
  */
-bool x20pWriteChunk(HardwareSerial &ser, uint32_t address, const uint8_t *chunk, uint16_t chunkLen, bool &eraseComplete,
+bool x20pWriteChunk(HardwareSerial &ser,
+                    uint32_t address,
+                    const uint8_t *chunk,
+                    uint16_t chunkLen,
+                    bool &eraseComplete,
                     uint32_t &eraseCompleteAt)
 {
     if (chunkLen == 0 || chunkLen > PACKET_SIZE)
@@ -3955,24 +3957,14 @@ bool x20pUpdateFirmware(HardwareSerial &ser, const uint8_t *data, uint32_t numBy
     if (x20pUpdateFailed)
         return false; // A prior chunk write failed - stop touching the page buffer/flash
 
-    for (uint32_t i = 0; i < numBytes; i++)
+    if (!x20pWriteChunk(ser, x20pCurrentAddress, data, numBytes, x20pEraseComplete,
+                        x20pEraseCompleteAt))
     {
-        x20pPageBuffer[x20pBufferIndex++] = data[i];
-
-        if (x20pBufferIndex == PACKET_SIZE)
-        {
-            if (!x20pWriteChunk(ser, x20pCurrentAddress, x20pPageBuffer, PACKET_SIZE, x20pEraseComplete,
-                                x20pEraseCompleteAt))
-            {
-                systemPrintf("  ERROR: write failed at address 0x%08X\r\n", x20pCurrentAddress);
-                x20pUpdateFailed = true;
-                return false;
-            }
-            x20pCurrentAddress += PACKET_SIZE;
-            x20pBufferIndex = 0;
-        }
+        systemPrintf("  ERROR: write failed at address 0x%08X\r\n", x20pCurrentAddress);
+        x20pUpdateFailed = true;
+        return false;
     }
-
+    x20pCurrentAddress += numBytes;
     return true;
 }
 
@@ -4167,10 +4159,7 @@ bool x20pFirmwareUpdateBegin()
     x20pSend(*serialGNSS, UBX_CLASS_UPD, 0x16, nullptr, 0);
     // Do NOT wait for chip erase ACK here - it arrives while packet 0 is in flight.
 
-    // Allocate the page-accumulation buffer and reset streaming state for this update.
-    if (x20pPageBuffer == nullptr)
-        x20pPageBuffer = (uint8_t *)malloc(PACKET_SIZE);
-    x20pBufferIndex = 0;
+    // Reset streaming state for this update.
     x20pCurrentAddress = FW_BASE_ADDR;
     x20pEraseComplete = false;
     x20pEraseCompleteAt = 0;
@@ -4197,18 +4186,6 @@ bool x20pFirmwareUpdateBegin()
 bool x20pFirmwareUpdateEnd(bool uploadSucceeded)
 {
     bool success = uploadSucceeded && !x20pUpdateFailed;
-
-    if (success && x20pBufferIndex > 0)
-    {
-        success = x20pWriteChunk(*serialGNSS, x20pCurrentAddress, x20pPageBuffer, x20pBufferIndex, x20pEraseComplete,
-                                 x20pEraseCompleteAt);
-        if (!success)
-            systemPrintf("  ERROR: final chunk write failed at address 0x%08X\r\n", x20pCurrentAddress);
-    }
-
-    free(x20pPageBuffer);
-    x20pPageBuffer = nullptr;
-
     if (success)
     {
         // ----------------------------------------------------------

--- a/Firmware/RTK_Everywhere/GNSS_ZED.ino
+++ b/Firmware/RTK_Everywhere/GNSS_ZED.ino
@@ -2222,7 +2222,7 @@ bool GNSS_ZED::setMessagesNMEA()
                 // Set NMEA messages to user's settings on UART1 interface
                 response &= _zed->addCfgValset(ubxMessages[messageNumber].msgConfigKey,
                                                rate); // msgConfigKey defaults to UART1
-                
+
                 // Disable NMEA on I2C : UBLOX_CFG UART1 - 1 = I2C
                 if (ubxMessages[messageNumber].msgClass == UBX_CLASS_NMEA)
                     response &= _zed->addCfgValset(ubxMessages[messageNumber].msgConfigKey - 1, 0);
@@ -4248,7 +4248,7 @@ bool x20pStreamFirmware(NetworkClient * stream,
                         size_t fileBytes,
                         uint32_t expectedCrc,
                         uint8_t * buffer,
-                        size_t bufferBytes)
+                        size_t packetBytes)
 {
     uint32_t crc = 0;
 
@@ -4283,7 +4283,7 @@ bool x20pStreamFirmware(NetworkClient * stream,
         }
 
         // Read the received data
-        size_t toRead = min(available, sizeof(buffer));
+        size_t toRead = min(available, packetBytes);
         int bytesRead = stream->readBytes(buffer, toRead);
         if (bytesRead <= 0)
             break;

--- a/Firmware/RTK_Everywhere/LoRa.ino
+++ b/Firmware/RTK_Everywhere/LoRa.ino
@@ -1944,6 +1944,7 @@ bool stm32StreamFirmware(NetworkClient * stream,
     }
 
     unsigned long lastDataTime = millis();
+    size_t validData = 0;
     while (stream->connected() && (fileBytes > 0))
     {
         // Wait until some data is available
@@ -1960,32 +1961,38 @@ bool stm32StreamFirmware(NetworkClient * stream,
         }
 
         // Read the received data
-        size_t toRead = min(available, packetBytes);
-        int bytesRead = stream->readBytes(buffer, toRead);
+        size_t toRead = min(available, packetBytes - validData);
+        int bytesRead = stream->readBytes(&buffer[validData], toRead);
         if (bytesRead <= 0)
             break;
+        validData += bytesRead;
+
+        // Fill the packet
+        if ((validData < packetBytes) && (validData != fileBytes))
+            continue;
 
         // Compute the CRC
-        crc = crc32Compute(crc, buffer, bytesRead);
+        crc = crc32Compute(crc, buffer, validData);
 
         // Validate the computed CRC matches the expected CRC
-        if ((bytesRead >= fileBytes) && (crc != expectedCrc))
+        if ((validData >= fileBytes) && (crc != expectedCrc))
         {
             systemPrintf("ERROR: File has changed, CRC does not match!\r\n");
             break;
         }
 
         // Update this portion of the firmware
-        if (stm32UpdateFirmware(buffer, (uint16_t)bytesRead) == false)
+        if (stm32UpdateFirmware(buffer, (uint16_t)validData) == false)
         {
             loraSharedPrintln("LoRa/STM32 update failed during WiFi data upload.");
             break;
         }
 
         // Account for this data
-        fileBytes -= bytesRead;
-        firmwareUpdateProgressCallback("LoRa/STM32", bytesRead);
+        fileBytes -= validData;
+        firmwareUpdateProgressCallback("LoRa/STM32", validData);
         lastDataTime = millis();
+        validData = 0;
     }
 
     loraSharedPrintln(otaEqualSigns);

--- a/Firmware/RTK_Everywhere/LoRa.ino
+++ b/Firmware/RTK_Everywhere/LoRa.ino
@@ -1927,7 +1927,7 @@ bool stm32StreamFirmware(NetworkClient * stream,
                          size_t fileBytes,
                          uint32_t expectedCrc,
                          uint8_t * buffer,
-                         size_t bufferBytes)
+                         size_t packetBytes)
 {
     uint32_t crc = 0;
 
@@ -1960,7 +1960,7 @@ bool stm32StreamFirmware(NetworkClient * stream,
         }
 
         // Read the received data
-        size_t toRead = min(available, sizeof(buffer));
+        size_t toRead = min(available, packetBytes);
         int bytesRead = stream->readBytes(buffer, toRead);
         if (bytesRead <= 0)
             break;

--- a/Firmware/RTK_Everywhere/OTA.h
+++ b/Firmware/RTK_Everywhere/OTA.h
@@ -84,7 +84,7 @@ typedef bool (*OTA_STREAM_FIRMWARE)(NetworkClient * stream,
                                     size_t contentLength,
                                     uint32_t expectedCrc,
                                     uint8_t * buffer,
-                                    size_t bufferBytes);
+                                    size_t packetBytes);
 
 typedef struct _OTA_SUBSYSTEM_INFO
 {

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -327,7 +327,8 @@ bool otaFirmwareUpdate(const OTA_TARGET * target, const OTA_SUBSYSTEM_INFO * sub
         }
 
         // Display the performance
-        otaDisplayPerformance(subsystemIndex, startMsec, millis(), fileBytes);
+        if (success)
+            otaDisplayPerformance(subsystemIndex, startMsec, millis(), fileBytes);
         return success;
     } while (0);
     return false;

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -607,7 +607,10 @@ OTA_SUBSYSTEM_MASK otaGetRequiredUpdates(const char * fileData,
                     buffer = csvNextLine(buffer, bufferEnd, fieldCount);
                     continue;
                 }
-                if ((target->_requestType == OTA_REQUEST_LATEST_VERSION)
+
+                // Check the version for latest or RC requests
+                if (((target->_requestType == OTA_REQUEST_LATEST_VERSION)
+                    || (target->_requestType == OTA_REQUEST_USE_RC))
                     && (versionDelta >= 0))
                 {
                     target->_requestType = OTA_REQUEST_SKIP_UPDATE;

--- a/Firmware/RTK_Everywhere/OTA.ino
+++ b/Firmware/RTK_Everywhere/OTA.ino
@@ -318,7 +318,7 @@ bool otaFirmwareUpdate(const OTA_TARGET * target, const OTA_SUBSYSTEM_INFO * sub
                                                  target->_fileBytes,
                                                  target->_crc,
                                                  otaFirmwareBuffer,
-                                                 OTA_BUFFER_BYTES);
+                                                 subsystemInfo->_packetBytes);
         if ((success == false) && (subsystemIndex == OTA_SUBSYSTEM_ESP32))
         {
             webServerSendString((char *)"gettingNewFirmware,ERROR,");

--- a/Firmware/RTK_Everywhere/Tilt.ino
+++ b/Firmware/RTK_Everywhere/Tilt.ino
@@ -1900,7 +1900,7 @@ static bool im19StreamMissingRanges(const char *url)
 bool im19FirmwareUpdate(const OTA_TARGET * target,
                         const OTA_SUBSYSTEM_INFO * subsystemInfo,
                         uint8_t * buffer,
-                        size_t bufferBytes)
+                        size_t packetBytes)
 {
     WiFiClientSecure client;
     if (!otaSecurelyConnectGitHub(client))

--- a/Firmware/RTK_Everywhere/menuFirmware.ino
+++ b/Firmware/RTK_Everywhere/menuFirmware.ino
@@ -666,6 +666,7 @@ bool otaEsp32StreamFirmware(NetworkClient * stream,
 
     // Stream the firmware in chunks so we can report progress via
     // firmwareUpdateProgressCallback() along the way.
+    size_t validData = 0;
     while (stream->connected() && (fileBytes > 0))
     {
         // Wait until some data is available
@@ -682,32 +683,38 @@ bool otaEsp32StreamFirmware(NetworkClient * stream,
         }
 
         // Read the received data
-        size_t bytesToRead = (availableBytes > packetBytes) ? packetBytes : availableBytes;
-        int bytesRead = stream->readBytes(buffer, bytesToRead);
+        size_t bytesToRead = min(availableBytes, packetBytes - validData);
+        int bytesRead = stream->readBytes(&buffer[validData], bytesToRead);
         if (bytesRead <= 0)
+            break;
+        validData += bytesRead;
+
+        // Fill the packet
+        if ((validData < packetBytes) && (validData != fileBytes))
             continue;
 
         // Compute the CRC
-        crc = crc32Compute(crc, buffer, bytesRead);
+        crc = crc32Compute(crc, buffer, validData);
 
         // Validate the computed CRC matches the expected CRC
-        if ((fileBytes == 0) && (crc != expectedCrc))
+        if ((fileBytes == validData) && (crc != expectedCrc))
         {
             systemPrintf("ERROR: File has changed, CRC does not match!\r\n");
             break;
         }
 
         // Update this portion of the firmware
-        if (Update.write(buffer, bytesRead) != (size_t)bytesRead)
+        if (Update.write(buffer, validData) != (size_t)validData)
         {
             systemPrintln("ESP32 OTA update failed during write");
             return false;
         }
 
         // Account for this data
-        fileBytes -= bytesRead;
-        firmwareUpdateProgressCallback("ESP32", (uint16_t)bytesRead);
+        fileBytes -= validData;
+        firmwareUpdateProgressCallback("ESP32", (uint16_t)validData);
         lastDataTime = millis();
+        validData = 0;
     }
 
     systemPrintln(otaEqualSigns);

--- a/Firmware/RTK_Everywhere/menuFirmware.ino
+++ b/Firmware/RTK_Everywhere/menuFirmware.ino
@@ -648,7 +648,7 @@ bool otaEsp32StreamFirmware(NetworkClient * stream,
                             size_t fileBytes,
                             uint32_t expectedCrc,
                             uint8_t * buffer,
-                            size_t bufferBytes)
+                            size_t packetBytes)
 {
     uint32_t crc = 0;
 
@@ -682,7 +682,7 @@ bool otaEsp32StreamFirmware(NetworkClient * stream,
         }
 
         // Read the received data
-        size_t bytesToRead = (availableBytes > bufferBytes) ? bufferBytes : availableBytes;
+        size_t bytesToRead = (availableBytes > packetBytes) ? packetBytes : availableBytes;
         int bytesRead = stream->readBytes(buffer, bytesToRead);
         if (bytesRead <= 0)
             continue;

--- a/Firmware/Test Sketches/Flash_Update/LG290P_Update_From_Array/GNSS.ino
+++ b/Firmware/Test Sketches/Flash_Update/LG290P_Update_From_Array/GNSS.ino
@@ -3,6 +3,8 @@ void gnssBoot()
 {
 #ifdef PLATFORM_FP
     gpioExpanderGnssBoot(); // Drive the GNSS reset pin high
+#elif defined(PLATFORM_POSTCARD)
+    digitalWrite(pin_GNSS_DR_Reset, HIGH); // Tell LG290P to boot
 #elif defined(PLATFORM_TX2)
     digitalWrite(pin_GNSS_DR_Reset, HIGH); // Tell LG290P to boot
 #endif
@@ -14,6 +16,8 @@ void gnssReset()
 
 #ifdef PLATFORM_FP
     gpioExpanderGnssReset(); // Drive the GNSS reset pin low
+#elif defined(PLATFORM_POSTCARD)
+    digitalWrite(pin_GNSS_DR_Reset, LOW); // Tell LG290P to reset
 #elif defined(PLATFORM_TX2)
     digitalWrite(pin_GNSS_DR_Reset, LOW); // Tell LG290P to reset
 #endif

--- a/Firmware/Test Sketches/Flash_Update/LG290P_Update_From_Array/GNSS_LG290P.ino
+++ b/Firmware/Test Sketches/Flash_Update/LG290P_Update_From_Array/GNSS_LG290P.ino
@@ -13,6 +13,14 @@ bool lg290pFirmwareUpdateBegin()
 
     // Begin update: reboot, sync, version, firmware info, erase (~30 s)
     return (myGnss.updateFirmwareBegin(fileSize, crc, true)); // Skip software reset
+#elif defined(PLATFORM_POSTCARD)
+    // If a previous attempt failed, the device won't respond to software reset commands. Do a hardware reset.
+    gnssReset();
+    delay(100);
+    gnssBoot();
+
+    // Begin update: reboot, sync, version, firmware info, erase (~30 s)
+    return (myGnss.updateFirmwareBegin(fileSize, crc, true)); // Skip software reset
 #elif defined(PLATFORM_FP)
     // We don't have hardware reset so use software reset.
 
@@ -39,6 +47,12 @@ bool lg290pFirmwareUpdate(uint8_t *dataArray, uint16_t bytesToWrite, bool sendLa
 bool lg290pFirmwareUpdateEnd()
 {
 #ifdef PLATFORM_TX2
+    gnssReset();
+    delay(100);
+    gnssBoot();
+
+    return (myGnss.updateFirmwareIsFinished(10));
+#elif defined(PLATFORM_POSTCARD)
     gnssReset();
     delay(100);
     gnssBoot();

--- a/Firmware/Test Sketches/Flash_Update/LG290P_Update_From_Array/LG290P_Update_From_Array.ino
+++ b/Firmware/Test Sketches/Flash_Update/LG290P_Update_From_Array/LG290P_Update_From_Array.ino
@@ -9,7 +9,7 @@
     Press 'r' to reset. The GNSS module should boot and respond to commands.
 
     If the update fails, the LG290P must be hardware reset or power reset, at which time
-    it will enter into a state where it can enter bootloader mode again. On the TX2, there is 
+    it will enter into a state where it can enter bootloader mode again. On the TX2, there is
     hardware reset. On the FP, the user may need to power cycle the device and restart the update.
 
     All loaders should have similar structure:
@@ -24,7 +24,8 @@
 
 #include "TheData.h" //Array containing the PKG data
 
-#define PLATFORM_FP
+//#define PLATFORM_FP
+#define PLATFORM_POSTCARD
 // #define PLATFORM_TX2
 
 #include <SparkFun_LG290P_GNSS.h>
@@ -33,9 +34,6 @@ LG290P myGnss;
 #include <SparkFun_I2C_Expander_Arduino_Library.h> // Click here to get the library: http://librarymanager/All#SparkFun_I2C_Expander_Arduino_Library
 SFE_PCA95XX io(PCA95XX_PCA9534); // Create a PCA9534
 SFE_PCA95XX *gpioExpanderSwitches = nullptr;
-
-int pin_SDA = 15;
-int pin_SCL = 4;
 
 const int gpioExpanderSwitch_S1 = 0; // Controls U16 switch 1: connect ESP UART0 to CH342 or SW2
 const int gpioExpanderSwitch_S2 = 1; // Controls U17 switch 2: connect SW1 to RS232 Output or GNSS UART4
@@ -51,9 +49,19 @@ const int gpioExpanderNumSwitches = 8;
 HardwareSerial SerialGNSS(1); // Use UART1 on the ESP32
 
 #ifdef PLATFORM_FP
+int pin_SDA = 15;
+int pin_SCL = 4;
 int pin_UART1_TX = 27; // FP
 int pin_UART1_RX = 26;
+#elif defined(PLATFORM_POSTCARD)
+int pin_SDA = 7;
+int pin_SCL = 20;
+int pin_UART1_TX = 22; // TX2
+int pin_UART1_RX = 21;
+int pin_GNSS_DR_Reset = 33; // Push low to reset GNSS/DR.
 #elif defined(PLATFORM_TX2)
+int pin_SDA = 15;
+int pin_SCL = 4;
 int pin_UART1_TX = 17; // TX2
 int pin_UART1_RX = 14;
 int pin_GNSS_DR_Reset = 22; // Push low to reset GNSS/DR.
@@ -96,6 +104,8 @@ void setup()
 
     // Connect Facet FP GNSS receiver UART1 to ESP32 UART1 for normal comms
     gpioExpanderConnectGNSSToESP32();
+#elif defined(PLATFORM_POSTCARD)
+    pinMode(pin_GNSS_DR_Reset, OUTPUT);
 #elif defined(PLATFORM_TX2)
     pinMode(pin_GNSS_DR_Reset, OUTPUT);
 #endif
@@ -136,6 +146,15 @@ void setup()
         offset += n;
     }
     Serial.printf("CRC32: 0x%08X\r\n", crc);
+    displayMenu();
+}
+
+void displayMenu()
+{
+    Serial.println();
+    Serial.println("r) Restart the ESP32");
+    Serial.println("u) Update the LG290P firmware");
+    Serial.print("Selection: ");
 }
 
 void loop()
@@ -143,6 +162,7 @@ void loop()
     if (Serial.available())
     {
         byte incoming = Serial.read();
+        Serial.printf("%c\r\n", incoming);
         if (incoming == 'r')
         {
             ESP.restart();
@@ -159,6 +179,7 @@ void loop()
             else
             {
                 Serial.println("Failed to enter bootloader mode.");
+                displayMenu();
                 return;
             }
 
@@ -173,6 +194,7 @@ void loop()
                 if (lg290pFirmwareUpdate(&c, 1, false) == false)
                 {
                     Serial.println("Firmware update failed during data upload.");
+                    displayMenu();
                     return;
                 }
             }
@@ -183,6 +205,7 @@ void loop()
             else
             {
                 Serial.println("FAILED");
+                displayMenu();
                 return;
             }
 
@@ -192,6 +215,7 @@ void loop()
             else
             {
                 Serial.println("LG290P update failed.");
+                displayMenu();
                 return;
             }
 
@@ -200,6 +224,7 @@ void loop()
             Serial.print("Firmware update time: ");
             Serial.print(firmwareUpdateElapsed / 1000.0, 3);
             Serial.println(" seconds");
+            displayMenu();
         }
     }
 }


### PR DESCRIPTION
This pull request contains the following commits:
* OTA: Use latest version when RC requested but not found
* Example: Add POSTCARD support to Flash_Update/LG290P_Update_From_Array
    Add displayMenu
* OTA: Only display performance metrics upon successful firmware update
* Switch from bufferBytes to packetBytes
* ESP32 OTA: Read full packets before write
* LG290P OTA: Read full packets before write
* LoRa OTA: Read full packets before write
* X20P OTA: Read full packets before write
* X20P OTA: Remove x20pPageBuffer