### PR TITLE
Update the product resistor table to remove RTK_UNKNOWN entries and display product ID

### DIFF
--- a/Firmware/RTK_Everywhere/Begin.ino
+++ b/Firmware/RTK_Everywhere/Begin.ino
@@ -2096,16 +2096,17 @@ void displayProductResistorTable()
 
     // Display the table header
     systemPrintln();
-    systemPrintln("                   R1 K Ohms           R2 K Ohms");
-    systemPrintf("  %d.%03d Volts -----/\\/\\/\\/\\/-----+-----/\\/\\/\\/\\/----- Ground\r\n", MAX_ADC_VOLTAGE / 1000,
-                 MAX_ADC_VOLTAGE % 1000);
-    systemPrintln("                                 |");
-    systemPrintf("                             ADC input: %d mVolts\r\n", readBoardIdValue());
-    systemPrintln("                                 |");
-    systemPrintln("                                 V");
-    systemPrintln("  K Ohms                    Millivolts              Max");
-    systemPrintln(" R1    R2   Tolerance  High  Expected   Low Delta  uAmps  Product");
-    systemPrintln("----  ----  ---------  --------------------------  -----  ---------------");
+    systemPrintln("                 R1 K Ohms           R2 K Ohms");
+    systemPrintf( "%d.%03d Volts -----/\\/\\/\\/\\/----+----/\\/\\/\\/\\/----- Ground\r\n",
+                  MAX_ADC_VOLTAGE / 1000, MAX_ADC_VOLTAGE % 1000);
+    systemPrintln("                              |");
+    systemPrintf("                     ADC input: %d mVolts\r\n",
+                 readBoardIdValue());
+    systemPrintln("                              |");
+    systemPrintln("                              V");
+    systemPrintln("  K Ohms                 Millivolts             Max");
+    systemPrintln(" R1    R2  Tolerance High Expected  Low Delta  uAmps  Product");
+    systemPrintln("----  ---- --------- ------------------------  -----  ------------------------");
 
     // Walk the list of products
     for (int i = 0; i < productCount; i++)
@@ -2132,20 +2133,19 @@ void displayProductResistorTable()
 
         // Display the product values
         if (prop->r2 == 0)
-            systemPrint("Using I2C instead                                         ");
+            systemPrint("Using I2C instead                                    ");
         else
         {
             systemPrintf("%4.1f  ", prop->r1);
             systemPrintf("%4.1f  ", prop->r2);
-            systemPrintf(" %4.1f%%     ", prop->tolerancePercentage);
-            systemPrintf("%4d    ", upperThreshold[j]);
-            systemPrintf("%4d    ", expectedValue[j]);
+            systemPrintf(" %4.1f%%   ", prop->tolerancePercentage);
+            systemPrintf("%4d   ", upperThreshold[j]);
+            systemPrintf("%4d   ", expectedValue[j]);
             systemPrintf("%4d  ", lowerThreshold[j]);
             systemPrintf("%4d ", upperThreshold[j] - lowerThreshold[j]);
-            systemPrintf("%6d  ", uAmps);
+            systemPrintf("%6d ", uAmps);
         }
-        if (prop->productVariant == productVariant)
-            systemPrint("* ");
+        systemPrintf("%c", (prop->productVariant == productVariant) ? '*' : ' ');
         systemPrintf("%02d:%s\r\n", prop->productVariant, productName);
     }
 }

