### PR TITLE
Move items into settings to make flash update comparisons easier

### DIFF
--- a/Firmware/RTK_Everywhere/OTA.h
+++ b/Firmware/RTK_Everywhere/OTA.h
@@ -9,7 +9,6 @@ OTA.h
 #define __OTA_H__
 
 typedef uint8_t OTA_SUBSYSTEM_MASK;
-bool otaDebugVerbose; // Enable verbose debug output
 
 #ifdef COMPILE_FIRMWARE_UPDATE
 
@@ -56,10 +55,6 @@ enum OTA_FIRMWARE_UPDATE_REQUEST
 #define OTA_DEVICE_GNSS         (1 << OTA_SUBSYSTEM_GNSS)
 #define OTA_DEVICE_LORA         (1 << OTA_SUBSYSTEM_LORA)
 #define OTA_DEVICE_IMU          (1 << OTA_SUBSYSTEM_IMU)
-
-#define OTA_DATA_TIMEOUT        (15 * MILLISECONDS_IN_A_SECOND)
-
-const char * otaEqualSigns = "==================================================";
 
 //----------------------------------------
 // Globals

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -236,10 +236,7 @@ const char *debugMessagePrefix = "# => "; // Something ~unique and easy to trigg
 // I2C for GNSS, battery gauge, display
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 #include "icons.h"
-#include <Wire.h> //Built-in
 #include <vector> //Needed for icons etc.
