### PR TITLE
Verify the brand, housing and product properties tables

### DIFF
--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -190,7 +190,11 @@ RTKBrandAttribute RTKBrandAttributes[RTKBrands_e::BRAND_NUM] = {
     { BRAND_SPARKPNT, "SparkPNT", logoSparkPNT_Width, logoSparkPNT_Height, logoSparkPNT },
 };
 
-// Product Variant used as part of device ID and whitelists. Do not reorder.
+// Product Variant - Do NOT reorder and do NOT remove unused values!!!
+// The label on the product lists the device ID which consists of the
+// Bluetooth address followed by two digits of the ProductVariant below.
+// This same ID value is used for the whitelists.  Skipped values represent
+// unreleased or new products.
 typedef enum
 {
     RTK_ALL = -1,
@@ -207,7 +211,8 @@ typedef enum
 } ProductVariant;
 ProductVariant productVariant = RTK_UNKNOWN;
 
-// Must match the contents of ProductVariant
+// allVariants - Do NOT remove, MUST match the contents of ProductVariant
+// without the RTK_ALL value!!!
 static const ProductVariant allVariants[] = { RTK_EVK, RTK_FACET_MOSAIC, RTK_TORCH, RTK_POSTCARD, RTK_FACET_FP, RTK_TORCH_X2, RTK_UNKNOWN};
 #define productVariantCount (sizeof(allVariants) / sizeof(allVariants[0]))
 

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -189,6 +189,7 @@ RTKBrandAttribute RTKBrandAttributes[RTKBrands_e::BRAND_NUM] = {
     { BRAND_SPARKFUN, "SparkFun", logoSparkFun_Width, logoSparkFun_Height, logoSparkFun },
     { BRAND_SPARKPNT, "SparkPNT", logoSparkPNT_Width, logoSparkPNT_Height, logoSparkPNT },
 };
+const int RTKBrandAttributesEntries = sizeof(RTKBrandAttributes) / sizeof(RTKBrandAttributes[0]);
 
 // Product Variant - Do NOT reorder and do NOT remove unused values!!!
 // The label on the product lists the device ID which consists of the

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -164,7 +164,7 @@ typedef enum {
     BRAND_NUM
 } RTKBrands_e;
 
-const RTKBrands_e DEFAULT_BRAND = BRAND_SPARKPNT;
+#define DEFAULT_BRAND           BRAND_SPARKPNT
 
 typedef struct
 {
@@ -302,9 +302,9 @@ const productProperties productPropertiesTable[] =
     //==============    ==    ==    =====   =====           =======                 ====            =========== ==========              =================   ======  ==============      ==================          ====================
     { RTK_EVK,          1,    10,   17.5,   BRAND_SPARKFUN, RTK_HOUSING_EVK,        "EVK",          "EVK",      "SFE_EVK",              "EVK",              true,   "0000000000000000", STATE_ROVER_NOT_STARTED,    "https://www.sparkfun.com/rtk_evk_registration" },
     { RTK_FACET_MOSAIC, 1,    4.7,  10,     BRAND_SPARKPNT, RTK_HOUSING_FACET,      "Facet X5",     "Facet X5", "SFE_Facet_mosaic",     "Facet mosaicX5",   true,   "0000000000000000", STATE_ROVER_NOT_STARTED,    "https://www.sparkfun.com/rtk_facet_mosaic_registration" },
-    { RTK_FACET_FP,     10,   20,   8.5,    BRAND_SPARKPNT, RTK_HOUSING_FP,         "FP",           "FP",       "SFE_FP",               "FP",               false,  "e9e877bb278140f0", STATE_ROVER_NOT_STARTED,    "https://www.sparkfun.com/rtk_facet_fp_registration" },
-    { RTK_POSTCARD,     3.3,  10,   8.5,    BRAND_SPARKFUN, RTK_HOUSING_POSTCARD,   "Postcard",     "Postcard", "SFE_Postcard",         "Postcard",         true,   "e9e877bb278140f0", STATE_ROVER_NOT_STARTED,    "https://www.sparkfun.com/rtk_postcard_registration" },
     { RTK_TORCH,        0,    0,    0,      BRAND_SPARKPNT, RTK_HOUSING_TORCH,      "Torch",        "Torch",    "SFE_Torch",            "Torch",            true,   "0000000000000000", STATE_ROVER_NOT_STARTED,    "https://www.sparkfun.com/rtk_torch_registration" },
+    { RTK_POSTCARD,     3.3,  10,   8.5,    BRAND_SPARKFUN, RTK_HOUSING_POSTCARD,   "Postcard",     "Postcard", "SFE_Postcard",         "Postcard",         true,   "e9e877bb278140f0", STATE_ROVER_NOT_STARTED,    "https://www.sparkfun.com/rtk_postcard_registration" },
+    { RTK_FACET_FP,     10,   20,   8.5,    BRAND_SPARKPNT, RTK_HOUSING_FP,         "FP",           "FP",       "SFE_FP",               "FP",               false,  "e9e877bb278140f0", STATE_ROVER_NOT_STARTED,    "https://www.sparkfun.com/rtk_facet_fp_registration" },
     { RTK_TORCH_X2,     8.2,  3.3,  8.5,    BRAND_SPARKPNT, RTK_HOUSING_TX2,        "TX2",          "TX2",      "SFE_TX2",              "TX2",              false,  "3407c7ca3d6b4984", STATE_ROVER_NOT_STARTED,    "https://www.sparkfun.com/tx2_registration" },
     { RTK_UNKNOWN,      0,    0,    0,      DEFAULT_BRAND,  RTK_HOUSING_MAX_NONE,   "Unknown",      "Unknown",  "SFE_Unknown",          "Unknown",          true,   "0000000000000000", STATE_ROVER_NOT_STARTED,    "Unknown" },
 };