--- a/Firmware/RTK_Everywhere/Begin.ino
+++ b/Firmware/RTK_Everywhere/Begin.ino
@@ -2046,16 +2046,17 @@ void tpISR()
 // Display the product table, resistors voltages
 void displayProductResistorTable()
 {
-    int lowerThreshold[RTK_UNKNOWN];
-    int expectedValue[RTK_UNKNOWN];
-    int upperThreshold[RTK_UNKNOWN];
-    int sortIndex[RTK_UNKNOWN];
+    int productCount = productPropertiesEntries - 1;
+    int lowerThreshold[productCount];
+    int expectedValue[productCount];
+    int upperThreshold[productCount];
+    int sortIndex[productCount];
 
     // Populate the tables
-    for (int i = 0; i < RTK_UNKNOWN; i++)
+    for (int i = 0; i < productCount; i++)
     {
         sortIndex[i] = i;
-        const productProperties *prop = getProductPropertiesFromVariant((ProductVariant)i);
+        const productProperties * prop = &productPropertiesTable[i];
 
         // A value of zero for r2 indicates no resistor network present
         if (prop->r2)
@@ -2073,13 +2074,13 @@ void displayProductResistorTable()
     }
 
     // Perform a bubble on the values to order the values high to low
-    for (int i = 0; i < RTK_UNKNOWN - 1; i++)
+    for (int i = 0; i < productCount - 1; i++)
     {
-        const productProperties *prodI = getProductPropertiesFromVariant((ProductVariant)sortIndex[i]);
+        const productProperties * prodI = &productPropertiesTable[sortIndex[i]];
         int vI = (prodI->r2 == 0) ? 0 : expectedValue[sortIndex[i]];
-        for (int j = i + 1; j < RTK_UNKNOWN; j++)
+        for (int j = i + 1; j < productCount; j++)
         {
-            const productProperties *prodJ = getProductPropertiesFromVariant((ProductVariant)sortIndex[j]);
+            const productProperties * prodJ = &productPropertiesTable[sortIndex[j]];
             int vJ = (prodJ->r2 == 0) ? 0 : expectedValue[sortIndex[j]];
             if (vI < vJ)
             {
@@ -2107,15 +2108,15 @@ void displayProductResistorTable()
     systemPrintln("----  ----  ---------  --------------------------  -----  ---------------");
 
     // Walk the list of products
-    for (int i = 0; i < RTK_UNKNOWN; i++)
+    for (int i = 0; i < productCount; i++)
     {
         int j = sortIndex[i];
-        const productProperties *prop = getProductPropertiesFromVariant((ProductVariant)j);
+        const productProperties * prop = &productPropertiesTable[j];
 
         // Get the product name
         char productName[64];
-        const char *brand = getBrandAttributeFromProductVariant((ProductVariant)j)->name;
-        const char *product = prop->name;
+        const char * brand = getBrandAttributeFromBrand(prop->brand)->name;
+        const char * product = prop->name;
         strcpy(productName, brand);
         strcat(productName, " ");
         if (prop->rtkPrefix)

--- a/Firmware/RTK_Everywhere/Begin.ino
+++ b/Firmware/RTK_Everywhere/Begin.ino
@@ -2131,7 +2131,9 @@ void displayProductResistorTable()
         int uAmps = (int)(ceil(microVolts / minResistance));
 
         // Display the product values
-        if (prop->r2 != 0)
+        if (prop->r2 == 0)
+            systemPrint("Using I2C instead                                         ");
+        else
         {
             systemPrintf("%4.1f  ", prop->r1);
             systemPrintf("%4.1f  ", prop->r2);
@@ -2141,11 +2143,9 @@ void displayProductResistorTable()
             systemPrintf("%4d  ", lowerThreshold[j]);
             systemPrintf("%4d ", upperThreshold[j] - lowerThreshold[j]);
             systemPrintf("%6d  ", uAmps);
-            if (prop->productVariant == productVariant)
-                systemPrint("* ");
-            systemPrintf("%s\r\n", productName);
         }
-        else
-            systemPrintf("Using I2C instead                                         %s\r\n", productName);
+        if (prop->productVariant == productVariant)
+            systemPrint("* ");
+        systemPrintf("%02d:%s\r\n", prop->productVariant, productName);
     }
 }


### PR DESCRIPTION
This pull request includes the following commits:
* Begin: Don't display RTK_UNKNOWN entries in product resistor table
* Begin: Display 2 digit product ID
* Begin: Reformat product resistor table to fit into 80 columns