### PR TITLE
Fix LoRa/STM32 OTA flash update

### DIFF
--- a/Firmware/RTK_Everywhere/LoRa.ino
+++ b/Firmware/RTK_Everywhere/LoRa.ino
@@ -1682,6 +1682,24 @@ uint16_t loraRead()
     return 0;
 }
 
+void loraRxFlush()
+{
+    if (productVariant == RTK_TORCH)
+    {
+        while (Serial.available())
+            Serial.read();
+        return;
+    }
+    else if (productVariant == RTK_FACET_FP)
+    {
+        while (SerialForLoRa->available())
+            SerialForLoRa->read();
+        return;
+    }
+
+    systemPrintln("loraRxFlush - invalid ProductVariant");
+}
+
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 // The following functions are for the STM32 firmware update process.
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -1745,6 +1763,10 @@ bool stm32UpdateFirmwareBegin()
     loraPowerOn(); // Regardless of previous state, turn on the STM32
 
     loraEnterBootloader(); // Push boot pin high and reset STM32
+
+    // Discard any characters in the RX FIFO
+    // If we are talking to the boot loader all we should receive are ACKs
+    loraRxFlush();
 
     // Send 0x7F for auto-baud detection
     loraWrite(0x7F);

--- a/Firmware/RTK_Everywhere/LoRa.ino
+++ b/Firmware/RTK_Everywhere/LoRa.ino
@@ -1682,6 +1682,7 @@ uint16_t loraRead()
     return 0;
 }
 
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 // The following functions are for the STM32 firmware update process.
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
@@ -1697,20 +1698,7 @@ uint32_t stm32CurrentAddress = 0x08000000; // Next flash address to write; advan
 // flashed every time a full 256 byte page accumulates.
 bool stm32UpdateFirmware(uint8_t *dataArray, uint16_t bytesToWrite)
 {
-    bool success = stm32UpdatePageBuffer(dataArray, bytesToWrite);
-
-    if (productVariant == RTK_TORCH)
-    {
-        muxSelectUsb();                               // Reconnect USB to print to terminal
-        firmwareUpdateProgressCallback("LoRa", bytesToWrite); // Notify callback
-        Serial.flush();
-        muxSelectLoRaCommunication(); // Disconnect USB, connect to LoRa
-    }
-    else
-    {
-        firmwareUpdateProgressCallback("LoRa", bytesToWrite); // Notify callback
-    }
-    return success;
+    return stm32UpdatePageBuffer(dataArray, bytesToWrite);
 }
 
 // Helper to send STM32 commands and wait for ACK (0x79)