-TwoWire *i2c_0 = nullptr;
-TwoWire *i2c_1 = nullptr;
 TwoWire *i2cDisplay = nullptr;
 TwoWire *i2cAuthCoPro = nullptr;
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -681,11 +678,6 @@ void applyCompensationCommon(char *nmeaSentence, int sentenceLength, const char 
 
 int imuFirmwareVersionInt;
 char imuFirmwareVersionStr[32];    // Ex: IM19_H2_B2.2_A11.4.1
-
-HardwareSerial *uart2Serial;   // Shared serial port between LoRa and Tilt
-
-#define SerialForLoRa           uart2Serial
-#define SerialForTilt           uart2Serial
 
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -229,120 +229,7 @@ const uint16_t HTTPS_PORT = 443;                                                
 #define IDLE_TIME_DISPLAY_SECONDS 5
 #define MAX_IDLE_TIME_COUNT (IDLE_TIME_DISPLAY_SECONDS * IDLE_COUNT_PER_SECOND)
 
-#define HOURS_IN_A_DAY 24L
-#define MINUTES_IN_AN_HOUR 60L
-#define SECONDS_IN_A_MINUTE 60L
-#define MILLISECONDS_IN_A_SECOND 1000L
-#define MILLISECONDS_IN_A_MINUTE (SECONDS_IN_A_MINUTE * MILLISECONDS_IN_A_SECOND)
-#define MILLISECONDS_IN_AN_HOUR (MINUTES_IN_AN_HOUR * MILLISECONDS_IN_A_MINUTE)
-#define MILLISECONDS_IN_A_DAY (HOURS_IN_A_DAY * MILLISECONDS_IN_AN_HOUR)
-
-#define SECONDS_IN_AN_HOUR (MINUTES_IN_AN_HOUR * SECONDS_IN_A_MINUTE)
-#define SECONDS_IN_A_DAY (HOURS_IN_A_DAY * SECONDS_IN_AN_HOUR)
-
 const char *debugMessagePrefix = "# => "; // Something ~unique and easy to trigger on
-
-// Hardware connections
-//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-// These pins are set in beginBoard()
-#define PIN_UNDEFINED -1
-int pin_debug = PIN_UNDEFINED;              // LED on EVK
-int pin_batteryStatusLED = PIN_UNDEFINED;   // LED on Torch
-int pin_baseStatusLED = PIN_UNDEFINED;      // LED on EVK
-int pin_bluetoothStatusLED = PIN_UNDEFINED; // LED on Torch
-int pin_gnssStatusLED = PIN_UNDEFINED;      // LED on Torch
-
-int pin_muxA = PIN_UNDEFINED;
-int pin_muxB = PIN_UNDEFINED;
-int pin_mux1 = PIN_UNDEFINED;
-int pin_mux2 = PIN_UNDEFINED;
-int pin_mux3 = PIN_UNDEFINED;
-int pin_mux4 = PIN_UNDEFINED;
-
-int pin_modeButton = PIN_UNDEFINED;   // Mode button on EVK, Function button on Facet FP
-int pin_powerButton = PIN_UNDEFINED;  // Power and general purpose button on Torch, Facet
-int pin_powerFastOff = PIN_UNDEFINED; // Output on Facet
-int pin_muxDAC = PIN_UNDEFINED;
-int pin_muxADC = PIN_UNDEFINED;
-int pin_peripheralPowerControl = PIN_UNDEFINED; // EVK and Facet mosaic
-
-int pin_GnssEvent = PIN_UNDEFINED;   // Facet mosaic
-int pin_GnssOnOff = PIN_UNDEFINED;   // Facet mosaic
-int pin_chargerLED = PIN_UNDEFINED;  // Facet mosaic
-int pin_chargerLED2 = PIN_UNDEFINED; // Facet mosaic
-int pin_GnssReady = PIN_UNDEFINED;   // Facet mosaic
-
-int pin_loraRadio_reset = PIN_UNDEFINED;
-int pin_loraRadio_boot = PIN_UNDEFINED;
-int pin_loraRadio_power = PIN_UNDEFINED;
-
-int pin_Ethernet_CS = PIN_UNDEFINED;
-int pin_Ethernet_Interrupt = PIN_UNDEFINED;
-int pin_GNSS_CS = PIN_UNDEFINED;
-int pin_GNSS_TimePulse = PIN_UNDEFINED;
-int pin_GNSS_Reset = PIN_UNDEFINED;
-
-// microSD card pins
-int pin_PICO = PIN_UNDEFINED;
-int pin_POCI = PIN_UNDEFINED;
-int pin_SCK = PIN_UNDEFINED;
-int pin_microSD_CardDetect = PIN_UNDEFINED;
-int pin_microSD_CS = PIN_UNDEFINED;
-
-int pin_I2C0_SDA = PIN_UNDEFINED;
-int pin_I2C0_SCL = PIN_UNDEFINED;
-
-// On EVK, Display is on separate I2C bus
-int pin_I2C1_SDA = PIN_UNDEFINED;
-int pin_I2C1_SCL = PIN_UNDEFINED;
-
-int pin_GnssUart_RX = PIN_UNDEFINED;
-int pin_GnssUart_TX = PIN_UNDEFINED;
-
-int pin_GnssUart2_RX = PIN_UNDEFINED;
-int pin_GnssUart2_TX = PIN_UNDEFINED;
-
-int pin_Cellular_RX = PIN_UNDEFINED;
-int pin_Cellular_TX = PIN_UNDEFINED;
-int pin_Cellular_PWR_ON = PIN_UNDEFINED;
-int pin_Cellular_Network_Indicator = PIN_UNDEFINED;
-int pin_Cellular_Reset = PIN_UNDEFINED;
-int pin_Cellular_RTS = PIN_UNDEFINED;
-int pin_Cellular_CTS = PIN_UNDEFINED;
-bool cellularModemResetLow = false;
-#define CELLULAR_MODEM_FC ESP_MODEM_FLOW_CONTROL_NONE
-uint8_t laraPwrLowValue;
-uint32_t laraTimer; // Backoff timer
-
-int pin_IMU_RX = PIN_UNDEFINED;
-int pin_IMU_TX = PIN_UNDEFINED;
-int pin_GNSS_DR_Reset = PIN_UNDEFINED;
-int pin_IMU_Boot = PIN_UNDEFINED;
-
-int pin_powerAdapterDetect = PIN_UNDEFINED;
-int pin_usbSelect = PIN_UNDEFINED;
-int pin_beeper = PIN_UNDEFINED;
-
-int pin_gpioExpanderInterrupt = PIN_UNDEFINED;
-const uint8_t gpioExpander_up = 0;
-const uint8_t gpioExpander_down = 1;
-const uint8_t gpioExpander_right = 2;
-const uint8_t gpioExpander_left = 3;
-const uint8_t gpioExpander_center = 4;
-const uint8_t gpioExpander_cardDetect = 5;
-const uint8_t gpioExpander_io6 = 6;
-const uint8_t gpioExpander_io7 = 7;
-
-const uint8_t gpioExpanderSwitch_S1 = 0; // Controls U16 switch 1: connect ESP UART0 to CH342 or SW2
-const uint8_t gpioExpanderSwitch_S2 = 1; // Controls U17 switch 2: connect SW1 to RS232 Output or GNSS UART4
-const uint8_t gpioExpanderSwitch_S3 = 2; // Controls U18 switch 3: connect ESP UART2 to GNSS UART3 or LoRa UART2
-const uint8_t gpioExpanderSwitch_S4 =
-    3; // Controls U19 switch 4: connect GNSS UART2 to 4-pin JST TTL Serial or LoRa UART0
-const uint8_t gpioExpanderSwitch_LoraEnable = 4; // LoRa_EN
-const uint8_t gpioExpanderSwitch_GNSS_Reset = 5; // RST_GNSS
-const uint8_t gpioExpanderSwitch_LoraBoot = 6;   // LoRa_BOOT0 - Used for bootloading the STM32 radio IC
-const uint8_t gpioExpanderSwitch_S5 = 7;         // Controls U61 switch 5: connect GNSS UART1 to Port A of CH342
-const uint8_t gpioExpanderNumSwitches = 8;
 
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
@@ -1019,7 +906,6 @@ unsigned long lastSpartnToPpl = 0;
 int commandCount;
 int16_t *commandIndex;
 
-bool usbSerialIsSelected = true;      // Goes false when switch U18 is moved from CH34x to LoRa
 unsigned long loraLastIncomingSerial; // Last time a user sent a serial command. Used in LoRa timeouts.
 char loraFirmwareVersionStr[25] = {'\0'};
 int loraFirmwareVersionInt = 0;

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -272,10 +272,8 @@ void beginSPI(bool force = false); // Header
 
 SdFat *sd;
 
-#define productVariantProperties getProductPropertiesFromVariant(productVariant)
 #define platformFilePrefix                                                                                             \
     getProductPropertiesFromVariant(productVariant)->filePrefix // Sets the prefix for logs and settings files
-#define variantHousingProperties getProductHousingPropertiesFromVariant(productVariant)
 
 SdFile *logFile;                  // File that all GNSS messages sentences are written to
 unsigned long lastUBXLogSyncTime; // Used to record to SD every half second

--- a/Firmware/RTK_Everywhere/RTK_Everywhere.ino
+++ b/Firmware/RTK_Everywhere/RTK_Everywhere.ino
@@ -497,9 +497,6 @@ volatile bool forwardGnssDataToUsbSerial;
 // entered then no changes are made and the +++ sequence must be re-entered.
 #define PLUS_PLUS_PLUS_TIMEOUT (2 * 1000) // Milliseconds
 
-HardwareSerial *serialGNSS = nullptr;  // Don't instantiate until we know what gnssPlatform we're on
-HardwareSerial *serial2GNSS = nullptr; // Don't instantiate until we know what gnssPlatform we're on
-
 volatile bool inDirectConnectMode = false; // Global state to indicate if GNSS/LoRa has direct connection for update
 
 #define SERIAL_SIZE_TX 512

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -312,6 +312,9 @@ const productProperties productPropertiesTable[] =
 };
 const int productPropertiesEntries = sizeof(productPropertiesTable) / sizeof(productPropertiesTable[0]);
 
