### PR TITLE
Flash update improvements

### DIFF
--- a/Firmware/RTK_Everywhere/GNSS.ino
+++ b/Firmware/RTK_Everywhere/GNSS.ino
@@ -992,8 +992,8 @@ void gnssFirmwareDirectConnectHardware() // Facet FP only
             char c = Serial.read();
             if ((c == 'r') || (c == 'R'))
                 // If the GNSS is a LG290P, putting it into reset will bring down I2C
-                // So use the fast GNSS-detect routine to do the reset
-                gpioExpanderDetectGnssForced();
+                // So use the fast GNSS reset
+                gpioExpanderGnssResetFast();
             else
                 break; // Break on any other character
         }

--- a/Firmware/RTK_Everywhere/LoRa.ino
+++ b/Firmware/RTK_Everywhere/LoRa.ino
@@ -935,6 +935,80 @@ bool loraSendCommand(const char *command, char *response, int *responseSize, con
     return (false);
 }
 
+// Reads incoming bytes looking for "version:x.y.z" in the response to AT+V?.
+// Parses and stores the version into loraFirmwareVersionStr/loraFirmwareVersionInt if found.
+bool loraWaitForVersionResponse(unsigned long timeoutMs)
+{
+    const int responseLen = 48; // Enough to capture "version:x.y.z" and nearby response text
+    char response[responseLen];
+    int responseSpot = 0;
+
+    unsigned long startTime = millis();
+    while ((millis() - startTime) < timeoutMs)
+    {
+        if (loraAvailable())
+        {
+            if (responseLen - 1 == responseSpot)
+            {
+                for (int i = 1; i < responseLen; i++)
+                    response[i - 1] = response[i]; // Shift the FIFO along by 1
+                responseSpot--;
+            }
+            response[responseSpot++] = loraRead();
+            response[responseSpot] = 0;
+
+            if (strstr(response, "version:"))
+            {
+                // Read in the entire response
+                delay(10);
+                while (loraAvailable())
+                {
+                    if (responseLen - 1 == responseSpot)
+                    {
+                        for (int i = 1; i < responseLen; i++)
+                            response[i - 1] = response[i]; // Shift the FIFO along by 1
+                        responseSpot--;
+                    }
+                    response[responseSpot++] = loraRead();
+                    response[responseSpot] = 0;
+                }
+
+                // Capture the version so loraGetVersion does not need a second AT+V? query
+                char *versionPtr = strstr(response, "version:");
+                if (versionPtr != nullptr)
+                {
+                    versionPtr += strlen("version:");
+                    while ((*versionPtr == ' ') || (*versionPtr == '\t'))
+                        versionPtr++;
+
+                    int versionSpot = 0;
+                    while ((versionPtr[versionSpot] >= '0' && versionPtr[versionSpot] <= '9') ||
+                           (versionPtr[versionSpot] == '.'))
+                    {
+                        if (versionSpot >= (int)(sizeof(loraFirmwareVersionStr) - 1))
+                            break;
+                        loraFirmwareVersionStr[versionSpot] = versionPtr[versionSpot];
+                        versionSpot++;
+                    }
+                    loraFirmwareVersionStr[versionSpot] = 0;
+
+                    int verMajor = 0;
+                    int verMinor = 0;
+                    int verPatch = 0;
+                    if (sscanf(loraFirmwareVersionStr, "%d.%d.%d", &verMajor, &verMinor, &verPatch) == 3)
+                    {
+                        loraFirmwareVersionInt = (verMajor * 100) + (verMinor * 10) + (verPatch);
+                        return (true);
+                    }
+                }
+            }
+        }
+        delay(1);
+    }
+
+    return false;
+}
+
 // On the Torch, USB and LoRa radio are shared, so disconnects from USB are required
 // On the Facet FP, LoRa UART2 is on ESP32 UART2
 // Sends AT+V?, if response, we are already in command mode -> Reconnects to USB, Return