@@ -1937,9 +1925,9 @@ bool stm32StreamFirmware(NetworkClient * stream,
 
     if (stm32UpdateFirmwareBegin() == false)
     {
-        loraSharedPrintln(otaEqualSigns);
-        loraSharedPrintln("LoRa/STM32 update failed.");
-        loraSharedPrintln(otaEqualSigns);
+        usbPrintf("%s\r\n", otaEqualSigns);
+        usbPrintf("LoRa/STM32 update failed.\r\n");
+        usbPrintf("%s\r\n", otaEqualSigns);
         return false;
     }
 
@@ -1953,7 +1941,7 @@ bool stm32StreamFirmware(NetworkClient * stream,
         {
             if ((millis() - lastDataTime) > OTA_DATA_TIMEOUT)
             {
-                systemPrintln("LoRa OTA update timed out waiting for data");
+                usbPrintf("LoRa OTA update timed out waiting for data\r\n");
                 return false;
             }
             delay(1);
@@ -1984,24 +1972,34 @@ bool stm32StreamFirmware(NetworkClient * stream,
         // Update this portion of the firmware
         if (stm32UpdateFirmware(buffer, (uint16_t)validData) == false)
         {
-            loraSharedPrintln("LoRa/STM32 update failed during WiFi data upload.");
+            usbPrintf("LoRa/STM32 update failed during WiFi data upload.\r\n");
             break;
         }
 
+        // Display the progress
+        if (productVariant == RTK_TORCH)
+        {
+            muxSelectUsb();                               // Reconnect USB to print to terminal
+            firmwareUpdateProgressCallback("LoRa/STM32", validData); // Notify callback
+            Serial.flush();
+            muxSelectLoRaCommunication(); // Disconnect USB, connect to LoRa
+        }
+        else
+            firmwareUpdateProgressCallback("LoRa/STM32", validData); // Notify callback
+
         // Account for this data
         fileBytes -= validData;
-        firmwareUpdateProgressCallback("LoRa/STM32", validData);
         lastDataTime = millis();
         validData = 0;
     }
 
-    loraSharedPrintln(otaEqualSigns);
+    usbPrintf("%s\r\n", otaEqualSigns);
     bool success = (fileBytes == 0) && stm32UpdateFirmwareEnd();
     if (success)
-        loraSharedPrintln("LoRa/STM32 updated successfully.");
+        usbPrintf("LoRa/STM32 updated successfully.\r\n");
     else
-        loraSharedPrintln("LoRa/STM32 update failed.");
-    loraSharedPrintln(otaEqualSigns);
+        usbPrintf("LoRa/STM32 update failed.\r\n");
+    usbPrintf("%s\r\n", otaEqualSigns);
     return success;
 }
 

--- a/Firmware/RTK_Everywhere/LoRa.ino
+++ b/Firmware/RTK_Everywhere/LoRa.ino
@@ -1722,12 +1722,16 @@ bool stm32UpdateFirmware(uint8_t *dataArray, uint16_t bytesToWrite)
 // Helper to send STM32 commands and wait for ACK (0x79)
 bool stm32UpdateFirmwareWaitForAck()
 {
+    uint32_t data;
     uint32_t startTime = millis();
     while (millis() - startTime < 1000)
     {
         if (loraAvailable())
         {
-            if (loraRead() == 0x79)
+            data = loraRead();
+            if (settings.debugFirmwareUpdate && otaDebugVerbose)
+                usbPrintf("0x%02x\r\n", data);
+            if (data == 0x79)
                 return true;
         }
         else

--- a/Firmware/RTK_Everywhere/LoRa.ino
+++ b/Firmware/RTK_Everywhere/LoRa.ino
@@ -1628,7 +1628,7 @@ void usbPrintf(const char *format, ...)
     }
 
     // Send the output to the USB UART
-    systemPrint(buf);
+    Serial.print(buf);
     va_end(args);
     va_end(args2);
 

--- a/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/LoRa.ino
+++ b/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/LoRa.ino
@@ -18,7 +18,7 @@ void usbPrintf(const char *format, ...)
     }
 
     // Send the output to the USB UART
-    systemPrint(buf);
+    Serial.print(buf);
     va_end(args);
     va_end(args2);
 

--- a/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/LoRa.ino
+++ b/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/LoRa.ino
@@ -1,3 +1,36 @@
+// Enable printfs to various endpoints
+// https://stackoverflow.com/questions/42131753/wrapper-for-printf
+void usbPrintf(const char *format, ...)
+{
+    va_list args;
+    va_list args2;
+
+    va_start(args, format);
+    va_copy(args2, args);
+    char buf[vsnprintf(nullptr, 0, format, args) + 1];
+    vsnprintf(buf, sizeof buf, format, args2);
+
+    // Connect UART 0 to the USB UART
+    if (productVariant == RTK_TORCH)
+    {
+        Serial.flush(); // Finishing any pending prints to before switching
+        muxSelectUsb(); // Reconnect USB to print to terminal
+    }
+
+    // Send the output to the USB UART
+    systemPrint(buf);
+    va_end(args);
+    va_end(args2);
+
+    // Connect UART 0 back to the LoRa
+    if (productVariant == RTK_TORCH)
+    {
+        Serial.flush();
+        muxSelectLoRaCommunication(); // Torch: Disconnect USB, connect to LoRa
+    }
+}
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 // The following functions are for the STM32 firmware update process.
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
@@ -147,7 +180,10 @@ bool stm32UpdateFirmwareFlashBlock(uint32_t addr, uint8_t *data, uint16_t len)
     loraWrite(0x31);
     loraWrite(0xCE);
     if (stm32UpdateFirmwareWaitForAck() == false)
+    {
+        usbPrintf("Write memory command failed, addr: 0x%08x, len: 0x%04x\r\n", addr, len);
         return false;
+    }
 
     // Send Address + Checksum
     uint8_t addrBytes[4] = {(uint8_t)(addr >> 24), (uint8_t)(addr >> 16), (uint8_t)(addr >> 8), (uint8_t)addr};
@@ -156,7 +192,10 @@ bool stm32UpdateFirmwareFlashBlock(uint32_t addr, uint8_t *data, uint16_t len)
     loraWrite(checksum);
 
     if (stm32UpdateFirmwareWaitForAck() == false)
+    {
+        usbPrintf("Send address failed, addr: 0x%08x, len: 0x%04x\r\n", addr, len);
         return false;
+    }
 
     // Send Number of bytes - 1 (STM32 protocol requirement)
     uint8_t n = len - 1;
@@ -169,7 +208,12 @@ bool stm32UpdateFirmwareFlashBlock(uint32_t addr, uint8_t *data, uint16_t len)
     }
     loraWrite(checksum);
 
-    return stm32UpdateFirmwareWaitForAck();
+    if (stm32UpdateFirmwareWaitForAck() == false)
+    {
+        usbPrintf("Send bytes failed, addr: 0x%08x, len: 0x%04x\r\n", addr, len);
+        return false;
+    }
+    return true;
 }
 
 // Add data to the stm32PageBuffer. Write to STM32 when we hit 256 bytes.