--- a/Firmware/RTK_Everywhere/support.ino
+++ b/Firmware/RTK_Everywhere/support.ino
@@ -770,6 +770,11 @@ void verifyTables()
         productBitMap |= bitMask;
     }
 
+    // Verify that RTK_UNKNOWN is in the allVariants list
+    uint32_t bitMask = 1 << RTK_UNKNOWN;
+    if ((productBitMap & bitMask) == 0)
+        reportFatalError("RTK_UNKNOWN missing from allVariants list");
+
     // Verify the product properties table
     if (productPropertiesEntries != productVariantCount)
         reportFatalError("Fix productPropertiesTable to match ProductVariant");

--- a/Firmware/RTK_Everywhere/support.ino
+++ b/Firmware/RTK_Everywhere/support.ino
@@ -777,7 +777,25 @@ void verifyTables()
 
     // Verify the product properties table
     if (productPropertiesEntries != productVariantCount)
-        reportFatalError("Fix productPropertiesTable to match ProductVariant");
+        reportFatalError("Fix productPropertiesTable to match ProductVariant enum");
+    for (int index = 0; index < productVariantCount; index++)
+    {
+        const productProperties * product = &productPropertiesTable[index];
+        if ((product->productVariant < 0) || (product->productVariant > RTK_UNKNOWN))
+            reportFatalError("Remove bad productVariant values from productPropertiesTable");
+        uint32_t bitMask = 1 << product->productVariant;
+        if ((productBitMap & bitMask) == 0)
+            reportFatalError("productPropertiesTable contains entry not listed in allVariants list");
+        if ((product->brand < 0) || (product->brand >= BRAND_NUM))
+            reportFatalError("Fix productPropertiesTable brand entries < BRAND_NUM");
+        if ((product->housing < 0) || (product->housing > RTK_HOUSING_MAX_NONE))
+            reportFatalError("Fix productPropertiesTable housing entries <= RTK_HOUSING_MAX_NONE");
+    }
+
+    // Verify that RTK_UNKNOWN is the last entry in the productPropertiesTable
+    const productProperties * product = &productPropertiesTable[productVariantCount - 1];
+    if (product->productVariant != RTK_UNKNOWN)
+        reportFatalError("Last entry in productPropertiesTable MUST be RTK_UNKNOWN");
 
     // Verify the measurement scales
     if (measurementScaleEntries != MEASUREMENT_UNITS_MAX)