@@ -942,9 +1016,8 @@ bool loraSendCommand(const char *command, char *response, int *responseSize, con
 // Sends AT+V?, if response, record the version number, we are in command mode -> Reconnects to USB, Return
 bool loraEnterCommandMode()
 {
-    const int responseLen = 48; // Enough to capture "version:x.y.z" and nearby response text
-    char response[responseLen];
-    int responseSpot = 0;
+    loraFirmwareVersionStr[0] = 0; // Clear any previously cached version before re-querying
+    loraFirmwareVersionInt = 0;
 
     loraReset(); // Needed for Torch
 
@@ -960,134 +1033,24 @@ bool loraEnterCommandMode()
     // Send version query. Wait up to 2000ms for a response
     // From the logic analyzer, "version:3.0.1\r\n\r\nOK\r\n" is typically sent after ~5ms
     loraPrint("AT+V?\r\n");
-    unsigned long startTime = millis();
-    while ((millis() - startTime) < 2000)
+    bool gotResponse = loraWaitForVersionResponse(2000);
+
+    if (gotResponse == false)
     {
-        if (loraAvailable())
-        {
-            if (responseLen - 1 == responseSpot)
-            {
-                for (int i = 1; i < responseLen; i++)
-                    response[i - 1] = response[i]; // Shift the FIFO along by 1
-            }
-            response[responseSpot++] = loraRead();
-            response[responseSpot] = 0;
+        // No response so send +++
+        loraPrint("+++\r\n");
+        delay(100); // Allow STM32 time to enter command mode
 
-            if (strstr(response, "version:"))
-            {
-                // Read in the entire response
-                delay(10);
-                while (loraAvailable())
-                {
-                    char incoming = loraRead();
-                    if (responseSpot < (responseLen - 1))
-                        response[responseSpot++] = incoming;
-                }
-                response[responseSpot] = 0;
-
-                // Capture the version so loraGetVersion does not need a second AT+V? query
-                char *versionPtr = strstr(response, "version:");
-                if (versionPtr != nullptr)
-                {
-                    versionPtr += strlen("version:");
-                    while ((*versionPtr == ' ') || (*versionPtr == '\t'))
-                        versionPtr++;
-
-                    int versionSpot = 0;
-                    while ((versionPtr[versionSpot] >= '0' && versionPtr[versionSpot] <= '9') ||
-                           (versionPtr[versionSpot] == '.'))
-                    {
-                        if (versionSpot >= (int)(sizeof(loraFirmwareVersionStr) - 1))
-                            break;
-                        loraFirmwareVersionStr[versionSpot] = versionPtr[versionSpot];
-                        versionSpot++;
-                    }
-                    loraFirmwareVersionStr[versionSpot] = 0;
-
-                    int verMajor = 0;
-                    int verMinor = 0;
-                    int verPatch = 0;
-                    if (sscanf(loraFirmwareVersionStr, "%d.%d.%d", &verMajor, &verMinor, &verPatch) == 3)
-                        loraFirmwareVersionInt = (verMajor * 100) + (verMinor * 10) + (verPatch);
-                }
-
-                muxSelectUsb(); // Connect USB
-                endLoRaConfigureCommunicationOnFacet();
-                return (true);
-            }
-        }
-        delay(1);
-    }
-
-    // No response so send +++
-    loraPrint("+++\r\n");
-    delay(100); // Allow STM32 time to enter command mode
-
-    // Send version query. Wait up to 2000ms for a response
-    loraPrint("AT+V?\r\n");
-    startTime = millis();
-    while ((millis() - startTime) < 2000)
-    {
-        if (loraAvailable())
-        {
-            if (responseLen - 1 == responseSpot)
-            {
-                for (int i = 1; i < responseLen; i++)
-                    response[i - 1] = response[i]; // Shift the FIFO along by 1
-            }
-            response[responseSpot++] = loraRead();
-            response[responseSpot] = 0;
-
-            if (strstr(response, "version:"))
-            {
-                // Read in the entire response
-                delay(10);
-                while (loraAvailable())
-                {
-                    char incoming = loraRead();
-                    if (responseSpot < (responseLen - 1))
-                        response[responseSpot++] = incoming;
-                }
-                response[responseSpot] = 0;
-
-                // Capture the version so loraGetVersion does not need a second AT+V? query
-                char *versionPtr = strstr(response, "version:");
-                if (versionPtr != nullptr)
-                {
-                    versionPtr += strlen("version:");
-                    while ((*versionPtr == ' ') || (*versionPtr == '\t'))
-                        versionPtr++;
-
-                    int versionSpot = 0;
-                    while ((versionPtr[versionSpot] >= '0' && versionPtr[versionSpot] <= '9') ||
-                           (versionPtr[versionSpot] == '.'))
-                    {
-                        if (versionSpot >= (int)(sizeof(loraFirmwareVersionStr) - 1))
-                            break;
-                        loraFirmwareVersionStr[versionSpot] = versionPtr[versionSpot];
-                        versionSpot++;
-                    }
-                    loraFirmwareVersionStr[versionSpot] = 0;
-
-                    int verMajor = 0;
-                    int verMinor = 0;
-                    int verPatch = 0;
-                    if (sscanf(loraFirmwareVersionStr, "%d.%d.%d", &verMajor, &verMinor, &verPatch) == 3)
-                        loraFirmwareVersionInt = (verMajor * 100) + (verMinor * 10) + (verPatch);
-                }
-
-                muxSelectUsb(); // Connect USB
-                endLoRaConfigureCommunicationOnFacet();
-                return (true);
-            }
-        }
-        delay(1);
+        // Send version query. Wait up to 2000ms for a response
+        loraPrint("AT+V?\r\n");
+        gotResponse = loraWaitForVersionResponse(2000);
     }
 
     muxSelectUsb(); // Connect USB
     endLoRaConfigureCommunicationOnFacet();
-    systemPrintln("LoRa Error: Unable to enter command mode");
-    return (false);
+    if (!gotResponse)
+        systemPrintln("LoRa Error: Unable to enter command mode");
+    return (gotResponse);
 }
 
 // Stores the current LoRa radio firmware version

--- a/Firmware/RTK_Everywhere/System.ino
+++ b/Firmware/RTK_Everywhere/System.ino
@@ -1128,17 +1128,19 @@ void gpioExpanderGnssBoot()
 }
 
 // This drives the GNSS_Reset low, which causes the GNSS and IMU to reset on the FP