--- a/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/LoRa.ino
+++ b/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/LoRa.ino
@@ -46,20 +46,7 @@ uint32_t stm32CurrentAddress = 0x08000000; // Next flash address to write; advan
 // flashed every time a full 256 byte page accumulates.
 bool stm32UpdateFirmware(uint8_t *dataArray, uint16_t bytesToWrite)
 {
-    bool success = stm32UpdatePageBuffer(dataArray, bytesToWrite);
-
-    if (productVariant == RTK_TORCH)
-    {
-        muxSelectUsb();                               // Reconnect USB to print to terminal
-        firmwareUpdateProgressCallback("LoRa", bytesToWrite); // Notify callback
-        Serial.flush();
-        muxSelectLoRaCommunication(); // Disconnect USB, connect to LoRa
-    }
-    else
-    {
-        firmwareUpdateProgressCallback("LoRa", bytesToWrite); // Notify callback
-    }
-    return success;
+    return stm32UpdatePageBuffer(dataArray, bytesToWrite);
 }
 
 // Helper to send STM32 commands and wait for ACK (0x79)
@@ -272,7 +259,89 @@ bool stm32UpdateFirmwareEnd()
 //----------------------------------------
 // Update the STM32 firmware
 //----------------------------------------
-bool stm32StreamFirmware(const char * url)
+bool stm32StreamFirmware(NetworkClient * stream,
+                         size_t fileBytes,
+                         uint8_t * buffer,
+                         size_t packetBytes)
+{
+    muxSelectLoRaCommunication(); // Mandatory for Torch: Connect ESP32 to LoRa for communication
+
+    loraSharedPrintln("Starting LoRa/STM32 firmware update...");
+
+    if (stm32UpdateFirmwareBegin() == false)
+    {
+        usbPrintf("%s\r\n", otaEqualSigns);
+        usbPrintf("LoRa/STM32 update failed.\r\n");
+        usbPrintf("%s\r\n", otaEqualSigns);
+        return false;
+    }
+
+    unsigned long lastDataTime = millis();
+    size_t validData = 0;
+    while (stream->connected() && (fileBytes > 0))
+    {
+        // Wait until some data is available
+        size_t available = stream->available();
+        if (available == 0)
+        {
+            if ((millis() - lastDataTime) > OTA_DATA_TIMEOUT)
+            {
+                usbPrintf("LoRa OTA update timed out waiting for data\r\n");
+                return false;
+            }
+            delay(1);
+            continue;
+        }
+
+        // Read the received data
+        size_t toRead = min(available, packetBytes - validData);
+        int bytesRead = stream->readBytes(&buffer[validData], toRead);
+        if (bytesRead <= 0)
+            break;
+        validData += bytesRead;
+
+        // Fill the packet
+        if ((validData < packetBytes) && (validData != fileBytes))
+            continue;
+
+        // Update this portion of the firmware
+        if (stm32UpdateFirmware(buffer, (uint16_t)validData) == false)
+        {
+            usbPrintf("LoRa/STM32 update failed during WiFi data upload.\r\n");
+            break;
+        }
+
+        // Display the progress
+        if (productVariant == RTK_TORCH)
+        {
+            muxSelectUsb();                               // Reconnect USB to print to terminal
+            firmwareUpdateProgressCallback("LoRa/STM32", validData); // Notify callback
+            Serial.flush();
+            muxSelectLoRaCommunication(); // Disconnect USB, connect to LoRa
+        }
+        else
+            firmwareUpdateProgressCallback("LoRa/STM32", validData); // Notify callback
+
+        // Account for this data
+        fileBytes -= validData;
+        lastDataTime = millis();
+        validData = 0;
+    }
+
+    usbPrintf("%s\r\n", otaEqualSigns);
+    bool success = (fileBytes == 0) && stm32UpdateFirmwareEnd();
+    if (success)
+        usbPrintf("LoRa/STM32 updated successfully.\r\n");
+    else
+        usbPrintf("LoRa/STM32 update failed.\r\n");
+    usbPrintf("%s\r\n", otaEqualSigns);
+    return success;
+}
+
+//----------------------------------------
+// Update the STM32 firmware
+//----------------------------------------
+bool stm32FirmwareUpdate(const char * url)
 {
     muxSelectLoRaCommunication(); // Mandatory for Torch: Connect ESP32 to LoRa for communication
 
@@ -305,60 +374,18 @@ bool stm32StreamFirmware(const char * url)
         return false;
     }
 