+#define productVariantProperties getProductPropertiesFromVariant(productVariant)
+#define variantHousingProperties getProductHousingPropertiesFromVariant(productVariant)
+
 // Corrections Priority
 typedef enum
 {

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -764,13 +764,6 @@ enum
 typedef uint8_t NETCONSUMER_t;
 typedef uint16_t NETCONSUMER_MASK_t;
 
-enum Im19UpdateResult
-{
-    IM19_UPDATE_FAILED = 0,
-    IM19_UPDATE_SUCCESS,
-    IM19_UPDATE_RETRY, // lost frames (or no response) - caller should re-stream the source and call again
-};
-
 enum PP_NickName
 {
     PP_NICKNAME_DISABLED = 0,
@@ -2680,5 +2673,16 @@ HardwareSerial *uart2Serial; // Shared serial port between LoRa and Tilt
 
 #define SECONDS_IN_AN_HOUR (MINUTES_IN_AN_HOUR * SECONDS_IN_A_MINUTE)
 #define SECONDS_IN_A_DAY (HOURS_IN_A_DAY * SECONDS_IN_AN_HOUR)
+
+//----------------------------------------
+// IM19 IMU
+//----------------------------------------
+
+enum Im19UpdateResult
+{
+    IM19_UPDATE_FAILED = 0,
+    IM19_UPDATE_SUCCESS,
+    IM19_UPDATE_RETRY, // IM19 reports lost frames - caller should re-request only those byte ranges and call again
+};
 
 #endif // __SETTINGS_H__

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2536,4 +2536,128 @@ class RTK_WIFI
 
 #endif // COMPILE_WIFI
 #endif // COMPILE_NETWORK
+
+//----------------------------------------
+// Hardware connections
+//----------------------------------------
+
+#define PIN_UNDEFINED -1
+
+// These pins are set in beginBoard()
+int pin_debug = PIN_UNDEFINED;              // LED on EVK
+int pin_batteryStatusLED = PIN_UNDEFINED;   // LED on Torch
+int pin_baseStatusLED = PIN_UNDEFINED;      // LED on EVK
+int pin_bluetoothStatusLED = PIN_UNDEFINED; // LED on Torch
+int pin_gnssStatusLED = PIN_UNDEFINED;      // LED on Torch
+
+int pin_muxA = PIN_UNDEFINED;
+int pin_muxB = PIN_UNDEFINED;
+int pin_mux1 = PIN_UNDEFINED;
+int pin_mux2 = PIN_UNDEFINED;
+int pin_mux3 = PIN_UNDEFINED;
+int pin_mux4 = PIN_UNDEFINED;
+
+int pin_modeButton = PIN_UNDEFINED;   // Mode button on EVK, Function button on Facet FP
+int pin_powerButton = PIN_UNDEFINED;  // Power and general purpose button on Torch, Facet
+int pin_powerFastOff = PIN_UNDEFINED; // Output on Facet
+int pin_muxDAC = PIN_UNDEFINED;
+int pin_muxADC = PIN_UNDEFINED;
+int pin_peripheralPowerControl = PIN_UNDEFINED; // EVK and Facet mosaic
+
+int pin_GnssEvent = PIN_UNDEFINED;   // Facet mosaic
+int pin_GnssOnOff = PIN_UNDEFINED;   // Facet mosaic
+int pin_chargerLED = PIN_UNDEFINED;  // Facet mosaic
+int pin_chargerLED2 = PIN_UNDEFINED; // Facet mosaic
+int pin_GnssReady = PIN_UNDEFINED;   // Facet mosaic
+
+int pin_loraRadio_reset = PIN_UNDEFINED;
+int pin_loraRadio_boot = PIN_UNDEFINED;
+int pin_loraRadio_power = PIN_UNDEFINED;
+
+int pin_Ethernet_CS = PIN_UNDEFINED;
+int pin_Ethernet_Interrupt = PIN_UNDEFINED;
+int pin_GNSS_CS = PIN_UNDEFINED;
+int pin_GNSS_TimePulse = PIN_UNDEFINED;
+int pin_GNSS_Reset = PIN_UNDEFINED;
+
+// microSD card pins
+int pin_PICO = PIN_UNDEFINED;
+int pin_POCI = PIN_UNDEFINED;
+int pin_SCK = PIN_UNDEFINED;
+int pin_microSD_CardDetect = PIN_UNDEFINED;
+int pin_microSD_CS = PIN_UNDEFINED;
+
+int pin_I2C0_SDA = PIN_UNDEFINED;
+int pin_I2C0_SCL = PIN_UNDEFINED;
+
+// On EVK, Display is on separate I2C bus
+int pin_I2C1_SDA = PIN_UNDEFINED;
+int pin_I2C1_SCL = PIN_UNDEFINED;
+
+int pin_GnssUart_RX = PIN_UNDEFINED;
+int pin_GnssUart_TX = PIN_UNDEFINED;
+
+int pin_GnssUart2_RX = PIN_UNDEFINED;
+int pin_GnssUart2_TX = PIN_UNDEFINED;
+
+int pin_Cellular_RX = PIN_UNDEFINED;
+int pin_Cellular_TX = PIN_UNDEFINED;
+int pin_Cellular_PWR_ON = PIN_UNDEFINED;
+int pin_Cellular_Network_Indicator = PIN_UNDEFINED;
+int pin_Cellular_Reset = PIN_UNDEFINED;
+int pin_Cellular_RTS = PIN_UNDEFINED;
+int pin_Cellular_CTS = PIN_UNDEFINED;
+
+int pin_GNSS_DR_Reset = PIN_UNDEFINED;
+
+int pin_IMU_RX = PIN_UNDEFINED;
+int pin_IMU_TX = PIN_UNDEFINED;
+int pin_IMU_Boot = PIN_UNDEFINED;
+
+int pin_powerAdapterDetect = PIN_UNDEFINED;
+int pin_usbSelect = PIN_UNDEFINED;
+int pin_beeper = PIN_UNDEFINED;
+
+bool cellularModemResetLow = false;
+#define CELLULAR_MODEM_FC ESP_MODEM_FLOW_CONTROL_NONE
+uint8_t laraPwrLowValue;
+uint32_t laraTimer; // Backoff timer
+
+int pin_gpioExpanderInterrupt = PIN_UNDEFINED;
+const uint8_t gpioExpander_up = 0;
+const uint8_t gpioExpander_down = 1;
+const uint8_t gpioExpander_right = 2;
+const uint8_t gpioExpander_left = 3;
+const uint8_t gpioExpander_center = 4;
+const uint8_t gpioExpander_cardDetect = 5;
+const uint8_t gpioExpander_io6 = 6;
+const uint8_t gpioExpander_io7 = 7;
+
+const uint8_t gpioExpanderSwitch_S1 = 0; // Controls U16 switch 1: connect ESP UART0 to CH342 or SW2
+const uint8_t gpioExpanderSwitch_S2 = 1; // Controls U17 switch 2: connect SW1 to RS232 Output or GNSS UART4
+const uint8_t gpioExpanderSwitch_S3 = 2; // Controls U18 switch 3: connect ESP UART2 to GNSS UART3 or LoRa UART2
+const uint8_t gpioExpanderSwitch_S4 = 3; // Controls U19 switch 4: connect GNSS UART2 to 4-pin JST TTL Serial or LoRa UART0
+const uint8_t gpioExpanderSwitch_LoraEnable = 4; // LoRa_EN
+const uint8_t gpioExpanderSwitch_GNSS_Reset = 5; // RST_GNSS
+const uint8_t gpioExpanderSwitch_LoraBoot = 6;   // LoRa_BOOT0 - Used for bootloading the STM32 radio IC
+const uint8_t gpioExpanderSwitch_S5 = 7;         // Controls U61 switch 5: connect GNSS UART1 to Port A of CH342
+const uint8_t gpioExpanderNumSwitches = 8;
+
+bool usbSerialIsSelected = true;      // Goes false when switch U18 is moved from CH34x to LoRa
+
+//----------------------------------------
+// Time measurement
+//----------------------------------------
+
+#define HOURS_IN_A_DAY 24L
+#define MINUTES_IN_AN_HOUR 60L
+#define SECONDS_IN_A_MINUTE 60L
+#define MILLISECONDS_IN_A_SECOND 1000L
+#define MILLISECONDS_IN_A_MINUTE (SECONDS_IN_A_MINUTE * MILLISECONDS_IN_A_SECOND)
+#define MILLISECONDS_IN_AN_HOUR (MINUTES_IN_AN_HOUR * MILLISECONDS_IN_A_MINUTE)
+#define MILLISECONDS_IN_A_DAY (HOURS_IN_A_DAY * MILLISECONDS_IN_AN_HOUR)
+
+#define SECONDS_IN_AN_HOUR (MINUTES_IN_AN_HOUR * SECONDS_IN_A_MINUTE)
+#define SECONDS_IN_A_DAY (HOURS_IN_A_DAY * SECONDS_IN_AN_HOUR)
+
 #endif // __SETTINGS_H__

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2657,6 +2657,8 @@ bool usbSerialIsSelected = true;      // Goes false when switch U18 is moved fro
 TwoWire * i2c_0;
 TwoWire * i2c_1;
 
+HardwareSerial *serialGNSS = nullptr;  // Don't instantiate until we know what gnssPlatform we're on
+HardwareSerial *serial2GNSS = nullptr; // Don't instantiate until we know what gnssPlatform we're on
 HardwareSerial *uart2Serial; // Shared serial port between LoRa and Tilt
 
 #define SerialForLoRa uart2Serial
@@ -2695,6 +2697,8 @@ enum Im19UpdateResult
 #define OTA_DATA_TIMEOUT        (15 * MILLISECONDS_IN_A_SECOND)
 
 const char * otaEqualSigns = "==================================================";
+
+#define OTA_FIRMWARE_GITHUB_RAW "raw.githubusercontent.com"
 
 // Constants to parse GitHub directory listings
 const char * otaRawHead = "/raw/refs/heads/main";

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -2685,4 +2685,24 @@ enum Im19UpdateResult
     IM19_UPDATE_RETRY, // IM19 reports lost frames - caller should re-request only those byte ranges and call again
 };
 
+//----------------------------------------
+// Over-The-Air (OTA) Updates
+//----------------------------------------
+
+#define OTA_DATA_TIMEOUT        (15 * MILLISECONDS_IN_A_SECOND)
+
+const char * otaEqualSigns = "==================================================";
+
+// Constants to parse GitHub directory listings
+const char * otaRawHead = "/raw/refs/heads/main";
+const char * otaTree = "},\"tree";
+const char * otaFileTree = ":{\"fileTree\":{\"";
+const char * otaItems = "\":{\"items\":[";
+const char * otaListEnd = "]";
+const char * otaName = "\"name\":\"";
+const char * otaNameEnd = "\"";
+
+bool otaDebugVerbose;
+uint32_t otaFileBytes;
+
 #endif // __SETTINGS_H__

--- a/Firmware/RTK_Everywhere/settings.h
+++ b/Firmware/RTK_Everywhere/settings.h
@@ -74,12 +74,14 @@ typedef enum {
 // sd->begin will crash second time around with ~v2.2.3
 #include "SdFat.h" //http://librarymanager/All#sdfat_exfat by Bill Greiman.
 
+// Peripherals
 #include "GNSS.h"
 #include "GNSS_None.h"
 #include "GNSS_ZED.h" //Structs of ZED messages, needed for settings.h
 #include "GNSS_UM980.h" //Structs of UM980 messages, needed for settings.h
 #include "GNSS_Mosaic.h" //Structs of mosaic messages, needed for settings.h
 #include "GNSS_LG290P.h" //Structs of LG90P messages, needed for settings.h
+
 #include <vector>
 
 // System can enter a variety of states
@@ -2644,6 +2646,25 @@ const uint8_t gpioExpanderSwitch_S5 = 7;         // Controls U61 switch 5: conne
 const uint8_t gpioExpanderNumSwitches = 8;
 
 bool usbSerialIsSelected = true;      // Goes false when switch U18 is moved from CH34x to LoRa
+
+//----------------------------------------
+// Peripherals
+//----------------------------------------
+
+#include <SparkFun_I2C_Expander_Arduino_Library.h> // Click here to get the library: http://librarymanager/All#SparkFun_I2C_Expander_Arduino_Library
+#include <SparkFun_IM19_IMU_Arduino_Library.h> //http://librarymanager/All#SparkFun_IM19_IMU
+#include <SparkFun_LG290P_GNSS.h> //http://librarymanager/All#SparkFun_LG290P
+#include <SparkFun_Unicore_GNSS_Arduino_Library.h> //http://librarymanager/All#SparkFun_Unicore_GNSS
+#include <SparkFun_u-blox_GNSS_v3.h> //http://librarymanager/All#SparkFun_u-blox_GNSS_v3
+#include <Wire.h>
+
+TwoWire * i2c_0;
+TwoWire * i2c_1;
+
+HardwareSerial *uart2Serial; // Shared serial port between LoRa and Tilt
+
+#define SerialForLoRa uart2Serial
+#define SerialForTilt uart2Serial
 
 //----------------------------------------
 // Time measurement


### PR DESCRIPTION
This pull request includes the following commits:
* settings: Declare pins and define time measurement values
* settings: Add some peripheral includes and peripheral objects
* settings: Move Im19UpdateResult
* settings: Add some OTA definitions and declarations
* settings: Define getProduct*FromVariant macros
* settings: Move serialGNSS and serial2GNSS