+// Use a fast reset if the GNSS is LG290P or unknown
 void gpioExpanderGnssReset()
 {
     if (online.gpioExpanderSwitches == true)
     {
-        if (settings.detectedGnssReceiver != GNSS_RECEIVER_LG290P)
-        {
-            gpioExpanderSwitches->digitalWrite(gpioExpanderSwitch_GNSS_Reset, LOW);
-        }
+        // Disabling an LG290P when it's connected to an I2C bus will bring down the I2C bus
+        // Perform a fast reset and return to boot
+        // For safety, also do this if the GNSS is unknown
+        if ((settings.detectedGnssReceiver == GNSS_RECEIVER_LG290P)
+            || (settings.detectedGnssReceiver == GNSS_RECEIVER_UNKNOWN))
+            gpioExpanderGnssResetFast();
         else
-            systemPrintln("Skipped disable of LG290P"); // Disabling an LG290P when it's connected to an I2C bus will
-                                                        // bring down the I2C bus
+            gpioExpanderSwitches->digitalWrite(gpioExpanderSwitch_GNSS_Reset, LOW);
     }
 }
 
@@ -1221,6 +1223,43 @@ bool gpioExpanderDetectGnssCommon(bool forceDetection)
         }
     }
     return (true); // Default to true so gnssDetectReceiverType() will continue with detection
+}
+
+// Use the same technique as gpioExpanderDetectGnssForced() to perform a fast GNSS reset:
+// avoiding the slow read-modify-write in the TCA9534 library;
+// without the slow flexModuleDetected for loop.
+void gpioExpanderGnssResetFast()
+{
+    if (online.gpioExpanderSwitches == true)
+    {
+        // Use 400kHz for speed
+        if (present.i2c0BusSpeed_400 == false)
+            i2c_0->setClock(400000);
+
+        // Set GNSS Reset LOW
+        gpioExpanderSwitches->digitalWrite(gpioExpanderSwitch_GNSS_Reset, LOW);
+
+        // Flex LG290P with Tilt does not reset unless we delay just a little...
+        delayMicroseconds(50); // 250 OK. 100 OK. 50 OK. 25 OK. 10 not OK.
+
+        // Clock is ticking! Be quick!
+        // Set GNSS Reset to INPUT as fast as possible - without read-modify-write
+        // The pull-up will bring the GNSS out of reset
+        i2c_0->beginTransmission(0x21);                              // FacetFP TCA9534 is on address 0x21
+        i2c_0->write(0x03);                                          // TCA9534 CONFIGURATION register
+        i2c_0->write((uint8_t)(1 << gpioExpanderSwitch_GNSS_Reset)); // Reset INPUT, all others OUTPUT
+        i2c_0->endTransmission(true);
+
+        // Now we can take our time to
+
+        // Restore 100kHz
+        if (present.i2c0BusSpeed_400 == false)
+            i2c_0->setClock(100000);
+
+        // Make GNSS Reset OUTPUT HIGH again
+        gpioExpanderSwitches->digitalWrite(gpioExpanderSwitch_GNSS_Reset, HIGH);
+        gpioExpanderSwitches->pinMode(gpioExpanderSwitch_GNSS_Reset, OUTPUT);
+    }
 }
 
 // The IMU is on UART3 of the Facet FP module connected to switch 3

