### PR TITLE
Add example showing how to update IM19 from microSD

### DIFF
--- a/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/Begin.ino
+++ b/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/Begin.ino
@@ -1,0 +1,99 @@
+//----------------------------------------
+// Configure UART2 serial port shared between LoRa and Tilt
+// This only applies to the FP. The Torch has tilt connected direct to ESP UART0 (shared with USB)
+//----------------------------------------
+bool beginUart2Serial()
+{
+    // Determine if serial port is already configured
+    if (uart2Serial)
+        return true;
+
+    // Allocate the serial port object
+    uart2Serial = new HardwareSerial(2);
+
+    // Determine if the allocation failed
+    if (uart2Serial == nullptr)
+    {
+        systemPrintf("ERROR: Failed to allocate the uart2Serial port!\r\n");
+        return false;
+    }
+
+    // Configure the serial port
+    //uart2Serial->setRxBufferSize(settings.uartReceiveBufferSize);
+    //uart2Serial->setTimeout(settings.serialTimeoutGNSS); // Requires serial traffic on the UART pins for detection
+    uart2Serial->begin(115200, SERIAL_8N1, pin_IMU_RX, pin_IMU_TX);
+    return true;
+}
+
+//----------------------------------------
+// Select the desired *.enc file from the microSD root directory
+// Return the file name in the global char array fileName
+// Use the global file object (File / File32 / ExFile / FsFile) to check the file size
+// Use the global dir object to access the directory
+//----------------------------------------
+bool selectFirmwareFile()
+{
+    systemPrintln("Select firmware file:");
+
+    // Open root directory
+    if (!dir.open("/")) {
+        systemPrintln("ERROR: dir.open failed");
+        return false;
+    }
+
+    // Open next file in root.
+    // Warning, openNext starts at the current position of dir so a
+    // rewind may be necessary in your application.
+    bool fileSelected = false;
+    while (file.openNext(&dir, O_RDONLY)) {
+        if (!file.isDir()) {
+            file.getName(fileName, sizeof(fileName));
+            size_t fileNameLen = strlen(fileName);
+            if (fileNameLen > 10) {
+                if ((fileName[fileNameLen - 4] == '.') &&
+                    ((fileName[fileNameLen - 3] == 'E') || (fileName[fileNameLen - 3] == 'e')) &&
+                    ((fileName[fileNameLen - 2] == 'N') || (fileName[fileNameLen - 2] == 'n')) &&
+                    ((fileName[fileNameLen - 1] == 'C') || (fileName[fileNameLen - 1] == 'c'))) {
+                    systemPrint("Update with ");
+                    systemPrint(fileName);
+                    systemPrint(" (");
+                    systemPrint(file.fileSize());
+                    systemPrintln(" bytes) (y/N)?");
+                    do {
+                        if (systemAvailable())
+                        {
+                            byte incoming = systemRead();
+                            if ((incoming == 'Y') || (incoming == 'y'))
+                                fileSelected = true;
+                            break;
+                        }
+                    } while (1);
+                }
+            }
+        }
+        if (!fileSelected)
+            file.close();
+        else
+            break;
+    }
+
+    if (!file)
+    {
+        systemPrintln("ERROR: no firmware file found / selected");
+        return false;
+    }
+
+    file.close(); // im19 methods will re-open the file
+
+    return true;
+}
+
+//----------------------------------------
+// Print the menu to systemPrint (Serial)
+//----------------------------------------
+void printMenu()
+{
+    systemPrintln();
+    systemPrintln("r) Reset ESP32");
+    systemPrintln("u) Update firmware with *.enc from the SD card root folder");
+}

--- a/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/IM19_Update_From_microSD.ino
+++ b/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/IM19_Update_From_microSD.ino
@@ -22,7 +22,9 @@
     Pull the IM19 Breakout CH342_EN pad low, to disconnect the CH342
     Connect TX1 of the IM19 to pin 16 of the ESP32
     Connect RX1 of the IM19 to pin 17 of the ESP32
+    Connect IM19 RST to pin 4 of the ESP32
 */
+
 #include "Tilt.h"
 
 #include "SdFat.h"
@@ -30,8 +32,8 @@
 // Adjust these values according to your configuration
 //------------------------------------------------------------------------------
 // https://www.sparkfun.com/sparkfun-thing-plus-esp32-wroom-usb-c.html
-int pin_UART1_TX = 17;
-int pin_UART1_RX = 16;
+int pin_IMU_TX = 17;
+int pin_IMU_RX = 16;
 int pin_GNSS_DR_Reset = 4; // The Free pin
 int pin_SCK = 18;
 int pin_PICO = 23; // microSD SDI
@@ -39,7 +41,9 @@ int pin_POCI = 19; // microSD SDO
 int pin_microSD_CS = 5;
 const char * platform = "SparkFun ESP32 Thing Plus C";
 
-HardwareSerial IMU_SERIAL(1); // Use UART1 on the ESP32
+HardwareSerial *uart2Serial;
+
+#define SerialForTilt uart2Serial
 
 #define SD_CONFIG SdSpiConfig(pin_microSD_CS, SHARED_SPI, SD_SCK_MHZ(16))
 //#define SD_CONFIG SdSpiConfig(pin_microSD_CS, DEDICATED_SPI, SD_SCK_MHZ(16))
@@ -80,12 +84,7 @@ uint32_t firmwareUpdateBytesProcessed = 0;
 
 char imuVersion[96];
 