-    int contentLength = http.getSize();
-    if (contentLength > 0)
-        firmwareUpdateBytesToProcess = (uint32_t)contentLength;
+    size_t fileBytes = http.getSize();
+    if ((ssize_t)fileBytes > 0)
+        firmwareUpdateBytesToProcess = fileBytes;
 
     WiFiClient *stream = http.getStreamPtr();
     uint8_t buffer[256];
 
-    bool success = true;
-
-    loraSharedPrintln("Starting STM32 firmware update...");
-
-    if (stm32UpdateFirmwareBegin() == false)
-    {
-        http.end();
-        return false;
-    }
-
-    while (http.connected() && (contentLength > 0 || contentLength == -1))
-    {
-        size_t available = stream->available();
-        if (available == 0)
-        {
-            if (!client.connected())
-                break;
-            delay(1);
-            continue;
-        }
-
-        size_t toRead = min(available, sizeof(buffer));
-        int bytesRead = stream->readBytes(buffer, toRead);
-        if (bytesRead <= 0)
-            break;
-
-        if (stm32UpdateFirmware(buffer, (uint16_t)bytesRead) == false)
-        {
-            loraSharedPrintln("Firmware update failed during WiFi data upload.");
-            success = false;
-            break;
-        }
-
-        if (contentLength > 0)
-            contentLength -= bytesRead;
-    }
-
-    if (success == true && stm32UpdateFirmwareEnd() == false)
-        success = false;
-
-    if (success)
-        loraSharedPrintln("LoRa/STM32 updated successfully.");
-    else
-        loraSharedPrintln("LoRa/STM32 update failed.");
-
-    http.end();
-    return success;
+    return stm32StreamFirmware(stream,
+                               fileBytes,
+                               buffer,
+                               sizeof(buffer));
 }
+
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 // End of LoRa/STM32 firmware update functions.

--- a/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/LoRa.ino
+++ b/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/LoRa.ino
@@ -30,6 +30,24 @@ void usbPrintf(const char *format, ...)
     }
 }
 