--- a/Firmware/RTK_Everywhere/Tilt.ino
+++ b/Firmware/RTK_Everywhere/Tilt.ino
@@ -1323,7 +1323,7 @@ static bool im19SendATCommand(const char *cmd, const char *response, int retries
         delay(50);
         im19Serial()->setTimeout(50);
         int buf_len = im19Serial()->readBytes(buf, sizeof(buf));
-        if (buf_len > 0 && im19FindStr(buf, buf_len, response))
+        if ((buf_len > 0) && im19FindStr(buf, buf_len, response))
             return true;
     }
     return false;
@@ -1378,6 +1378,8 @@ bool im19UpdateFirmwareBegin(uint32_t fileSize)
     {
         im19ResetImu();
         delay(1000);
+        while (im19Serial()->available()) // Ensure the RX buffer is clear
+            im19Serial()->read();
         if (im19SendATCommand("AT+UPDATE_APP\r\n", "OK", 5))
             return true;
     }

--- a/Firmware/RTK_Everywhere/Tilt.ino
+++ b/Firmware/RTK_Everywhere/Tilt.ino
@@ -1332,10 +1332,29 @@ static bool im19SendATCommand(const char *cmd, const char *response, int retries
 // Hardware-resets the GNSS/IMU module ahead of entering the bootloader.
 static void im19ResetImu()
 {
-    pinMode(pin_GNSS_DR_Reset, OUTPUT);
-    digitalWrite(pin_GNSS_DR_Reset, LOW);
-    delay(100);
-    digitalWrite(pin_GNSS_DR_Reset, HIGH);
+    if (productVariant == RTK_TORCH)
+    {
+        // ESP32 UART2 is connected directly to IM19 UART1
+
+        gnssReset();
+        delay(50);
+        gnssBoot();
+    }
+    else if (productVariant == RTK_FACET_FP)
+    {
+        // On FP, confirm SW3 is in the correct position
+        // linking ESP32 UART2 to IMU UART1 on Flex Module (Flex UART3)
+        gpioExpanderSelectImu();
+
+        // On FP, the GNSS and IMU reset is shared
+        // Putting the LG290P Flex Module into reset can bring down the I2C bus
+        // gpioExpanderDetectGnssForced() will perfrom a very quick reset if needed
+        gpioExpanderDetectGnssForced()
+    }
+    else
+    {
+        reportFatalError("im19ResetImu: unknown product variant");
+    }
 }
 
 // Puts the IM19 into its bootloader and gets ready to receive frames for a file of

--- a/Firmware/RTK_Everywhere/Tilt.ino
+++ b/Firmware/RTK_Everywhere/Tilt.ino
@@ -1349,7 +1349,7 @@ static void im19ResetImu()
         // On FP, the GNSS and IMU reset is shared
         // Putting the LG290P Flex Module into reset can bring down the I2C bus
         // gpioExpanderDetectGnssForced() will perfrom a very quick reset if needed
-        gpioExpanderDetectGnssForced()
+        gpioExpanderDetectGnssForced();
     }
     else
     {

--- a/Firmware/RTK_Everywhere/Tilt.ino
+++ b/Firmware/RTK_Everywhere/Tilt.ino
@@ -1348,8 +1348,8 @@ static void im19ResetImu()
 
         // On FP, the GNSS and IMU reset is shared
         // Putting the LG290P Flex Module into reset can bring down the I2C bus
-        // gpioExpanderDetectGnssForced() will perfrom a very quick reset if needed
-        gpioExpanderDetectGnssForced();
+        // so we need to perfrom a very quick reset
+        gpioExpanderGnssResetFast();
     }
     else
     {

--- a/Firmware/Test Sketches/Flash_Update/IM19_Update_From_WiFi/Switch.ino
+++ b/Firmware/Test Sketches/Flash_Update/IM19_Update_From_WiFi/Switch.ino
@@ -68,15 +68,59 @@ void gpioExpanderGnssBoot()
 void gpioExpanderGnssReset()
 {
     //if (online.gpioExpanderSwitches == true)
-    {
-        // if (settings.detectedGnssReceiver != GNSS_RECEIVER_LG290P)
-        {
-            gpioExpanderSwitches->digitalWrite(gpioExpanderSwitch_GNSS_Reset, LOW);
-        }
-        // else
-            // systemPrintln("Skipped disable of LG290P"); // Disabling an LG290P when it's connected to an I2C bus will
-                                                        // bring down the I2C bus
-    }
+    //{
+        // Disabling an LG290P when it's connected to an I2C bus will bring down the I2C bus
+        // Perform a fast reset and return to boot
+        // For safety, also do this if the GNSS is unknown
+        //if ((settings.detectedGnssReceiver == GNSS_RECEIVER_LG290P)
+        //    || (settings.detectedGnssReceiver == GNSS_RECEIVER_UNKNOWN))
+            gpioExpanderGnssResetFast();
+        //else
+        //    gpioExpanderSwitches->digitalWrite(gpioExpanderSwitch_GNSS_Reset, LOW);
+    //}
+}
+
+// Use the same technique as gpioExpanderDetectGnssForced() to perform a fast GNSS reset:
+// avoiding the slow read-modify-write in the TCA9534 library;
+// without the slow flexModuleDetected for loop.
+void gpioExpanderGnssResetFast()
+{
+    //if (online.gpioExpanderSwitches == true)
+    //{
+        // Use 400kHz for speed
+        //if (present.i2c0BusSpeed_400 == false)
+        //    i2c_0->setClock(400000);
+        Wire.setClock(400000);
+
+        // Set GNSS Reset LOW
+        gpioExpanderSwitches->digitalWrite(gpioExpanderSwitch_GNSS_Reset, LOW);
+
+        // Flex LG290P with Tilt does not reset unless we delay just a little...
+        delayMicroseconds(50); // 250 OK. 100 OK. 50 OK. 25 OK. 10 not OK.
+
+        // Clock is ticking! Be quick!
+        // Set GNSS Reset to INPUT as fast as possible - without read-modify-write
+        // The pull-up will bring the GNSS out of reset
+        //i2c_0->beginTransmission(0x21);                              // FacetFP TCA9534 is on address 0x21
+        //i2c_0->write(0x03);                                          // TCA9534 CONFIGURATION register
+        //i2c_0->write((uint8_t)(1 << gpioExpanderSwitch_GNSS_Reset)); // Reset INPUT, all others OUTPUT
+        //i2c_0->endTransmission(true);
+        Wire.beginTransmission(0x21);                              // FacetFP TCA9534 is on address 0x21
+        Wire.write(0x03);                                          // TCA9534 CONFIGURATION register
+        Wire.write((uint8_t)(1 << gpioExpanderSwitch_GNSS_Reset)); // Reset INPUT, all others OUTPUT
+        Wire.endTransmission(true);
+
+        // Now we can take our time to
+
+        // Restore 100kHz
+        //if (present.i2c0BusSpeed_400 == false)
+        //    i2c_0->setClock(100000);
+        Wire.setClock(100000);
+
+        // Make GNSS Reset OUTPUT HIGH again
+        gpioExpanderSwitches->digitalWrite(gpioExpanderSwitch_GNSS_Reset, HIGH);
+        gpioExpanderSwitches->pinMode(gpioExpanderSwitch_GNSS_Reset, OUTPUT);
+    //}
 }
 
 // On Flex modules, the IMU reset is tied to the GNSS reset

--- a/Firmware/Test Sketches/Flash_Update/IM19_Update_From_WiFi/Tilt.ino
+++ b/Firmware/Test Sketches/Flash_Update/IM19_Update_From_WiFi/Tilt.ino
@@ -296,6 +296,8 @@ bool im19UpdateFirmwareBegin(uint32_t fileSize)
     {
         imuReset();
         delay(1000);
+        while (SerialForTilt->available()) // Ensure the RX buffer is clear
+            SerialForTilt->read();
         if (im19SendATCommand("AT+UPDATE_APP\r\n", "OK", 5, nullptr, 0, nullptr))
             return true;
     }

--- a/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/Lora-Common.ino
+++ b/Firmware/Test Sketches/Flash_Update/STM32_Update_From_WiFi/Lora-Common.ino
@@ -218,35 +218,45 @@ bool loraWaitForVersionResponse(unsigned long timeoutMs)
                 delay(10);
                 while (loraAvailable())
                 {
-                    char incoming = loraRead();
-                    if (responseSpot < (responseLen - 1))
-                        response[responseSpot++] = incoming;
+                    if (responseLen - 1 == responseSpot)
+                    {
+                        for (int i = 1; i < responseLen; i++)
+                            response[i - 1] = response[i]; // Shift the FIFO along by 1
+                        responseSpot--;
+                    }
+                    response[responseSpot++] = loraRead();
+                    response[responseSpot] = 0;
                 }
-                response[responseSpot] = 0;
 
                 char *versionPtr = strstr(response, "version:");
-                versionPtr += strlen("version:");
-                while ((*versionPtr == ' ') || (*versionPtr == '\t'))
-                    versionPtr++;
-
-                int versionSpot = 0;
-                while ((versionPtr[versionSpot] >= '0' && versionPtr[versionSpot] <= '9') ||
-                       (versionPtr[versionSpot] == '.'))
+                if (versionPtr != nullptr)
                 {
-                    if (versionSpot >= (int)(sizeof(loraFirmwareVersionStr) - 1))
-                        break;
-                    loraFirmwareVersionStr[versionSpot] = versionPtr[versionSpot];
-                    versionSpot++;
+                    versionPtr += strlen("version:");
+                    while ((*versionPtr == ' ') || (*versionPtr == '\t'))
+                        versionPtr++;
+
+                    int versionSpot = 0;
+                    while ((versionPtr[versionSpot] >= '0' && versionPtr[versionSpot] <= '9') ||
+                        (versionPtr[versionSpot] == '.'))
+                    {
+                        if (versionSpot >= (int)(sizeof(loraFirmwareVersionStr) - 1))
+                            break;
+                        loraFirmwareVersionStr[versionSpot] = versionPtr[versionSpot];
+                        versionSpot++;
+                    }
+                    loraFirmwareVersionStr[versionSpot] = 0;
+
+                    int verMajor = 0;
+                    int verMinor = 0;
+                    int verPatch = 0;
+                    if (sscanf(loraFirmwareVersionStr, "%d.%d.%d", &verMajor, &verMinor, &verPatch) == 3)
+                    {
+                        loraFirmwareVersionInt = (verMajor * 100) + (verMinor * 10) + (verPatch);
+                        return true;
+                    }
                 }
-                loraFirmwareVersionStr[versionSpot] = 0;
 
-                int verMajor = 0;
-                int verMinor = 0;
-                int verPatch = 0;
-                if (sscanf(loraFirmwareVersionStr, "%d.%d.%d", &verMajor, &verMinor, &verPatch) == 3)
-                    loraFirmwareVersionInt = (verMajor * 100) + (verMinor * 10) + (verPatch);
-
-                return true;
+                return false;
             }
         }
         else


### PR DESCRIPTION
Add ```gpioExpanderGnssResetFast()``` to perform a fast reset on the Facet FPL LG290P - or if the GNSS is unknown
Update ```im19ResetImu()``` so it works on both Torch and Facet FP (the original code was Torch-specific)
Update the IM19_Update_From_WiFi example to match
Add ```loraWaitForVersionResponse``` from the STM32 WiFi example - avoiding the code duplication in ```loraEnterCommandMode()```
In the STM32 WiFi example, shift the LoRa response FIFO to avoid it becoming full
Purge the ESP32 UART RX buffer before sending IM19 AT+UPDATE_APP - otherwise the OK response is buried under a truck load of fmi messages