--- a/Firmware/RTK_Everywhere/support.ino
+++ b/Firmware/RTK_Everywhere/support.ino
@@ -1342,12 +1342,9 @@ const productProperties *getProductPropertiesFromVariant(ProductVariant variant)
 
 RTKBrandAttribute *getBrandAttributeFromBrand(RTKBrands_e brand)
 {
-    for (int i = 0; i < (int)RTKBrands_e::BRAND_NUM; i++)
-    {
-        if (RTKBrandAttributes[i].brand == brand)
-            return &RTKBrandAttributes[i];
-    }
-    return getBrandAttributeFromBrand(DEFAULT_BRAND);
+    if (brand >= BRAND_NUM)
+        brand = DEFAULT_BRAND;
+    return &RTKBrandAttributes[brand];
 }
 
 RTKBrandAttribute *getBrandAttributeFromProductVariant(ProductVariant variant)
@@ -1359,12 +1356,7 @@ RTKBrandAttribute *getBrandAttributeFromProductVariant(ProductVariant variant)
 const productHousingProperties *getProductHousingPropertiesFromVariant(ProductVariant variant)
 {
     const productProperties *properties = getProductPropertiesFromVariant(variant);
-    for (int i = 0; i < productHousingEntries; i++)
-    {
-        if (productHousingPropertiesTable[i].housing == properties->housing)
-            return &productHousingPropertiesTable[i];
-    }
-    return getProductHousingPropertiesFromVariant(RTK_UNKNOWN);
+    return &productHousingPropertiesTable[properties->housing];
 }
 
 // Used to report delay until next WiFi/NTRIP/etc connection attempt

--- a/Firmware/RTK_Everywhere/support.ino
+++ b/Firmware/RTK_Everywhere/support.ino
@@ -751,6 +751,13 @@ void verifyTables()
         if (RTKBrandAttributes[index].brand != index)
             reportFatalError("RTKBrandAttributes entries are out of order");
 
+    // Verify the product housing table
+    if (productHousingEntries != (RTK_HOUSING_MAX_NONE + 1))
+        reportFatalError("Fix productHousingPropertiesTable to match ProductVariantHousing");
+    for (int index = 0; index <= RTK_HOUSING_MAX_NONE; index++)
+        if (productHousingPropertiesTable[index].housing != index)
+            reportFatalError("productHousingPropertiesTable entries are out of order");
+
     // Verify the product properties table
     if (productPropertiesEntries != productVariantCount)
         reportFatalError("Fix productPropertiesTable to match ProductVariant");

--- a/Firmware/RTK_Everywhere/support.ino
+++ b/Firmware/RTK_Everywhere/support.ino
@@ -758,6 +758,18 @@ void verifyTables()
         if (productHousingPropertiesTable[index].housing != index)
             reportFatalError("productHousingPropertiesTable entries are out of order");
 
+    // Verify the allVariants list
+    uint32_t productBitMap = 0;
+    for (int index = 0; index < productVariantCount; index++)
+    {
+        if ((allVariants[index] < 0) || (allVariants[index] > RTK_UNKNOWN))
+            reportFatalError("Remove bad values from allVariants list");
+        uint32_t bitMask = 1 << allVariants[index];
+        if (productBitMap & bitMask)
+            reportFatalError("Remove duplicate entries from allVariants list");
+        productBitMap |= bitMask;
+    }
+
     // Verify the product properties table
     if (productPropertiesEntries != productVariantCount)
         reportFatalError("Fix productPropertiesTable to match ProductVariant");

--- a/Firmware/RTK_Everywhere/support.ino
+++ b/Firmware/RTK_Everywhere/support.ino
@@ -744,6 +744,13 @@ void checkArrayDefaults()
 // Verify table sizes match enum definitions
 void verifyTables()
 {
+    // Verify the brand table
+    if (RTKBrandAttributesEntries != BRAND_NUM)
+        reportFatalError("Fix RTKBrandAttributes to match RTKBrands_e");
+    for (int index = 0; index < BRAND_NUM; index++)
+        if (RTKBrandAttributes[index].brand != index)
+            reportFatalError("RTKBrandAttributes entries are out of order");
+
     // Verify the product properties table
     if (productPropertiesEntries != productVariantCount)
         reportFatalError("Fix productPropertiesTable to match ProductVariant");


### PR DESCRIPTION
This pull request includes the following commits:
* settings: Add warnings for ProductVariants and allVariants
* support: Verify RTKBrandAttributes table
* support: Verify productHousingPropertiesTable
* support: Verify the allVariants list
* support: Verify RTK_UNKNOWN is in the allVariants list
* support: Verify productPropertiesTable
* support: Reduce look ups for brands and housings