-void printMenu()
-{
-    Serial.println();
-    Serial.println("r) Reset ESP32");
-    Serial.println("u) Update firmware with *.enc from the SD card root folder");
-}
+char fileName[strlen("20260522185649_VH2_B2.2_A11.4.1_131b44ecee0bdad5670c7.enc") + 10];
 
 void setup()
 {
@@ -96,20 +95,20 @@ void setup()
 
     Serial.begin(115200);
 
-    Serial.println("IM19 firmware update test");
-    Serial.flush();
+    systemPrintln("IM19 firmware update test");
+    systemFlush();
 
     SPI.begin(pin_SCK, pin_POCI, pin_PICO);
 
     if (sd.begin(SD_CONFIG) == false)
     {
-        Serial.println("Failed to start SD. Freezing...");
+        systemPrintln("Failed to start SD. Freezing...");
         while (1)
             ;
     }
-    Serial.println("SD started");
+    systemPrintln("SD started");
 
-    IMU_SERIAL.begin(115200, SERIAL_8N1, pin_UART1_RX, pin_UART1_TX);
+    beginUart2Serial(); // Init the UART that communicates between the ESP32 and the IM19.
 
     systemPrint("Checking IM19 version: ");
     if (im19GetVersionString(imuVersion, sizeof(imuVersion)))
@@ -122,144 +121,35 @@ void setup()
 
 void loop()
 {
-    if (Serial.available())
+    if (systemAvailable())
     {
-        byte incoming = Serial.read();
+        byte incoming = systemRead();
         if (incoming == 'r')
         {
             ESP.restart();
         }
         else if (incoming == 'u')
         {
-            Serial.println("Select firmware file:");
-
-            // Open root directory
-            if (!dir.open("/")) {
-                Serial.println("ERROR: dir.open failed");
-                return;
-            }
-
-            // Open next file in root.
-            // Warning, openNext starts at the current position of dir so a
-            // rewind may be necessary in your application.
-            bool fileSelected = false;
-            while (file.openNext(&dir, O_RDONLY)) {
-                if (!file.isDir()) {
-                    char fileName[strlen("20260522185649_VH2_B2.2_A11.4.1_131b44ecee0bdad5670c7.enc") + 10];
-                    file.getName(fileName, sizeof(fileName));
-                    size_t fileNameLen = strlen(fileName);
-                    //Serial.println(fileName);
-                    if (fileNameLen > 10) {
-                        if ((fileName[fileNameLen - 4] == '.') &&
-                            ((fileName[fileNameLen - 3] == 'E') || (fileName[fileNameLen - 3] == 'e')) &&
-                            ((fileName[fileNameLen - 2] == 'N') || (fileName[fileNameLen - 2] == 'n')) &&
-                            ((fileName[fileNameLen - 1] == 'C') || (fileName[fileNameLen - 1] == 'c'))) {
-                            Serial.print("Update with ");
-                            Serial.print(fileName);
-                            Serial.print(" (");
-                            Serial.print(file.fileSize());
-                            Serial.println(" bytes) (y/N)?");
-                            do {
-                                if (Serial.available())
-                                {
-                                    byte incoming = Serial.read();
-                                    if ((incoming == 'Y') || (incoming == 'y'))
-                                        fileSelected = true;
-                                    break;
-                                }
-                            } while (1);
-                        }
-                    }
-                }
-                if (!fileSelected)
-                    file.close();
-                else
-                    break;
-            }
-
-            if (!file)
+            if (selectFirmwareFile())
             {
-                Serial.println("ERROR: no firmware file found / selected");
-                return;
-            }
+                systemPrintln("Starting IM19 firmware update...");
 
-            systemPrintln("Starting IM19 firmware update...");
+                firmwareUpdateBytesToProcess = 0;
+                firmwareUpdateBytesProcessed = 0;
+                firmwareUpdateStartTime = millis();
 
-            // Start timer before erase
-            firmwareUpdateStartTime = millis();
-
-            if (im19UpdateFirmwareBegin() == false)
-            {
-                systemPrintln("Failed to enter update mode (AT+UPDATE_APP).");
-                return;
-            }
-            systemPrintln("IM19 is in update mode, sending firmware...");
-
-            firmwareUpdateBytesToProcess = file.fileSize();
-            firmwareUpdateBytesProcessed = 0;
-
-            // Frames already acknowledged by the
-            // IM19 (tracked in im19FrameMap) are skipped rather than resent.
-            bool updateSuccess = false;
-            bool uploadFailed = false;
-            int passesLeft = 5;
-            while (passesLeft > 0)
-            {
-                uint32_t blobIndex = 0;
-                while (blobIndex < file.fileSize())
+                if (im19StreamFirmwareFromFile((const char *)fileName) == true)
                 {
-                    // Test with 17-byte sized chunks
-                    uint32_t chunk = min((uint32_t)17, (uint32_t)(file.fileSize() - blobIndex));
-                    uint8_t chunkStore[chunk];
-                    size_t n = file.read(chunkStore, chunk);
-                    if (im19UpdateFirmware(chunkStore, n) == false)
-                    {
-                        systemPrintln("Firmware update failed during data upload.");
-                        uploadFailed = true;
-                        break;
-                    }
-                    blobIndex += n;
-                }
-                if (uploadFailed)
-                    break;
+                    firmwareUpdateElapsed = millis() - firmwareUpdateStartTime;
+                    systemPrintf("IM19 firmware update complete in %0.2f s.\r\n", firmwareUpdateElapsed / 1000.0);
 
-                int result = im19UpdateFirmwareEndPass();
-                passesLeft--;
-                if (result == IM19_UPDATE_SUCCESS)
-                {
-                    updateSuccess = true;
-                    break;
+                    systemPrint("Checking IM19 version: ");
+                    if (im19GetVersionString(imuVersion, sizeof(imuVersion)))
+                        systemPrintln(imuVersion);
+                    else
+                        systemPrintln("Version query failed.");
                 }
-                else if (result == IM19_UPDATE_FAILED)
-                {
-                    break;
-                }
-                // else IM19_UPDATE_RETRY: loop and re-stream the array
             }
-
-            im19UpdateFirmwareEnd();
-
-            file.close();
-
-            if (updateSuccess)
-                systemPrintln("Upgrade completed successfully.");
-            else
-                systemPrintln("Upgrade failed.");
-
-            if (updateSuccess)
-            {
-                systemPrint("Checking IM19 version: ");
-                if (im19GetVersionString(imuVersion, sizeof(imuVersion)))
-                    systemPrintln(imuVersion);
-                else
-                    systemPrintln("Version query failed.");
-            }
-
-            // Stop timer and print elapsed time
-            firmwareUpdateElapsed = millis() - firmwareUpdateStartTime;
-            systemPrint("Firmware update time: ");
-            systemPrint(firmwareUpdateElapsed / 1000.0, 3);
-            systemPrintln(" seconds");
 
             printMenu();
         }

--- a/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/IM19_Update_From_microSD.ino
+++ b/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/IM19_Update_From_microSD.ino
@@ -1,0 +1,267 @@
+/*
+    This example shows how to read a firmware file from microSD and send chunks to the IM19.
+
+    Ported from the reference implementation in upgrade.c: a 268-byte framed
+    protocol (0xAA55 header, 256-byte payload, uint32 checksum) used to push
+    a firmware image to the IM19 module and confirm it booted the new image.
+
+    This example is written for the ESP32 Thing Plus C:
+    https://www.sparkfun.com/sparkfun-thing-plus-esp32-wroom-usb-c.html
+    Connected to a IM19 Breakout:
+    https://www.sparkfun.com/sparkfun-9dof-imu-breakout.html
+
+    To test: load this sketch onto the ESP32 Thing Plus C.
+    Place multiple IM19 firmware binaries in the root directory of the SD card.
+    https://github.com/sparkfun/SparkFun_RTK_Everywhere_Firmware_Binaries/tree/main/imu/im19
+    E.g.:
+    20230419111130_VH2_B2.2_A6.1_2eea4d4c024538bf5ed52.enc
+    20260302210315_VH2_B2.2_A11.1_6bf04becee0bda310e65d.enc
+    20260522185649_VH2_B2.2_A11.4.1_131b44ecee0bdad5670c7.enc
+
+    Hardware Connections:
+    Pull the IM19 Breakout CH342_EN pad low, to disconnect the CH342
+    Connect TX1 of the IM19 to pin 16 of the ESP32
+    Connect RX1 of the IM19 to pin 17 of the ESP32
+*/
+#include "Tilt.h"
+
+#include "SdFat.h"
+
+// Adjust these values according to your configuration
+//------------------------------------------------------------------------------
+// https://www.sparkfun.com/sparkfun-thing-plus-esp32-wroom-usb-c.html
+int pin_UART1_TX = 17;
+int pin_UART1_RX = 16;
+int pin_GNSS_DR_Reset = 4; // The Free pin
+int pin_SCK = 18;
+int pin_PICO = 23; // microSD SDI
+int pin_POCI = 19; // microSD SDO
+int pin_microSD_CS = 5;
+const char * platform = "SparkFun ESP32 Thing Plus C";
+
+HardwareSerial IMU_SERIAL(1); // Use UART1 on the ESP32
+
+#define SD_CONFIG SdSpiConfig(pin_microSD_CS, SHARED_SPI, SD_SCK_MHZ(16))
+//#define SD_CONFIG SdSpiConfig(pin_microSD_CS, DEDICATED_SPI, SD_SCK_MHZ(16))
+
+// SD_FAT_TYPE = 0 for SdFat/File as defined in SdFatConfig.h,
+// 1 for FAT16/FAT32, 2 for exFAT, 3 for FAT16/FAT32 and exFAT.
+#define SD_FAT_TYPE 3
+#if SD_FAT_TYPE == 0
+SdFat sd;
+File dir;
+File file;
+#elif SD_FAT_TYPE == 1
+SdFat32 sd;
+File32 dir;
+File32 file;
+#elif SD_FAT_TYPE == 2
+SdExFat sd;
+ExFile dir;
+ExFile file;
+#elif SD_FAT_TYPE == 3
+SdFs sd;
+FsFile dir;
+FsFile file;
+#else  // SD_FAT_TYPE
+#error invalid SD_FAT_TYPE
+#endif  // SD_FAT_TYPE
+
+// Reports firmware update progress to the shared system callback.
+void firmwareUpdateProgressCallback(uint16_t bytesProcessed);
+
+// Timer for firmware update duration
+unsigned long firmwareUpdateStartTime = 0;
+unsigned long firmwareUpdateElapsed = 0;
+
+// Global variables used by firmwareUpdateProgressCallback, called by all firmware update procedures
+uint32_t firmwareUpdateBytesToProcess = 0;
+uint32_t firmwareUpdateBytesProcessed = 0;
+
+char imuVersion[96];
+
+void printMenu()
+{
+    Serial.println();
+    Serial.println("r) Reset ESP32");
+    Serial.println("u) Update firmware with *.enc from the SD card root folder");
+}
+
+void setup()
+{
+    pinMode(pin_GNSS_DR_Reset, OUTPUT);
+    digitalWrite(pin_GNSS_DR_Reset, HIGH); // Keep GNSS/DR out of reset
+
+    delay(1000);
+
+    Serial.begin(115200);
+
+    Serial.println("IM19 firmware update test");
+    Serial.flush();
+
+    SPI.begin(pin_SCK, pin_POCI, pin_PICO);
+
+    if (sd.begin(SD_CONFIG) == false)
+    {
+        Serial.println("Failed to start SD. Freezing...");
+        while (1)
+            ;
+    }
+    Serial.println("SD started");
+
+    IMU_SERIAL.begin(115200, SERIAL_8N1, pin_UART1_RX, pin_UART1_TX);
+
+    systemPrint("Checking IM19 version: ");
+    if (im19GetVersionString(imuVersion, sizeof(imuVersion)))
+        systemPrintln(imuVersion);
+    else
+        systemPrintln("Version query failed.");
+
+    printMenu();
+}
+
+void loop()
+{
+    if (Serial.available())
+    {
+        byte incoming = Serial.read();
+        if (incoming == 'r')
+        {
+            ESP.restart();
+        }
+        else if (incoming == 'u')
+        {
+            Serial.println("Select firmware file:");
+
+            // Open root directory
+            if (!dir.open("/")) {
+                Serial.println("ERROR: dir.open failed");
+                return;
+            }
+
+            // Open next file in root.
+            // Warning, openNext starts at the current position of dir so a
+            // rewind may be necessary in your application.
+            bool fileSelected = false;
+            while (file.openNext(&dir, O_RDONLY)) {
+                if (!file.isDir()) {
+                    char fileName[strlen("20260522185649_VH2_B2.2_A11.4.1_131b44ecee0bdad5670c7.enc") + 10];
+                    file.getName(fileName, sizeof(fileName));
+                    size_t fileNameLen = strlen(fileName);
+                    //Serial.println(fileName);
+                    if (fileNameLen > 10) {
+                        if ((fileName[fileNameLen - 4] == '.') &&
+                            ((fileName[fileNameLen - 3] == 'E') || (fileName[fileNameLen - 3] == 'e')) &&
+                            ((fileName[fileNameLen - 2] == 'N') || (fileName[fileNameLen - 2] == 'n')) &&
+                            ((fileName[fileNameLen - 1] == 'C') || (fileName[fileNameLen - 1] == 'c'))) {
+                            Serial.print("Update with ");
+                            Serial.print(fileName);
+                            Serial.print(" (");
+                            Serial.print(file.fileSize());
+                            Serial.println(" bytes) (y/N)?");
+                            do {
+                                if (Serial.available())
+                                {
+                                    byte incoming = Serial.read();
+                                    if ((incoming == 'Y') || (incoming == 'y'))
+                                        fileSelected = true;
+                                    break;
+                                }
+                            } while (1);
+                        }
+                    }
+                }
+                if (!fileSelected)
+                    file.close();
+                else
+                    break;
+            }
+
+            if (!file)
+            {
+                Serial.println("ERROR: no firmware file found / selected");
+                return;
+            }
+
+            systemPrintln("Starting IM19 firmware update...");
+
+            // Start timer before erase
+            firmwareUpdateStartTime = millis();
+
+            if (im19UpdateFirmwareBegin() == false)
+            {
+                systemPrintln("Failed to enter update mode (AT+UPDATE_APP).");
+                return;
+            }
+            systemPrintln("IM19 is in update mode, sending firmware...");
+
+            firmwareUpdateBytesToProcess = file.fileSize();
+            firmwareUpdateBytesProcessed = 0;
+
+            // Frames already acknowledged by the
+            // IM19 (tracked in im19FrameMap) are skipped rather than resent.
+            bool updateSuccess = false;
+            bool uploadFailed = false;
+            int passesLeft = 5;
+            while (passesLeft > 0)
+            {
+                uint32_t blobIndex = 0;
+                while (blobIndex < file.fileSize())
+                {
+                    // Test with 17-byte sized chunks
+                    uint32_t chunk = min((uint32_t)17, (uint32_t)(file.fileSize() - blobIndex));
+                    uint8_t chunkStore[chunk];
+                    size_t n = file.read(chunkStore, chunk);
+                    if (im19UpdateFirmware(chunkStore, n) == false)
+                    {
+                        systemPrintln("Firmware update failed during data upload.");
+                        uploadFailed = true;
+                        break;
+                    }
+                    blobIndex += n;
+                }
+                if (uploadFailed)
+                    break;
+
+                int result = im19UpdateFirmwareEndPass();
+                passesLeft--;
+                if (result == IM19_UPDATE_SUCCESS)
+                {
+                    updateSuccess = true;
+                    break;
+                }
+                else if (result == IM19_UPDATE_FAILED)
+                {
+                    break;
+                }
+                // else IM19_UPDATE_RETRY: loop and re-stream the array
+            }
+
+            im19UpdateFirmwareEnd();
+
+            file.close();
+
+            if (updateSuccess)
+                systemPrintln("Upgrade completed successfully.");
+            else
+                systemPrintln("Upgrade failed.");
+
+            if (updateSuccess)
+            {
+                systemPrint("Checking IM19 version: ");
+                if (im19GetVersionString(imuVersion, sizeof(imuVersion)))
+                    systemPrintln(imuVersion);
+                else
+                    systemPrintln("Version query failed.");
+            }
+
+            // Stop timer and print elapsed time
+            firmwareUpdateElapsed = millis() - firmwareUpdateStartTime;
+            systemPrint("Firmware update time: ");
+            systemPrint(firmwareUpdateElapsed / 1000.0, 3);
+            systemPrintln(" seconds");
+
+            printMenu();
+        }
+    }
+}

--- a/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/Print.ino
+++ b/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/Print.ino
@@ -1,0 +1,197 @@
+// Enable printfs to various endpoints
+// https://stackoverflow.com/questions/42131753/wrapper-for-printf
+void systemPrintf(const char *format, ...)
+{
+  va_list args;
+  va_start(args, format);
+
+  va_list args2;
+  va_copy(args2, args);
+  char buf[vsnprintf(nullptr, 0, format, args) + 1];
+
+  vsnprintf(buf, sizeof buf, format, args2);
+
+  systemPrint(buf);
+
+  va_end(args);
+  va_end(args2);
+}
+
+// If we are printing to all endpoints, BT gets priority
+int systemAvailable()
+{
+//  if (bluetoothIsConnected())
+//    return (bluetoothAvailable());
+
+  return (Serial.available());
+}
+
+// If we are reading all endpoints, BT gets priority
+int systemRead()
+{
+//  if (bluetoothIsConnected())
+//    return (bluetoothRead());
+
+  return (Serial.read());
+}
+
+// Output a buffer of the specified length to the serial port
+void systemWrite(const uint8_t *buffer, uint16_t length)
+{
+  //bluetoothWrite(buffer, length);
+  Serial.write(buffer, length);
+}
+
+// Ensure all serial output has been transmitted, FIFOs are empty
+void systemFlush()
+{
+  //bluetoothFlush();
+  Serial.flush();
+}
+
+// Output a byte to the serial port
+void systemWrite(uint8_t value)
+{
+  systemWrite(&value, 1);
+}
+
+// Point the string at the selected endpoint
+void systemPrint(const char *string)
+{
+  systemWrite((const uint8_t *)string, strlen(string));
+}
+
+// Print a string with a carriage return and linefeed
+void systemPrintln(const char *value)
+{
+  systemPrint(value);
+  systemPrintln();
+}
+
+// Print an integer value
+void systemPrint(int value)
+{
+  char temp[20];
+  snprintf(temp, sizeof(temp), "%d", value);
+  systemPrint(temp);
+}
+
+// Print an integer value as HEX or decimal
+void systemPrint(int value, uint8_t printType)
+{
+  char temp[20];
+
+  if (printType == HEX)
+    snprintf(temp, sizeof(temp), "%08X", value);
+  else if (printType == DEC)
+    snprintf(temp, sizeof(temp), "%d", value);
+
+  systemPrint(temp);
+}
+
+// Pretty print IP addresses
+void systemPrint(IPAddress ipaddress)
+{
+  systemPrint(ipaddress.toString().c_str());
+}
+void systemPrintln(IPAddress ipaddress)
+{
+  systemPrint(ipaddress);
+  systemPrintln();
+}
+
+// Print an integer value with a carriage return and line feed
+void systemPrintln(int value)
+{
+  systemPrint(value);
+  systemPrintln();
+}
+
+// Print an 8-bit value as HEX or decimal
+void systemPrint(uint8_t value, uint8_t printType)
+{
+  char temp[20];
+
+  if (printType == HEX)
+    snprintf(temp, sizeof(temp), "%02X", value);
+  else if (printType == DEC)
+    snprintf(temp, sizeof(temp), "%d", value);
+
+  systemPrint(temp);
+}
+
+// Print an 8-bit value as HEX or decimal with a carriage return and linefeed
+void systemPrintln(uint8_t value, uint8_t printType)
+{
+  systemPrint(value, printType);
+  systemPrintln();
+}
+
+// Print a 16-bit value as HEX or decimal
+void systemPrint(uint16_t value, uint8_t printType)
+{
+  char temp[20];
+
+  if (printType == HEX)
+    snprintf(temp, sizeof(temp), "%04X", value);
+  else if (printType == DEC)
+    snprintf(temp, sizeof(temp), "%d", value);
+
+  systemPrint(temp);
+}
+
+// Print a 16-bit value as HEX or decimal with a carriage return and linefeed
+void systemPrintln(uint16_t value, uint8_t printType)
+{
+  systemPrint(value, printType);
+  systemPrintln();
+}
+
+// Print a floating point value with a specified number of decimal places
+void systemPrint(float value, uint8_t decimals)
+{
+  char temp[20];
+  snprintf(temp, sizeof(temp), "%.*f", decimals, value);
+  systemPrint(temp);
+}
+
+// Print a floating point value with a specified number of decimal places and a
+// carriage return and linefeed
+void systemPrintln(float value, uint8_t decimals)
+{
+  systemPrint(value, decimals);
+  systemPrintln();
+}
+
+// Print a double precision floating point value with a specified number of decimal places
+void systemPrint(double value, uint8_t decimals)
+{
+  char temp[30];
+  snprintf(temp, sizeof(temp), "%.*f", decimals, value);
+  systemPrint(temp);
+}
+
+// Print a double precision floating point value with a specified number of decimal
+// places and a carriage return and linefeed
+void systemPrintln(double value, uint8_t decimals)
+{
+  systemPrint(value, decimals);
+  systemPrintln();
+}
+
+// Print a string
+void systemPrint(String myString)
+{
+  systemPrint(myString.c_str());
+}
+void systemPrintln(String myString)
+{
+  systemPrint(myString);
+  systemPrintln();
+}
+
+// Print a carriage return and linefeed
+void systemPrintln()
+{
+  systemPrint("\r\n");
+}

--- a/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/System.ino
+++ b/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/System.ino
@@ -1,0 +1,31 @@
+// Callback for all firmware update targets. Called with the number of bytes written to flash so far. Used to track and print progress.
+void firmwareUpdateProgressCallback(uint16_t bytesProcessed)
+{
+    const uint8_t progressBarWidth = 20;
+    static uint8_t lastUpdatePercent = 0;
+
+    firmwareUpdateBytesProcessed += bytesProcessed;
+
+    uint32_t progressPercent = 0;
+    if (firmwareUpdateBytesToProcess > 0)
+        progressPercent = (firmwareUpdateBytesProcessed * 100UL) / firmwareUpdateBytesToProcess;
+
+    if (progressPercent > 100)
+        progressPercent = 100;
+
+    uint8_t filled = (progressPercent * progressBarWidth) / 100;
+
+    // Don't update unless there is a change
+    if (progressPercent == lastUpdatePercent)
+        return;
+
+    lastUpdatePercent = progressPercent;
+
+    Serial.print("Update Progress: [");
+    for (uint8_t i = 0; i < progressBarWidth; i++)
+        Serial.print(i < filled ? '#' : '-');
+
+    Serial.print("] ");
+    Serial.print(progressPercent);
+    Serial.println("%");
+}

--- a/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/Tilt.h
+++ b/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/Tilt.h
@@ -1,0 +1,6 @@
+enum Im19UpdateResult
+{
+    IM19_UPDATE_FAILED = 0,
+    IM19_UPDATE_SUCCESS,
+    IM19_UPDATE_RETRY, // lost frames (or no response) - caller should re-stream the source and call again
+};

--- a/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/Tilt.ino
+++ b/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/Tilt.ino
@@ -1,191 +1,154 @@
+// Reset the GNSS/IMU module ahead of entering the bootloader.
+// On Flex modules, the IMU reset is tied to the GNSS reset
+void imuReset()
+{
+    digitalWrite(pin_GNSS_DR_Reset, LOW); // Tell UM980 and DR to reset
+    delay(50);
+    digitalWrite(pin_GNSS_DR_Reset, HIGH);
+}
+
 // Below are the functions necessary for firmware upgrading the IM19
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-const uint16_t IM19_FRAME_HEADER = 0xAA55;
-const uint16_t IM19_FRAME_TYPE_BIN = 0x01;
-const uint16_t IM19_FRAME_TYPE_REQ = 0x02;
-const uint16_t IM19_FRAME_TYPE_CPL = 0x03;
-const uint16_t IM19_FRAME_TYPE_RDY = 0x04;
-const int IM19_FRAME_PAYLOAD_SIZE = 256;
-const int IM19_FRAME_SIZE = 12 + IM19_FRAME_PAYLOAD_SIZE; // 12-byte frame header + 256-byte payload
-const int IM19_FRAME_MAP_SIZE = 256;                 // 2048 bits -> max 2048 frames (512KB firmware) we are able to track
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+// IM19 bootloader state.
+//
+// im19FrameMap is a small bitmap (one bit per 256 byte frame) that mirrors what the
+// IM19 last told us it received. It is required by the wire protocol itself, not an
+// optimization we chose to add: after every pass the IM19 replies to FRAME_TYPE_CPL
+// with a FRAME_TYPE_REQ frame whose payload IS that bitmap (see im19CheckResponse()
+// / FRAME_TYPE_REQ in code/upgrade.c). Without recording it we would have no way to
+// tell "fully received" from "still missing some frames", and no way to know which
+// bytes to send on a retry - we'd be forced to either trust an unverified flash (risk
+// of bricking the IM19) or blindly resend the whole file every retry.
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-uint8_t *im19FrameMap = nullptr; // Tracks individual frames. Firmware completes when all frames are marked received.
+// IM19 bootloader wire protocol (268 byte frames: 12 byte header + 256 byte payload).
+// Ported from the reference implementation in code/upgrade.c.
+#define IM19_FRAME_HEADER 0xAA55
+#define IM19_FRAME_TYPE_BIN 0x01 // host -> IM19 : one 256 byte chunk of the firmware image
+#define IM19_FRAME_TYPE_REQ 0x02 // IM19 -> host : bitmap of frames received so far (sent in response to CPL)
+#define IM19_FRAME_TYPE_CPL 0x03 // host -> IM19 : "that's every frame I have, tell me what you're missing"
+#define IM19_FRAME_TYPE_RDY 0x04 // host -> IM19 : "you have everything, boot it" / IM19 -> host : "already booting"
+#define IM19_FRAME_PAYLOAD_SIZE 256
+#define IM19_FRAME_TOTAL_SIZE 268
+#define IM19_FRAME_MAP_SIZE 256 // bitmap bytes -> supports up to 2048 frames (512KB firmware image)
 
-// Frames are 256 bytes max (transfers require 12 more bytes). IM19_FRAME_TYPE_REQ resends are handled by
-// having the caller re-stream the source data on another pass; frames already
-// marked received in im19FrameMap are skipped rather than resent.
-uint8_t *im19FramePayloadBuf = nullptr;
-uint32_t im19FramePayloadLen = 0; // bytes currently held in im19FramePayloadBuf
-uint32_t im19CurrentFrameID = 0;  // frame ID the assembly buffer belongs to
+// Delay after each frame is put on the wire, giving the IM19 bootloader time to parse
+// and flash it before the next one arrives. The wire protocol has no per-frame ACK, so
+// this is a blind pacing value (ported from the vendor's SleepMs(50) in upgrade.c) -
+// tune it empirically on hardware: lower it, then watch how many frames the IM19
+// reports missing at the end. The existing retry path only re-fetches what's missing,
+// so occasional drops are safe; a delay set too low just means more retry passes.
+static const uint32_t IM19_FRAME_PACING_MS = 100; // Works - 0.1% frame failure.
+// static const uint32_t IM19_FRAME_PACING_MS = 75; // Works - 42% frame failure.
+// static const uint32_t IM19_FRAME_PACING_MS = 50; // Original mfg timeout. 87% frame failure.
+//  static const uint32_t IM19_FRAME_PACING_MS = 30; // Works - 94% frame failure.
+// static const uint32_t IM19_FRAME_PACING_MS = 15; // Works in test sketch. Partial fail in RTK Everywhere.
 
-// Resets frame-assembly state at the start of a streaming pass.
-void im19ResetFrameAssembly()
+// How long to wait for the IM19 to reply after CPL. After the last frame lands, the
+// IM19 still has to finish flashing it and scan every received frame to build its
+// reply bitmap.
+static const uint32_t IM19_CPL_RESPONSE_TIMEOUT_MS = 500;
+static const int IM19_CPL_RESPONSE_RETRIES = 10; // up to IM19_CPL_RESPONSE_RETRIES * IM19_CPL_RESPONSE_TIMEOUT_MS total
+
+static uint8_t *im19FrameMap = nullptr; // bit set = IM19 has confirmed receipt of that frame
+static uint32_t im19TotalFrames = 0;
+static uint32_t im19FileSize = 0;
+
+static uint8_t *im19FrameAssembly = nullptr; // accumulates bytes until a full frame is ready
+static uint32_t im19FrameAssemblyLen = 0;
+static uint32_t im19NextFrameID = 0; // frame ID that the next assembled byte belongs to
+
+static void im19ReleaseBuffers()
 {
-    im19FramePayloadLen = 0;
-    im19CurrentFrameID = 0;
-}
-
-// Reads up to size bytes from IMU serial within timeout and returns bytes read or -1.
-int im19ReceiveTimeout(uint8_t *buffer, int size, int timeoutMs)
-{
-    unsigned long start = millis();
-    int len = 0;
-    while (((millis() - start) < (unsigned long)timeoutMs) && (len < size))
+    if (im19FrameMap != nullptr)
     {
-        if (IMU_SERIAL.available())
-            buffer[len++] = IMU_SERIAL.read();
+        free(im19FrameMap);
+        im19FrameMap = nullptr;
     }
-    return len > 0 ? len : -1;
-}
 
-// Returns true if the byte buffer contains the given string sequence.
-bool im19FindStr(const uint8_t *buf, int bufLen, const char *str)
-{
-    int strLen = strlen(str);
-    for (int i = 0; i <= bufLen - strLen; i++)
+    if (im19FrameAssembly != nullptr)
     {
-        if (memcmp(buf + i, str, strLen) == 0)
-            return true;
+        free(im19FrameAssembly);
+        im19FrameAssembly = nullptr;
     }
-    return false;
 }
 
-// Sends an AT command and waits for a matching response substring.
-bool im19SendCommand(const char *cmd, const char *response)
+static bool im19AllocateBuffers()
 {
-    uint8_t buf[128];
-    IMU_SERIAL.write(cmd, strlen(cmd));
-    delay(50);
+    im19ReleaseBuffers();
 
-    int retry = 5;
-    while (retry--)
-    {
-        int len = im19ReceiveTimeout(buf, sizeof(buf), 50);
-        if (len > 0 && im19FindStr(buf, len, response))
-            return true;
-    }
-    return false;
-}
-
-// Sends AT+VERSION and copies the returned "Version:" line into versionOut.
-// Returns true if "Version:" is seen in the response
-// Example response:
-// \r\nOK\r\n\r\nVersion:IM19_H2_B2.2_A6.1_2eea4d4c024538bf5ed52\r\n
-
-bool im19GetVersionString(char *versionOut, size_t versionOutSize)
-{
-    if (versionOut == nullptr || versionOutSize < 2)
+    im19FrameMap = (uint8_t *)malloc(IM19_FRAME_MAP_SIZE);
+    if (im19FrameMap == nullptr)
         return false;
 
-    versionOut[0] = '\0';
-    const char CMD_VERSION[] = "AT+VERSION\r\n";
-
-    uint8_t buf[256];
-    int retry = 3;
-    while (retry--)
+    im19FrameAssembly = (uint8_t *)malloc(IM19_FRAME_PAYLOAD_SIZE);
+    if (im19FrameAssembly == nullptr)
     {
-        IMU_SERIAL.write(CMD_VERSION, strlen(CMD_VERSION));
-        delay(50);
-
-        int totalLen = 0;
-        unsigned long start = millis();
-        while (((millis() - start) < 500) && (totalLen < ((int)sizeof(buf) - 1)))
-        {
-            int len = im19ReceiveTimeout(buf + totalLen, sizeof(buf) - 1 - totalLen, 80);
-            if (len > 0)
-            {
-                //Serial.println((const char *)buf);
-                totalLen += len;
-                if (im19FindStr(buf, totalLen, "Version:"))
-                    break;
-            }
-        }
-
-        if (totalLen <= 0)
-        {
-            delay(100);
-            continue;
-        }
-
-        buf[totalLen] = '\0';
-        char *versionStart = strstr((char *)buf, "Version:");
-        if (versionStart != nullptr)
-        {
-            char *lineEnd = strchr(versionStart, '\r');
-            if (lineEnd == nullptr)
-                lineEnd = strchr(versionStart, '\n');
-
-            size_t copyLen = lineEnd != nullptr ? (size_t)(lineEnd - versionStart) : strlen(versionStart);
-            if (copyLen >= versionOutSize)
-                copyLen = versionOutSize - 1;
-
-            memcpy(versionOut, versionStart, copyLen);
-            versionOut[copyLen] = '\0';
-            return true;
-        }
-
-        delay(100);
+        im19ReleaseBuffers();
+        return false;
     }
 
-    return false;
+    return true;
 }
 
-// Requests a soft reset of the IM19 module.
-void im19Reset()
+static uint16_t im19BufToUint16(const uint8_t *buffer)
 {
-    const char CMD_RESET[] = "AT+SYSTEM_RESET\r\n";
-    IMU_SERIAL.write(CMD_RESET, strlen(CMD_RESET));
+    return (uint16_t)(buffer[0] | (buffer[1] << 8));
 }
 
-// Decodes a little-endian uint16 from a byte buffer.
-uint16_t im19BufToUint16(const uint8_t *b)
+static uint32_t im19BufToUint32(const uint8_t *buffer)
 {
-    return (uint16_t)(b[0] | (b[1] << 8));
+    return (uint32_t)(buffer[0] | (buffer[1] << 8) | (buffer[2] << 16) | (buffer[3] << 24));
 }
 
-// Decodes a little-endian uint32 from a byte buffer.
-uint32_t im19BufToUint32(const uint8_t *b)
-{
-    return (uint32_t)b[0] | ((uint32_t)b[1] << 8) | ((uint32_t)b[2] << 16) | ((uint32_t)b[3] << 24);
-}
-
-// Computes protocol checksum for a 268-byte frame.
-uint32_t im19FrameChecksum(const uint8_t *frame)
+static uint32_t im19CheckSum(const uint8_t *frame)
 {
     uint16_t type = im19BufToUint16(&frame[2]);
     uint32_t id = im19BufToUint32(&frame[8]);
-    uint32_t check = (uint32_t)type + id;
-
-    for (int i = 12; i < IM19_FRAME_SIZE; i++)
+    uint32_t check = type + id;
+    for (int i = 12; i < IM19_FRAME_TOTAL_SIZE; i++)
         check += frame[i];
-
     return check;
 }
 
-// Builds a protocol frame header and writes its checksum.
-void im19BuildFrame(uint16_t type, uint32_t id, uint8_t *frame)
+static void im19BuildFrame(uint16_t type, uint32_t id, uint8_t *frame)
 {
-    frame[0] = IM19_FRAME_HEADER & 0xFF;
+    frame[0] = (IM19_FRAME_HEADER >> 0) & 0xFF;
     frame[1] = (IM19_FRAME_HEADER >> 8) & 0xFF;
-    frame[2] = type & 0xFF;
+
+    frame[2] = (type >> 0) & 0xFF;
     frame[3] = (type >> 8) & 0xFF;
-    frame[8] = id & 0xFF;
+
+    frame[8] = (id >> 0) & 0xFF;
     frame[9] = (id >> 8) & 0xFF;
     frame[10] = (id >> 16) & 0xFF;
     frame[11] = (id >> 24) & 0xFF;
 
-    uint32_t check = im19FrameChecksum(frame);
-    frame[4] = check & 0xFF;
+    uint32_t check = im19CheckSum(frame);
+    frame[4] = (check >> 0) & 0xFF;
     frame[5] = (check >> 8) & 0xFF;
     frame[6] = (check >> 16) & 0xFF;
     frame[7] = (check >> 24) & 0xFF;
 }
 
-// Sends a command frame, optionally priming the frame bitmap for RDY.
-void im19SendCmdFrame(uint16_t cmd, uint32_t frameTotal)
+// Sends one 256 byte firmware chunk as frame 'frameID'.
+static bool im19SendOneFrame(uint32_t frameID, const uint8_t *payload)
 {
-    uint8_t frame[IM19_FRAME_SIZE] = {0};
+    uint8_t frame[IM19_FRAME_TOTAL_SIZE] = {0};
+    memcpy(&frame[12], payload, IM19_FRAME_PAYLOAD_SIZE);
+    im19BuildFrame(IM19_FRAME_TYPE_BIN, frameID, frame);
+    SerialForTilt->write(frame, sizeof(frame));
+    SerialForTilt->flush(); // Block until the frame is actually on the wire, not just queued
+    delay(IM19_FRAME_PACING_MS);
+    return true;
+}
+
+// Sends a command frame (CPL to ask what's missing, or RDY to tell the IM19 to boot).
+static void im19SendCmdFrame(uint16_t cmd, uint32_t frameTotal)
+{
+    uint8_t frame[IM19_FRAME_TOTAL_SIZE] = {0};
     if (cmd == IM19_FRAME_TYPE_RDY)
     {
         uint32_t num = frameTotal / 8, mod = frameTotal % 8;
@@ -195,261 +158,436 @@ void im19SendCmdFrame(uint16_t cmd, uint32_t frameTotal)
             frame[12 + num] = 0xFF >> (8 - mod);
     }
     im19BuildFrame(cmd, 0xFFFFFFFF, frame);
-
-    IMU_SERIAL.write(frame, IM19_FRAME_SIZE);
-
-    delay(50);
+    SerialForTilt->write(frame, sizeof(frame));
+    SerialForTilt->flush();
+    delay(IM19_FRAME_PACING_MS);
 }
 
-// Builds and sends one frame to the IM19 to be recorded.
-void im19SendFrameBytes(const uint8_t *payload, uint32_t payloadLen, uint32_t frameID)
+// Waits for a response frame from the IM19. On FRAME_TYPE_REQ, copies the IM19's
+// received-frame bitmap into frameMap. Returns the frame type, or -1 on timeout/garbage.
+static int im19CheckResponse(uint8_t *frameMap, uint32_t timeoutMs)
 {
-    uint8_t frame[IM19_FRAME_SIZE] = {0};
-
-    memcpy(&frame[12], payload, payloadLen); // remaining bytes stay zero-padded
-
-    im19BuildFrame(IM19_FRAME_TYPE_BIN, frameID, frame);
-
-    IMU_SERIAL.write(frame, IM19_FRAME_SIZE);
-
-    firmwareUpdateProgressCallback((uint16_t)payloadLen);
-    delay(50);
-}
-
-// Returns IM19_FRAME_TYPE_REQ, IM19_FRAME_TYPE_RDY, or -1 (no/invalid response).
-// Receives and validates response frames from the IM19 update protocol.
-int im19CheckResponse()
-{
-    uint8_t buf[350];
-    int bufLen = im19ReceiveTimeout(buf, sizeof(buf), 50);
-    if (bufLen < 0)
-        return -1;
-
+    uint8_t buf[350]; // a little slack past one frame (268B) in case of a leading garbage byte
+    SerialForTilt->setTimeout(timeoutMs);
+    int buf_len = SerialForTilt->readBytes(buf, sizeof(buf));
     uint8_t *p = buf;
-    while (bufLen >= IM19_FRAME_SIZE)
+
+    while (buf_len >= IM19_FRAME_TOTAL_SIZE)
     {
-        if (im19BufToUint16(p) != IM19_FRAME_HEADER || im19BufToUint32(p + 4) != im19FrameChecksum(p))
+        if (im19BufToUint16(p + 0) != IM19_FRAME_HEADER || im19BufToUint32(p + 4) != im19CheckSum(p))
         {
             p++;
-            bufLen--;
+            buf_len--;
             continue;
         }
 
-        uint16_t type = im19BufToUint16(p + 2);
-        if (type == IM19_FRAME_TYPE_REQ)
+        switch (im19BufToUint16(p + 2))
         {
-            if (im19FrameMap == nullptr)
+        case IM19_FRAME_TYPE_REQ:
+            if (frameMap == nullptr)
                 return -1;
-            memcpy(im19FrameMap, p + 12, IM19_FRAME_MAP_SIZE);
+            memcpy(frameMap, p + 12, IM19_FRAME_MAP_SIZE);
             return IM19_FRAME_TYPE_REQ;
-        }
-        else if (type == IM19_FRAME_TYPE_RDY)
-        {
+        case IM19_FRAME_TYPE_RDY:
             return IM19_FRAME_TYPE_RDY;
-        }
-        else
-        {
+        default:
             return -1;
         }
     }
     return -1;
 }
 
-// Returns true when all frames up to totalFrame are marked received.
-bool im19CheckLostFrame(uint32_t totalFrame)
+// True if every frame in [0, totalFrame) is marked present in frameMap.
+static bool im19AllFramesPresent(const uint8_t *frameMap, uint32_t totalFrame)
 {
-    if (im19FrameMap == nullptr)
+    if (frameMap == nullptr)
         return false;
 
-    uint32_t frameNumber = 0;
-    for (int i = 0; i < IM19_FRAME_MAP_SIZE; i++)
+    for (uint32_t frame = 0; frame < totalFrame; frame++)
     {
-        uint8_t byte = im19FrameMap[i];
-        for (int j = 0; j < 8; j++)
-        {
-            if (frameNumber >= totalFrame)
-                return true;
-            if ((byte >> j) & 0x01)
-                frameNumber++;
-            else
-                return false;
-        }
+        uint8_t bit = 0x01 << (frame % 8);
+        if ((frameMap[frame / 8] & bit) == 0)
+            return false;
     }
     return true;
 }
 
-// Resets the module and attempts to enter application update mode.
-bool im19UpdateFirmwareBegin()
+static bool im19FindStr(const uint8_t *buf, int buf_len, const char *str)
 {
-    im19ResetFrameAssembly();
-
-    int retry = 3;
-    while (retry--)
+    int str_len = strlen(str);
+    for (int i = 0; i <= buf_len - str_len; i++)
     {
-        im19Reset();
-        delay(1000);
-        if (im19SendCommand("AT+UPDATE_APP", "OK"))
-        {
-            if (im19FrameMap != nullptr)
-            {
-                free(im19FrameMap);
-                im19FrameMap = nullptr;
-            }
-
-            im19FrameMap = (uint8_t *)malloc(IM19_FRAME_MAP_SIZE);
-            if (im19FrameMap == nullptr)
-            {
-                systemPrintln("Failed to allocate im19FrameMap.");
-                return false;
-            }
-            memset(im19FrameMap, 0, IM19_FRAME_MAP_SIZE);
-
-            im19FramePayloadBuf = (uint8_t *)malloc(IM19_FRAME_PAYLOAD_SIZE);
-            if (im19FramePayloadBuf == nullptr)
-            {
-                systemPrintln("Failed to allocate im19FramePayloadBuf.");
-                return false;
-            }
+        if (memcmp(buf + i, str, str_len) == 0)
             return true;
+    }
+    return false;
+}
+
+// Sends an AT command and waits (with retries) for the expected response substring.
+static bool im19SendATCommand(const char *cmd, const char *response, int retries, uint8_t *responseBuf, size_t responseBufSize,
+                              int *responseLenOut)
+{
+    if (responseLenOut != nullptr)
+        *responseLenOut = 0;
+
+    uint8_t buf[256];
+    while (retries--)
+    {
+        SerialForTilt->write((const uint8_t *)cmd, strlen(cmd));
+        delay(50);
+        SerialForTilt->setTimeout(50);
+        int buf_len = SerialForTilt->readBytes(buf, sizeof(buf));
+        if (buf_len > 0)
+        {
+            if (responseBuf != nullptr && responseBufSize > 0)
+            {
+                size_t copyLen = (size_t)buf_len;
+                if (copyLen >= responseBufSize)
+                    copyLen = responseBufSize - 1;
+
+                memcpy(responseBuf, buf, copyLen);
+                responseBuf[copyLen] = '\0';
+                if (responseLenOut != nullptr)
+                    *responseLenOut = (int)copyLen;
+            }
+
+            if (im19FindStr(buf, buf_len, response))
+                return true;
         }
     }
     return false;
 }
 
-// Verifies the firmware is running by checking for a version response.
-bool im19CheckFirmwareRunning()
+// Puts the IM19 into its bootloader and gets ready to receive frames for a file of
+// 'fileSize' bytes. Mallocs nothing - the frame map is a fixed, small static buffer.
+bool im19UpdateFirmwareBegin(uint32_t fileSize)
 {
-    bool response = false;
-    for (int x = 0; x < 50; x++)
+    uint32_t totalFrames = (fileSize + IM19_FRAME_PAYLOAD_SIZE - 1) / IM19_FRAME_PAYLOAD_SIZE;
+    if (totalFrames > (uint32_t)IM19_FRAME_MAP_SIZE * 8)
     {
-        delay(100);
-        char versionLine[96];
-        response = im19GetVersionString(versionLine, sizeof(versionLine));
-        if (response == true)
-            break;
+        systemPrintf("Firmware image too large for the IM19 update protocol (%lu bytes).\r\n", (unsigned long)fileSize);
+        return false;
     }
-    return response;
+
+    if (!im19AllocateBuffers())
+    {
+        systemPrintln("Unable to allocate IM19 update buffers.");
+        return false;
+    }
+
+    memset(im19FrameMap, 0, IM19_FRAME_MAP_SIZE);
+    im19TotalFrames = totalFrames;
+    im19FileSize = fileSize;
+    im19FrameAssemblyLen = 0;
+    im19NextFrameID = 0;
+
+    for (int retry = 0; retry < 3; retry++)
+    {
+        imuReset();
+        delay(1000);
+        if (im19SendATCommand("AT+UPDATE_APP\r\n", "OK", 5, nullptr, 0, nullptr))
+            return true;
+    }
+
+    im19ReleaseBuffers();
+    return false;
 }
 
-// Streams firmware bytes, assembling and sending a IM19_FRAME_PAYLOAD_SIZE
-// frame at a time. Frames already marked received in im19FrameMap (from a
-// previous pass) are skipped rather than resent. Call im19UpdateFirmwareEndPass()
-// once all bytes for a pass have been given.
+// Repositions the frame-assembly cursor to a frame-aligned byte offset. Used before
+// streaming a retry range so its bytes land in the right frame IDs.
+void im19UpdateFirmwareFileSeek(uint32_t byteOffset)
+{
+    im19NextFrameID = byteOffset / IM19_FRAME_PAYLOAD_SIZE;
+    file.seekSet(byteOffset);
+    im19FrameAssemblyLen = 0;
+}
+
+// Feeds a chunk of firmware bytes (any length, any alignment) to the IM19. Internally
+// groups them into 256 byte protocol frames and sends each as it fills.
 bool im19UpdateFirmware(const uint8_t *data, uint32_t length)
 {
-    if (im19FrameMap == nullptr)
-    {
-        systemPrintln("im19FrameMap not allocated. Call im19UpdateFirmwareBegin first.");
+    if (im19FrameAssembly == nullptr)
         return false;
-    }
 
-    if (length == 0)
-        return true;
-
-    if (data == nullptr)
+    uint32_t consumed = 0;
+    while (consumed < length)
     {
-        systemPrintln("im19UpdateFirmware called with null data and non-zero length.");
-        return false;
-    }
+        uint32_t copyLen = length - consumed;
+        uint32_t space = IM19_FRAME_PAYLOAD_SIZE - im19FrameAssemblyLen;
+        if (copyLen > space)
+            copyLen = space;
 
-    uint32_t srcOffset = 0;
-    while (srcOffset < length)
-    {
-        uint32_t space = IM19_FRAME_PAYLOAD_SIZE - im19FramePayloadLen;
-        uint32_t take = min(space, length - srcOffset);
+        memcpy(im19FrameAssembly + im19FrameAssemblyLen, data + consumed, copyLen);
+        im19FrameAssemblyLen += copyLen;
+        consumed += copyLen;
 
-        memcpy(im19FramePayloadBuf + im19FramePayloadLen, data + srcOffset, take);
-        im19FramePayloadLen += take;
-        srcOffset += take;
-
-        if (im19FramePayloadLen == IM19_FRAME_PAYLOAD_SIZE)
+        if (im19FrameAssemblyLen == IM19_FRAME_PAYLOAD_SIZE)
         {
-            uint8_t bit = 0x01 << (im19CurrentFrameID % 8);
-            if ((im19FrameMap[im19CurrentFrameID / 8] & bit) != bit)
-                im19SendFrameBytes(im19FramePayloadBuf, im19FramePayloadLen, im19CurrentFrameID);
-
-            im19CurrentFrameID++;
-            im19FramePayloadLen = 0;
+            if (!im19SendOneFrame(im19NextFrameID, im19FrameAssembly))
+                return false;
+            im19NextFrameID++;
+            im19FrameAssemblyLen = 0;
         }
     }
-
     return true;
 }
 
-// Finalizes one streaming pass: flushes any partial frame, tells the
-// IM19 the image is complete, and checks its response. On IM19_UPDATE_RETRY,
-// frame-assembly state is reset and the caller should re-stream the full
-// source data (already-received frames are tracked in im19FrameMap and will be
-// skipped, not resent).
-int im19UpdateFirmwareEndPass()
+// Confirms the new firmware is running by polling for a response to AT+VERSION.
+static bool im19VerifyFirmwareRunning()
 {
-    if (im19FrameMap == nullptr)
+    delay(5000); // Give the IM19 time to flash and boot the new image
+    for (int retry = 0; retry < 3; retry++)
     {
-        systemPrintln("im19FrameMap not allocated. Call im19UpdateFirmwareBegin first.");
+        if (im19SendATCommand("AT+VERSION\r\n", "Version:", 1, nullptr, 0, nullptr))
+            return true;
+        delay(100);
+    }
+    return false;
+}
+
+// Tells the IM19 "that's every frame I have" and handles its reply. Returns SUCCESS
+// once the IM19 confirms it received everything and has booted the new image, RETRY
+// if it reports missing frames (caller should re-request just those and call again),
+// or FAILED if the IM19 never responds.
+Im19UpdateResult im19UpdateFirmwareEnd()
+{
+    if (im19FrameMap == nullptr || im19FrameAssembly == nullptr)
         return IM19_UPDATE_FAILED;
-    }
 
-    if (im19FramePayloadLen > 0)
+    // The last frame of the file is usually short - zero-pad and send it now.
+    if (im19FrameAssemblyLen > 0)
     {
-        uint8_t bit = 0x01 << (im19CurrentFrameID % 8);
-        if ((im19FrameMap[im19CurrentFrameID / 8] & bit) != bit)
-            im19SendFrameBytes(im19FramePayloadBuf, im19FramePayloadLen, im19CurrentFrameID);
-        im19CurrentFrameID++;
-        im19FramePayloadLen = 0;
+        memset(im19FrameAssembly + im19FrameAssemblyLen, 0, IM19_FRAME_PAYLOAD_SIZE - im19FrameAssemblyLen);
+        im19SendOneFrame(im19NextFrameID, im19FrameAssembly);
+        im19NextFrameID++;
+        im19FrameAssemblyLen = 0;
     }
 
-    const uint32_t totalFrames = im19CurrentFrameID;
-    if (totalFrames == 0)
-    {
-        systemPrintln("No firmware bytes streamed.");
-        return IM19_UPDATE_FAILED;
-    }
+    im19SendCmdFrame(IM19_FRAME_TYPE_CPL, im19TotalFrames);
 
-    im19SendCmdFrame(IM19_FRAME_TYPE_CPL, totalFrames);
-
-    int retry = 5;
-    bool lostFrames = false;
+    int retry = IM19_CPL_RESPONSE_RETRIES;
     while (retry--)
     {
-        int response = im19CheckResponse();
+        int response = im19CheckResponse(im19FrameMap, IM19_CPL_RESPONSE_TIMEOUT_MS);
+
         if (response == IM19_FRAME_TYPE_RDY)
         {
-            systemPrintln("Device acknowledged complete image, verifying boot...");
-            return im19CheckFirmwareRunning() ? IM19_UPDATE_SUCCESS : IM19_UPDATE_FAILED;
+            Im19UpdateResult result = im19VerifyFirmwareRunning() ? IM19_UPDATE_SUCCESS : IM19_UPDATE_FAILED;
+            im19ReleaseBuffers();
+            return result;
         }
-        else if (response == IM19_FRAME_TYPE_REQ)
+
+        if (response == IM19_FRAME_TYPE_REQ)
         {
-            if (im19CheckLostFrame(totalFrames))
+            if (im19AllFramesPresent(im19FrameMap, im19TotalFrames))
             {
-                im19SendCmdFrame(IM19_FRAME_TYPE_RDY, totalFrames);
+                im19SendCmdFrame(IM19_FRAME_TYPE_RDY, im19TotalFrames);
+                Im19UpdateResult result = im19VerifyFirmwareRunning() ? IM19_UPDATE_SUCCESS : IM19_UPDATE_FAILED;
+                im19ReleaseBuffers();
+                return result;
             }
-            else
-            {
-                lostFrames = true;
-                break;
-            }
+            return IM19_UPDATE_RETRY;
         }
     }
 
-    systemPrintln(lostFrames ? "Resending missing frames" : "No response, retrying");
-    im19ResetFrameAssembly();
-    return IM19_UPDATE_RETRY;
+    im19ReleaseBuffers();
+    return IM19_UPDATE_FAILED;
 }
 
-// Frees buffers allocated by im19UpdateFirmwareBegin.
-void im19UpdateFirmwareEnd()
-{
-    if (im19FrameMap != nullptr)
-    {
-        free(im19FrameMap);
-        im19FrameMap = nullptr;
-    }
-    if (im19FramePayloadBuf != nullptr)
-    {
-        free(im19FramePayloadBuf);
-        im19FramePayloadBuf = nullptr;
-    }
-    im19ResetFrameAssembly();
-}
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-// End
+// WiFi streaming: pulls bytes from the URL and feeds them to the IM19 update state
+// machine above. A retry only re-requests (via HTTP Range) the byte ranges the IM19
+// says it's still missing - the rest of the file is never re-downloaded or re-sent.
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+// Reads 'byteCount' bytes starting at 'startOffset' from an already-open file object
+// and feeds them to the IM19, reporting progress as it goes.
+static bool im19PumpFileToDevice(const char *fileName, uint32_t startOffset, uint32_t byteCount)
+{
+    file.open(fileName, O_RDONLY);
+    if(!file)
+    {
+        systemPrintf("im19PumpFileToDevice: could not open firmware file %s\r\n.", fileName);
+        return false;
+    }
+
+    im19UpdateFirmwareFileSeek(startOffset);
+
+    uint8_t buffer[512];
+    uint32_t received = 0;
+
+    while (received < byteCount)
+    {
+        size_t toRead = (size_t)(byteCount - received);
+        toRead = min(toRead, sizeof(buffer));
+
+        int bytesRead = file.read(buffer, toRead);
+        if (bytesRead <= 0)
+            break;
+
+        if (!im19UpdateFirmware(buffer, (uint32_t)bytesRead))
+            return false;
+
+        received += bytesRead;
+        firmwareUpdateProgressCallback((uint16_t)bytesRead);
+    }
+
+    file.close();
+
+    return received == byteCount;
+}
+
+// Re-reads only [startByte, endByte] (inclusive) and streams it to the IM19.
+static bool im19StreamFileRange(const char *fileName, uint32_t startByte, uint32_t endByte)
+{
+    bool success = im19PumpFileToDevice(fileName, startByte, endByte - startByte + 1);
+    return success;
+}
+
+// Walks im19FrameMap for runs of missing frames and re-requests just those byte
+// ranges from the source file, instead of re-streaming the entire firmware image.
+static bool im19StreamMissingFileRanges(const char *fileName)
+{
+    if (im19FrameMap == nullptr)
+        return false;
+
+    uint32_t totalMissingFrames = 0;
+    for (uint32_t i = 0; i < im19TotalFrames; i++)
+    {
+        if ((im19FrameMap[i / 8] & (0x01 << (i % 8))) == 0)
+            totalMissingFrames++;
+    }
+
+    uint32_t missingRateTenthsPct = 0;
+    if (im19TotalFrames > 0)
+        missingRateTenthsPct = (totalMissingFrames * 1000 + (im19TotalFrames / 2)) / im19TotalFrames;
+
+    uint32_t frame = 0;
+    while (frame < im19TotalFrames)
+    {
+        uint8_t bit = 0x01 << (frame % 8);
+        if (im19FrameMap[frame / 8] & bit)
+        {
+            frame++;
+            continue;
+        }
+
+        uint32_t runStart = frame;
+        while (frame < im19TotalFrames && !(im19FrameMap[frame / 8] & (0x01 << (frame % 8))))
+            frame++;
+
+        uint32_t startByte = runStart * IM19_FRAME_PAYLOAD_SIZE;
+        uint32_t endByte = min(frame * IM19_FRAME_PAYLOAD_SIZE, im19FileSize) - 1;
+
+        systemPrintf("Requesting missing frames %lu-%lu (%lu bytes) from file (failure rate: %lu.%lu%%).\r\n",
+                     (unsigned long)runStart, (unsigned long)(frame - 1), (unsigned long)(endByte - startByte + 1),
+                     (unsigned long)(missingRateTenthsPct / 10), (unsigned long)(missingRateTenthsPct % 10));
+
+        if (!im19StreamFileRange(fileName, startByte, endByte))
+            return false;
+    }
+    return true;
+}
+
+// Updates the IM19 module firmware from the given global file object
+//
+// Structure (see the header comment at the top of the .ino for the general pattern):
+//   1. im19UpdateFirmwareBegin() puts the IM19 into its bootloader.
+//   2. Stream the file once, feeding chunks to im19UpdateFirmware().
+//   3. im19UpdateFirmwareEnd() asks the IM19 what it's missing. If anything, re-request
+//      only those byte ranges (im19StreamMissingRanges) and ask again - up to a few
+//      attempts - rather than re-streaming the whole binary.
+bool im19StreamFirmwareFromFile(const char *fileName)
+{
+    file.open(fileName, O_RDONLY);
+    if(!file)
+    {
+        systemPrintf("im19StreamFirmwareFromFile: could not open firmware file %s\r\n.", fileName);
+        return false;
+    }
+
+    uint32_t fileSize = (uint32_t)file.fileSize();
+    firmwareUpdateBytesToProcess = fileSize;
+
+    file.close();
+
+    if (!im19UpdateFirmwareBegin(fileSize))
+    {
+        systemPrintln("IM19 did not respond to the bootloader entry command.");
+        return false;
+    }
+
+    // Now that the IM19 is in its bootloader and waiting, stream the
+    // file straight to it.
+    bool streamed = im19PumpFileToDevice(fileName, 0, fileSize);
+
+    if (!streamed)
+    {
+        systemPrintln("Firmware update failed during file read.");
+        im19ReleaseBuffers();
+        return false;
+    }
+
+    const int maxAttempts = 5;
+    for (int attempt = 1; attempt <= maxAttempts; attempt++)
+    {
+        Im19UpdateResult result = im19UpdateFirmwareEnd();
+
+        if (result == IM19_UPDATE_SUCCESS)
+        {
+            return true;
+        }
+
+        if (result == IM19_UPDATE_FAILED)
+        {
+            systemPrintln("IM19 firmware update failed: no response from IM19.");
+            return false;
+        }
+
+        // IM19_UPDATE_RETRY - the IM19 told us exactly which frames it's missing.
+        systemPrintf("Attempt %d: IM19 reports missing frames.\r\n", attempt);
+        if (!im19StreamMissingFileRanges(fileName))
+        {
+            systemPrintln("Firmware update failed while re-requesting missing frames.");
+            im19ReleaseBuffers();
+            return false;
+        }
+    }
+
+    systemPrintln("IM19 firmware update failed: too many retries.");
+    im19ReleaseBuffers();
+    return false;
+}
+
+// Sends AT+VERSION and copies the returned "Version:" line into versionOut.
+// Returns true if "Version:" is seen in the response
+bool im19GetVersionString(char *versionOut, size_t versionOutSize)
+{
+    if (versionOut == nullptr || versionOutSize < 2)
+        return false;
+
+    versionOut[0] = '\0';
+    uint8_t responseBuf[256];
+
+    if (!im19SendATCommand("AT+VERSION\r\n", "Version:", 3, responseBuf, sizeof(responseBuf), nullptr))
+        return false;
+
+    char *versionStart = strstr((char *)responseBuf, "Version:");
+    if (versionStart == nullptr)
+        return false;
+
+    char *lineEnd = strchr(versionStart, '\r');
+    if (lineEnd == nullptr)
+        lineEnd = strchr(versionStart, '\n');
+
+    size_t copyLen = lineEnd != nullptr ? (size_t)(lineEnd - versionStart) : strlen(versionStart);
+    if (copyLen >= versionOutSize)
+        copyLen = versionOutSize - 1;
+
+    memcpy(versionOut, versionStart, copyLen);
+    versionOut[copyLen] = '\0';
+    return true;
+}
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+// End of IM19 firmware update functions.

--- a/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/Tilt.ino
+++ b/Firmware/Test Sketches/Flash_Update/IM19_Update_From_microSD/Tilt.ino
@@ -1,0 +1,455 @@
+// Below are the functions necessary for firmware upgrading the IM19
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+const uint16_t IM19_FRAME_HEADER = 0xAA55;
+const uint16_t IM19_FRAME_TYPE_BIN = 0x01;
+const uint16_t IM19_FRAME_TYPE_REQ = 0x02;
+const uint16_t IM19_FRAME_TYPE_CPL = 0x03;
+const uint16_t IM19_FRAME_TYPE_RDY = 0x04;
+const int IM19_FRAME_PAYLOAD_SIZE = 256;
+const int IM19_FRAME_SIZE = 12 + IM19_FRAME_PAYLOAD_SIZE; // 12-byte frame header + 256-byte payload
+const int IM19_FRAME_MAP_SIZE = 256;                 // 2048 bits -> max 2048 frames (512KB firmware) we are able to track
+
+uint8_t *im19FrameMap = nullptr; // Tracks individual frames. Firmware completes when all frames are marked received.
+
+// Frames are 256 bytes max (transfers require 12 more bytes). IM19_FRAME_TYPE_REQ resends are handled by
+// having the caller re-stream the source data on another pass; frames already
+// marked received in im19FrameMap are skipped rather than resent.
+uint8_t *im19FramePayloadBuf = nullptr;
+uint32_t im19FramePayloadLen = 0; // bytes currently held in im19FramePayloadBuf
+uint32_t im19CurrentFrameID = 0;  // frame ID the assembly buffer belongs to
+
+// Resets frame-assembly state at the start of a streaming pass.
+void im19ResetFrameAssembly()
+{
+    im19FramePayloadLen = 0;
+    im19CurrentFrameID = 0;
+}
+
+// Reads up to size bytes from IMU serial within timeout and returns bytes read or -1.
+int im19ReceiveTimeout(uint8_t *buffer, int size, int timeoutMs)
+{
+    unsigned long start = millis();
+    int len = 0;
+    while (((millis() - start) < (unsigned long)timeoutMs) && (len < size))
+    {
+        if (IMU_SERIAL.available())
+            buffer[len++] = IMU_SERIAL.read();
+    }
+    return len > 0 ? len : -1;
+}
+
+// Returns true if the byte buffer contains the given string sequence.
+bool im19FindStr(const uint8_t *buf, int bufLen, const char *str)
+{
+    int strLen = strlen(str);
+    for (int i = 0; i <= bufLen - strLen; i++)
+    {
+        if (memcmp(buf + i, str, strLen) == 0)
+            return true;
+    }
+    return false;
+}
+
+// Sends an AT command and waits for a matching response substring.
+bool im19SendCommand(const char *cmd, const char *response)
+{
+    uint8_t buf[128];
+    IMU_SERIAL.write(cmd, strlen(cmd));
+    delay(50);
+
+    int retry = 5;
+    while (retry--)
+    {
+        int len = im19ReceiveTimeout(buf, sizeof(buf), 50);
+        if (len > 0 && im19FindStr(buf, len, response))
+            return true;
+    }
+    return false;
+}
+
+// Sends AT+VERSION and copies the returned "Version:" line into versionOut.
+// Returns true if "Version:" is seen in the response
+// Example response:
+// \r\nOK\r\n\r\nVersion:IM19_H2_B2.2_A6.1_2eea4d4c024538bf5ed52\r\n
+
+bool im19GetVersionString(char *versionOut, size_t versionOutSize)
+{
+    if (versionOut == nullptr || versionOutSize < 2)
+        return false;
+
+    versionOut[0] = '\0';
+    const char CMD_VERSION[] = "AT+VERSION\r\n";
+
+    uint8_t buf[256];
+    int retry = 3;
+    while (retry--)
+    {
+        IMU_SERIAL.write(CMD_VERSION, strlen(CMD_VERSION));
+        delay(50);
+
+        int totalLen = 0;
+        unsigned long start = millis();
+        while (((millis() - start) < 500) && (totalLen < ((int)sizeof(buf) - 1)))
+        {
+            int len = im19ReceiveTimeout(buf + totalLen, sizeof(buf) - 1 - totalLen, 80);
+            if (len > 0)
+            {
+                //Serial.println((const char *)buf);
+                totalLen += len;
+                if (im19FindStr(buf, totalLen, "Version:"))
+                    break;
+            }
+        }
+
+        if (totalLen <= 0)
+        {
+            delay(100);
+            continue;
+        }
+
+        buf[totalLen] = '\0';
+        char *versionStart = strstr((char *)buf, "Version:");
+        if (versionStart != nullptr)
+        {
+            char *lineEnd = strchr(versionStart, '\r');
+            if (lineEnd == nullptr)
+                lineEnd = strchr(versionStart, '\n');
+
+            size_t copyLen = lineEnd != nullptr ? (size_t)(lineEnd - versionStart) : strlen(versionStart);
+            if (copyLen >= versionOutSize)
+                copyLen = versionOutSize - 1;
+
+            memcpy(versionOut, versionStart, copyLen);
+            versionOut[copyLen] = '\0';
+            return true;
+        }
+
+        delay(100);
+    }
+
+    return false;
+}
+
+// Requests a soft reset of the IM19 module.
+void im19Reset()
+{
+    const char CMD_RESET[] = "AT+SYSTEM_RESET\r\n";
+    IMU_SERIAL.write(CMD_RESET, strlen(CMD_RESET));
+}
+
+// Decodes a little-endian uint16 from a byte buffer.
+uint16_t im19BufToUint16(const uint8_t *b)
+{
+    return (uint16_t)(b[0] | (b[1] << 8));
+}
+
+// Decodes a little-endian uint32 from a byte buffer.
+uint32_t im19BufToUint32(const uint8_t *b)
+{
+    return (uint32_t)b[0] | ((uint32_t)b[1] << 8) | ((uint32_t)b[2] << 16) | ((uint32_t)b[3] << 24);
+}
+
+// Computes protocol checksum for a 268-byte frame.
+uint32_t im19FrameChecksum(const uint8_t *frame)
+{
+    uint16_t type = im19BufToUint16(&frame[2]);
+    uint32_t id = im19BufToUint32(&frame[8]);
+    uint32_t check = (uint32_t)type + id;
+
+    for (int i = 12; i < IM19_FRAME_SIZE; i++)
+        check += frame[i];
+
+    return check;
+}
+
+// Builds a protocol frame header and writes its checksum.
+void im19BuildFrame(uint16_t type, uint32_t id, uint8_t *frame)
+{
+    frame[0] = IM19_FRAME_HEADER & 0xFF;
+    frame[1] = (IM19_FRAME_HEADER >> 8) & 0xFF;
+    frame[2] = type & 0xFF;
+    frame[3] = (type >> 8) & 0xFF;
+    frame[8] = id & 0xFF;
+    frame[9] = (id >> 8) & 0xFF;
+    frame[10] = (id >> 16) & 0xFF;
+    frame[11] = (id >> 24) & 0xFF;
+
+    uint32_t check = im19FrameChecksum(frame);
+    frame[4] = check & 0xFF;
+    frame[5] = (check >> 8) & 0xFF;
+    frame[6] = (check >> 16) & 0xFF;
+    frame[7] = (check >> 24) & 0xFF;
+}
+
+// Sends a command frame, optionally priming the frame bitmap for RDY.
+void im19SendCmdFrame(uint16_t cmd, uint32_t frameTotal)
+{
+    uint8_t frame[IM19_FRAME_SIZE] = {0};
+    if (cmd == IM19_FRAME_TYPE_RDY)
+    {
+        uint32_t num = frameTotal / 8, mod = frameTotal % 8;
+        for (uint32_t i = 0; i < num; i++)
+            frame[12 + i] = 0xFF;
+        if (mod > 0)
+            frame[12 + num] = 0xFF >> (8 - mod);
+    }
+    im19BuildFrame(cmd, 0xFFFFFFFF, frame);
+
+    IMU_SERIAL.write(frame, IM19_FRAME_SIZE);
+
+    delay(50);
+}
+
+// Builds and sends one frame to the IM19 to be recorded.
+void im19SendFrameBytes(const uint8_t *payload, uint32_t payloadLen, uint32_t frameID)
+{
+    uint8_t frame[IM19_FRAME_SIZE] = {0};
+
+    memcpy(&frame[12], payload, payloadLen); // remaining bytes stay zero-padded
+
+    im19BuildFrame(IM19_FRAME_TYPE_BIN, frameID, frame);
+
+    IMU_SERIAL.write(frame, IM19_FRAME_SIZE);
+
+    firmwareUpdateProgressCallback((uint16_t)payloadLen);
+    delay(50);
+}
+
+// Returns IM19_FRAME_TYPE_REQ, IM19_FRAME_TYPE_RDY, or -1 (no/invalid response).
+// Receives and validates response frames from the IM19 update protocol.
+int im19CheckResponse()
+{
+    uint8_t buf[350];
+    int bufLen = im19ReceiveTimeout(buf, sizeof(buf), 50);
+    if (bufLen < 0)
+        return -1;
+
+    uint8_t *p = buf;
+    while (bufLen >= IM19_FRAME_SIZE)
+    {
+        if (im19BufToUint16(p) != IM19_FRAME_HEADER || im19BufToUint32(p + 4) != im19FrameChecksum(p))
+        {
+            p++;
+            bufLen--;
+            continue;
+        }
+
+        uint16_t type = im19BufToUint16(p + 2);
+        if (type == IM19_FRAME_TYPE_REQ)
+        {
+            if (im19FrameMap == nullptr)
+                return -1;
+            memcpy(im19FrameMap, p + 12, IM19_FRAME_MAP_SIZE);
+            return IM19_FRAME_TYPE_REQ;
+        }
+        else if (type == IM19_FRAME_TYPE_RDY)
+        {
+            return IM19_FRAME_TYPE_RDY;
+        }
+        else
+        {
+            return -1;
+        }
+    }
+    return -1;
+}
+
+// Returns true when all frames up to totalFrame are marked received.
+bool im19CheckLostFrame(uint32_t totalFrame)
+{
+    if (im19FrameMap == nullptr)
+        return false;
+
+    uint32_t frameNumber = 0;
+    for (int i = 0; i < IM19_FRAME_MAP_SIZE; i++)
+    {
+        uint8_t byte = im19FrameMap[i];
+        for (int j = 0; j < 8; j++)
+        {
+            if (frameNumber >= totalFrame)
+                return true;
+            if ((byte >> j) & 0x01)
+                frameNumber++;
+            else
+                return false;
+        }
+    }
+    return true;
+}
+
+// Resets the module and attempts to enter application update mode.
+bool im19UpdateFirmwareBegin()
+{
+    im19ResetFrameAssembly();
+
+    int retry = 3;
+    while (retry--)
+    {
+        im19Reset();
+        delay(1000);
+        if (im19SendCommand("AT+UPDATE_APP", "OK"))
+        {
+            if (im19FrameMap != nullptr)
+            {
+                free(im19FrameMap);
+                im19FrameMap = nullptr;
+            }
+
+            im19FrameMap = (uint8_t *)malloc(IM19_FRAME_MAP_SIZE);
+            if (im19FrameMap == nullptr)
+            {
+                systemPrintln("Failed to allocate im19FrameMap.");
+                return false;
+            }
+            memset(im19FrameMap, 0, IM19_FRAME_MAP_SIZE);
+
+            im19FramePayloadBuf = (uint8_t *)malloc(IM19_FRAME_PAYLOAD_SIZE);
+            if (im19FramePayloadBuf == nullptr)
+            {
+                systemPrintln("Failed to allocate im19FramePayloadBuf.");
+                return false;
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
+// Verifies the firmware is running by checking for a version response.
+bool im19CheckFirmwareRunning()
+{
+    bool response = false;
+    for (int x = 0; x < 50; x++)
+    {
+        delay(100);
+        char versionLine[96];
+        response = im19GetVersionString(versionLine, sizeof(versionLine));
+        if (response == true)
+            break;
+    }
+    return response;
+}
+
+// Streams firmware bytes, assembling and sending a IM19_FRAME_PAYLOAD_SIZE
+// frame at a time. Frames already marked received in im19FrameMap (from a
+// previous pass) are skipped rather than resent. Call im19UpdateFirmwareEndPass()
+// once all bytes for a pass have been given.
+bool im19UpdateFirmware(const uint8_t *data, uint32_t length)
+{
+    if (im19FrameMap == nullptr)
+    {
+        systemPrintln("im19FrameMap not allocated. Call im19UpdateFirmwareBegin first.");
+        return false;
+    }
+
+    if (length == 0)
+        return true;
+
+    if (data == nullptr)
+    {
+        systemPrintln("im19UpdateFirmware called with null data and non-zero length.");
+        return false;
+    }
+
+    uint32_t srcOffset = 0;
+    while (srcOffset < length)
+    {
+        uint32_t space = IM19_FRAME_PAYLOAD_SIZE - im19FramePayloadLen;
+        uint32_t take = min(space, length - srcOffset);
+
+        memcpy(im19FramePayloadBuf + im19FramePayloadLen, data + srcOffset, take);
+        im19FramePayloadLen += take;
+        srcOffset += take;
+
+        if (im19FramePayloadLen == IM19_FRAME_PAYLOAD_SIZE)
+        {
+            uint8_t bit = 0x01 << (im19CurrentFrameID % 8);
+            if ((im19FrameMap[im19CurrentFrameID / 8] & bit) != bit)
+                im19SendFrameBytes(im19FramePayloadBuf, im19FramePayloadLen, im19CurrentFrameID);
+
+            im19CurrentFrameID++;
+            im19FramePayloadLen = 0;
+        }
+    }
+
+    return true;
+}
+
+// Finalizes one streaming pass: flushes any partial frame, tells the
+// IM19 the image is complete, and checks its response. On IM19_UPDATE_RETRY,
+// frame-assembly state is reset and the caller should re-stream the full
+// source data (already-received frames are tracked in im19FrameMap and will be
+// skipped, not resent).
+int im19UpdateFirmwareEndPass()
+{
+    if (im19FrameMap == nullptr)
+    {
+        systemPrintln("im19FrameMap not allocated. Call im19UpdateFirmwareBegin first.");
+        return IM19_UPDATE_FAILED;
+    }
+
+    if (im19FramePayloadLen > 0)
+    {
+        uint8_t bit = 0x01 << (im19CurrentFrameID % 8);
+        if ((im19FrameMap[im19CurrentFrameID / 8] & bit) != bit)
+            im19SendFrameBytes(im19FramePayloadBuf, im19FramePayloadLen, im19CurrentFrameID);
+        im19CurrentFrameID++;
+        im19FramePayloadLen = 0;
+    }
+
+    const uint32_t totalFrames = im19CurrentFrameID;
+    if (totalFrames == 0)
+    {
+        systemPrintln("No firmware bytes streamed.");
+        return IM19_UPDATE_FAILED;
+    }
+
+    im19SendCmdFrame(IM19_FRAME_TYPE_CPL, totalFrames);
+
+    int retry = 5;
+    bool lostFrames = false;
+    while (retry--)
+    {
+        int response = im19CheckResponse();
+        if (response == IM19_FRAME_TYPE_RDY)
+        {
+            systemPrintln("Device acknowledged complete image, verifying boot...");
+            return im19CheckFirmwareRunning() ? IM19_UPDATE_SUCCESS : IM19_UPDATE_FAILED;
+        }
+        else if (response == IM19_FRAME_TYPE_REQ)
+        {
+            if (im19CheckLostFrame(totalFrames))
+            {
+                im19SendCmdFrame(IM19_FRAME_TYPE_RDY, totalFrames);
+            }
+            else
+            {
+                lostFrames = true;
+                break;
+            }
+        }
+    }
+
+    systemPrintln(lostFrames ? "Resending missing frames" : "No response, retrying");
+    im19ResetFrameAssembly();
+    return IM19_UPDATE_RETRY;
+}
+
+// Frees buffers allocated by im19UpdateFirmwareBegin.
+void im19UpdateFirmwareEnd()
+{
+    if (im19FrameMap != nullptr)
+    {
+        free(im19FrameMap);
+        im19FrameMap = nullptr;
+    }
+    if (im19FramePayloadBuf != nullptr)
+    {
+        free(im19FramePayloadBuf);
+        im19FramePayloadBuf = nullptr;
+    }
+    im19ResetFrameAssembly();
+}
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+// End


### PR DESCRIPTION
This new example shows how you can update the IM19 with a firmware file from microSD
It uses SdFat, running on (e.g.) [SparkFun Thing Plus - ESP32 WROOM (USB-C)](https://www.sparkfun.com/sparkfun-thing-plus-esp32-wroom-usb-c.html)

Please let me know if RTK Everywhere Test Sketches is the right home for this - or if it would be better to include it in the IM19 Library examples instead.

It seems to be working well. I can swap between firmware versions with ease. But an update has never failed, so ```im19StreamMissingFileRanges``` is currently unproven.