+void loraRxFlush()
+{
+    if (productVariant == RTK_TORCH)
+    {
+        while (Serial.available())
+            Serial.read();
+        return;
+    }
+    else if (productVariant == RTK_FACET_FP)
+    {
+        while (SerialForLoRa->available())
+            SerialForLoRa->read();
+        return;
+    }
+
+    systemPrintln("loraRxFlush - invalid ProductVariant");
+}
+
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 // The following functions are for the STM32 firmware update process.
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -96,6 +114,10 @@ bool stm32UpdateFirmwareBegin()
     loraPowerOn(); // Regardless of previous state, turn on the STM32
 
     loraEnterBootloader(); // Push boot pin high and reset STM32
+
+    // Discard any characters in the RX FIFO
+    // If we are talking to the boot loader all we should receive are ACKs
+    loraRxFlush();
 
     // Send 0x7F for auto-baud detection
     loraWrite(0x7F);

--- a/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/LoRa.ino
+++ b/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/LoRa.ino
@@ -52,12 +52,15 @@ bool stm32UpdateFirmware(uint8_t *dataArray, uint16_t bytesToWrite)
 // Helper to send STM32 commands and wait for ACK (0x79)
 bool stm32UpdateFirmwareWaitForAck()
 {
+    uint32_t data;
     uint32_t startTime = millis();
     while (millis() - startTime < 1000)
     {
         if (loraAvailable())
         {
-            if (loraRead() == 0x79)
+            data = loraRead();
+                usbPrintf("0x%02x\r\n", data);
+            if (data == 0x79)
                 return true;
         }
         else

--- a/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/LoRa.ino
+++ b/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/LoRa.ino
@@ -269,12 +269,14 @@ bool stm32UpdateFirmwareEnd()
     return success;
 }
 
+//----------------------------------------
 // Update the STM32 firmware
-bool stm32StreamFirmware(char *relativeFirmwareFileLocation)
+//----------------------------------------
+bool stm32StreamFirmware(const char * url)
 {
     muxSelectLoRaCommunication(); // Mandatory for Torch: Connect ESP32 to LoRa for communication
 
-    if (relativeFirmwareFileLocation == nullptr)
+    if (url == nullptr)
     {
         loraSharedPrintln("Firmware file location is null.");
         return false;
@@ -288,7 +290,7 @@ bool stm32StreamFirmware(char *relativeFirmwareFileLocation)
     }
 
     HTTPClient http;
-    if (!http.begin(client, otaGetGithubFileLocation(relativeFirmwareFileLocation)))
+    if (!http.begin(client, url))
     {
         loraSharedPrintln("Unable to begin HTTP request.");
         return false;

--- a/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/LoRa.ino
+++ b/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/LoRa.ino
@@ -46,20 +46,20 @@ uint32_t stm32CurrentAddress = 0x08000000; // Next flash address to write; advan
 // flashed every time a full 256 byte page accumulates.
 bool stm32UpdateFirmware(uint8_t *dataArray, uint16_t bytesToWrite)
 {
-    stm32UpdatePageBuffer(dataArray, bytesToWrite);
+    bool success = stm32UpdatePageBuffer(dataArray, bytesToWrite);
 
     if (productVariant == RTK_TORCH)
     {
         muxSelectUsb();                               // Reconnect USB to print to terminal
-        firmwareUpdateProgressCallback(bytesToWrite); // Notify callback
+        firmwareUpdateProgressCallback("LoRa", bytesToWrite); // Notify callback
         Serial.flush();
         muxSelectLoRaCommunication(); // Disconnect USB, connect to LoRa
     }
     else
     {
-        firmwareUpdateProgressCallback(bytesToWrite); // Notify callback
+        firmwareUpdateProgressCallback("LoRa", bytesToWrite); // Notify callback
     }
-    return true;
+    return success;
 }
 
 // Helper to send STM32 commands and wait for ACK (0x79)

--- a/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/STM32_Update_From_WiFi.ino
+++ b/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/STM32_Update_From_WiFi.ino
@@ -28,7 +28,7 @@ bool RTK_CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC = false; // Needed because of local B
 #include <WiFiClientSecure.h>
 #include "secrets.h"
 
-char *firmwareURL = "/lora/stm32wl/SparkPNT_LoRa_3.0.1.bin";
+const char * firmwareURL = "https://raw.githubusercontent.com/sparkfun/SparkFun_RTK_Everywhere_Firmware_Binaries/main/lora/stm32wl/SparkPNT_LoRa_3.0.1.bin";
 
 #define OTA_FIRMWARE_GITHUB_RAW "raw.githubusercontent.com"
 

--- a/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/STM32_Update_From_WiFi.ino
+++ b/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/STM32_Update_From_WiFi.ino
@@ -70,6 +70,10 @@ unsigned long firmwareUpdateElapsed = 0;
 uint32_t firmwareUpdateBytesToProcess = 0;
 uint32_t firmwareUpdateBytesProcessed = 0;
 
+const char * otaEqualSigns = "==================================================";
+
+#define OTA_DATA_TIMEOUT        (15 * 1000)
+
 void setup()
 {
     Serial.begin(115200);
@@ -156,7 +160,7 @@ void loop()
             // Start timer before erase
             firmwareUpdateStartTime = millis();
 
-            stm32StreamFirmware(firmwareURL);
+            stm32FirmwareUpdate(firmwareURL);
 
             muxSelectUsb(); // Mandatory for Torch. Reconnect USB to print to terminal
 

--- a/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/System.ino
+++ b/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/System.ino
@@ -1,5 +1,5 @@
 // Callback for all firmware update targets. Called with the number of bytes written to flash so far. Used to track and print progress.
-void firmwareUpdateProgressCallback(uint16_t bytesProcessed)
+void firmwareUpdateProgressCallback(const char * subsystemName, uint16_t bytesProcessed)
 {
     const uint8_t progressBarWidth = 20;
     static uint8_t lastUpdatePercent = 0;
@@ -15,13 +15,13 @@ void firmwareUpdateProgressCallback(uint16_t bytesProcessed)
 
     uint8_t filled = (progressPercent * progressBarWidth) / 100;
 
-        // Don't update unless there is a change
+    // Don't update unless there is a change
     if (progressPercent == lastUpdatePercent)
         return;
 
     lastUpdatePercent = progressPercent;
-    
-    systemPrint("Update Progress: [");
+
+    systemPrintf("%s Update Progress: [", subsystemName);
     for (uint8_t i = 0; i < progressBarWidth; i++)
         systemWrite(i < filled ? '#' : '-');
 

--- a/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/System.ino
+++ b/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/System.ino
@@ -30,29 +30,6 @@ void firmwareUpdateProgressCallback(const char * subsystemName, uint16_t bytesPr
     systemPrintln("%");
 }
 
-// Given a relative location, return the full GitHub raw URL for the firmware file.
-char *otaGetGithubFileLocation(const char *relativeFirmwareFileLocation)
-{
-    // The relative file location looks like "\imu\im19\20260302210315_VH2_B2.2_A11.1_6bf04becee0bda310e65d.enc"
-    // We need to access
-    // "https://raw.githubusercontent.com/sparkfun/SparkFun_RTK_Everywhere_Firmware_Binaries/main/imu/im19/20260522185649_VH2_B2.2_A11.4.1_131b44ecee0bdad5670c7.enc"
-
-    static char firmwareFileLocation[256];
-    snprintf(firmwareFileLocation, sizeof(firmwareFileLocation),
-             "https://%s/sparkfun/SparkFun_RTK_Everywhere_Firmware_Binaries/main%s", OTA_FIRMWARE_GITHUB_RAW,
-             relativeFirmwareFileLocation);
-
-    // Convert backslashes to forward slashes for URL formatting
-    for (char *c = firmwareFileLocation; *c != '\0'; c++)
-        if (*c == '\\')
-            *c = '/';
-
-    // if(settings.enabledebugFirmwareUpdate)
-    systemPrintf("Absolute firmware location: %s\r\n", firmwareFileLocation);
-
-    return firmwareFileLocation;
-}
-
 // Returns true if we successfully establish a secure connection to GitHub.
 bool otaSecurelyConnectGitHub(WiFiClientSecure &client)
 {


### PR DESCRIPTION
This pull request includes the following commits:
* LoRa OTA: Updates from example
* LoRa OTA: Fix bootloader synchronization
* LoRa OTA: Use Serial.print instead of systemPrint in usbPrintf
* LoRa OTA: Display bootloader ACKs when verbose debugging is enabled